### PR TITLE
fix: seven bugs surfaced by test-gap analysis

### DIFF
--- a/pkg/cache/incremental_test.go
+++ b/pkg/cache/incremental_test.go
@@ -1,0 +1,531 @@
+package cache
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/findings"
+)
+
+// ---------------------------------------------------------------------------
+// SHA-256 collision-resistance
+// ---------------------------------------------------------------------------
+
+// TestHashFile_DifferentContent_DifferentHash verifies that two files with
+// different content produce different SHA-256 hashes (collision resistance).
+func TestHashFile_DifferentContent_DifferentHash(t *testing.T) {
+	dir := t.TempDir()
+	p1 := writeTempFile(t, dir, "a.go", "package main // RSA-2048")
+	p2 := writeTempFile(t, dir, "b.go", "package main // AES-256")
+
+	h1, err := HashFile(p1)
+	if err != nil {
+		t.Fatalf("HashFile p1: %v", err)
+	}
+	h2, err := HashFile(p2)
+	if err != nil {
+		t.Fatalf("HashFile p2: %v", err)
+	}
+	if h1 == h2 {
+		t.Errorf("different content must produce different hashes: both got %q", h1)
+	}
+}
+
+// TestHashFile_SameContentDifferentPaths_SameHash verifies that two files
+// with identical content have the same hash regardless of path.
+func TestHashFile_SameContentDifferentPaths_SameHash(t *testing.T) {
+	dir := t.TempDir()
+	content := "package main // identical content"
+	p1 := writeTempFile(t, dir, "a.go", content)
+	p2 := writeTempFile(t, dir, "b.go", content)
+
+	h1, err := HashFile(p1)
+	if err != nil {
+		t.Fatalf("HashFile p1: %v", err)
+	}
+	h2, err := HashFile(p2)
+	if err != nil {
+		t.Fatalf("HashFile p2: %v", err)
+	}
+	if h1 != h2 {
+		t.Errorf("same content must produce the same hash: %q vs %q", h1, h2)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// File modified mid-scan (hash changes after first read)
+// ---------------------------------------------------------------------------
+
+// TestGetUnchangedFindings_FileModifiedMidScan verifies that if a file's hash
+// changes between the time the cache was written and the current scan, it
+// appears in changedPaths (not in cachedFindings).
+func TestGetUnchangedFindings_FileModifiedMidScan(t *testing.T) {
+	dir := t.TempDir()
+	p := writeTempFile(t, dir, "scan_target.go", "package main // v1")
+
+	hashV1, err := HashFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Populate cache with v1 hash.
+	sc := New()
+	sc.Entries[p] = &CacheEntry{
+		ContentHash: hashV1,
+		Findings:    []findings.UnifiedFinding{sampleFinding("ag", p, "AES-128", 1)},
+	}
+
+	// Simulate file being modified between scan runs.
+	if err := os.WriteFile(p, []byte("package main // v2 (modified mid-scan)"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	hashV2, err := HashFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cached, changed := sc.GetUnchangedFindings(map[string]string{p: hashV2})
+
+	if len(cached) != 0 {
+		t.Errorf("modified file must not return cached findings, got %d", len(cached))
+	}
+	if len(changed) != 1 || changed[0] != p {
+		t.Errorf("modified file must appear in changedPaths: got %v", changed)
+	}
+	// Verify the hashes differ so the test is meaningful.
+	if hashV1 == hashV2 {
+		t.Skip("hash collision or filesystem timestamp granularity prevented content update")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Corrupt gzip
+// ---------------------------------------------------------------------------
+
+// TestUnmarshalGzip_CorruptData_ReturnsError verifies that UnmarshalGzip
+// returns an error for garbage input (not a valid gzip stream).
+func TestUnmarshalGzip_CorruptData_ReturnsError(t *testing.T) {
+	_, err := UnmarshalGzip([]byte("this is not gzip data"))
+	if err == nil {
+		t.Error("expected error for non-gzip input")
+	}
+}
+
+// TestUnmarshalGzip_ValidGzip_CorruptJSON_ReturnsError verifies that a valid
+// gzip stream wrapping invalid JSON returns an error from UnmarshalGzip.
+func TestUnmarshalGzip_ValidGzip_CorruptJSON_ReturnsError(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	_, _ = gz.Write([]byte("{not valid json"))
+	_ = gz.Close()
+
+	_, err := UnmarshalGzip(buf.Bytes())
+	if err == nil {
+		t.Error("expected error for gzip-wrapped invalid JSON")
+	}
+}
+
+// TestMarshalGzip_RoundTrip_NewFile verifies that MarshalGzip → UnmarshalGzip
+// round-trips a ScanCache with multiple entry types without data loss.
+func TestMarshalGzip_RoundTrip_NewFile(t *testing.T) {
+	sc := New()
+	sc.ScannerVersion = "1.2.3"
+	sc.EngineVersions["cipherscope"] = "0.4.0"
+	sc.Entries["/src/main.go"] = &CacheEntry{
+		ContentHash: "deadbeef",
+		ModTime:     time.Now().Truncate(time.Second),
+		Findings: []findings.UnifiedFinding{
+			sampleFinding("cipherscope", "/src/main.go", "RSA-2048", 42),
+		},
+		ScannedAt: time.Now().Truncate(time.Second),
+	}
+
+	compressed, err := sc.MarshalGzip()
+	if err != nil {
+		t.Fatalf("MarshalGzip: %v", err)
+	}
+	if len(compressed) == 0 {
+		t.Fatal("MarshalGzip returned empty bytes")
+	}
+
+	sc2, err := UnmarshalGzip(compressed)
+	if err != nil {
+		t.Fatalf("UnmarshalGzip: %v", err)
+	}
+
+	if sc2.ScannerVersion != "1.2.3" {
+		t.Errorf("ScannerVersion: want 1.2.3, got %q", sc2.ScannerVersion)
+	}
+	if sc2.EngineVersions["cipherscope"] != "0.4.0" {
+		t.Errorf("EngineVersion for cipherscope: want 0.4.0, got %q", sc2.EngineVersions["cipherscope"])
+	}
+	entry := sc2.Entries["/src/main.go"]
+	if entry == nil {
+		t.Fatal("expected entry for /src/main.go")
+	}
+	if entry.ContentHash != "deadbeef" {
+		t.Errorf("ContentHash: want deadbeef, got %q", entry.ContentHash)
+	}
+	if len(entry.Findings) != 1 {
+		t.Errorf("expected 1 finding, got %d", len(entry.Findings))
+	}
+}
+
+// TestMarshalGzip_ProducesCompressedOutput verifies that MarshalGzip output
+// is smaller than raw JSON for a cache with content (compression effectiveness).
+func TestMarshalGzip_ProducesCompressedOutput(t *testing.T) {
+	sc := New()
+	sc.ScannerVersion = "1.0.0"
+	// Add enough entries that compression is beneficial.
+	for i := 0; i < 50; i++ {
+		path := filepath.Join("/src", fmt.Sprintf("file%03d.go", i))
+		sc.Entries[path] = &CacheEntry{
+			ContentHash: fmt.Sprintf("hash%d", i),
+			Findings:    []findings.UnifiedFinding{sampleFinding("eng", path, "RSA-2048", i)},
+		}
+	}
+
+	compressed, err := sc.MarshalGzip()
+	if err != nil {
+		t.Fatalf("MarshalGzip: %v", err)
+	}
+	// Just verify it doesn't error and produces some output.
+	if len(compressed) == 0 {
+		t.Error("MarshalGzip must produce non-empty output")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Cache file permissions
+// ---------------------------------------------------------------------------
+
+// TestSave_FilePermissions_0600 verifies that saved cache files are created
+// with 0600 permissions (owner read/write only), preventing other users from
+// reading potentially sensitive scan results.
+func TestSave_FilePermissions_0600(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secure-cache.json")
+
+	sc := New()
+	sc.ScannerVersion = "0.1.0"
+	if err := sc.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("cache file permissions: got %04o, want 0600", perm)
+	}
+}
+
+// TestSave_SymlinkTarget_ReturnsError verifies that Save refuses to write to
+// a symlink target (symlink-attack mitigation).
+func TestSave_SymlinkTarget_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	realPath := filepath.Join(dir, "real.json")
+	symlinkPath := filepath.Join(dir, "link.json")
+
+	// Create the real file first.
+	if err := os.WriteFile(realPath, []byte("{}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	// Create a symlink pointing to the real file.
+	if err := os.Symlink(realPath, symlinkPath); err != nil {
+		t.Skipf("symlink creation failed (filesystem may not support it): %v", err)
+	}
+
+	sc := New()
+	err := sc.Save(symlinkPath)
+	if err == nil {
+		t.Error("Save must return an error when the target path is a symlink")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IsValidForEngine — per-engine cache gating
+// ---------------------------------------------------------------------------
+
+// TestIsValidForEngine_MatchingVersion_ReturnsTrue verifies that an engine
+// at the cached version is considered valid.
+func TestIsValidForEngine_MatchingVersion_ReturnsTrue(t *testing.T) {
+	sc := New()
+	sc.EngineVersions["cipherscope"] = "0.3.1"
+
+	if !sc.IsValidForEngine("cipherscope", "0.3.1") {
+		t.Error("expected IsValidForEngine=true for matching version")
+	}
+}
+
+// TestIsValidForEngine_MismatchedVersion_ReturnsFalse verifies that an engine
+// at a different version than cached returns false.
+func TestIsValidForEngine_MismatchedVersion_ReturnsFalse(t *testing.T) {
+	sc := New()
+	sc.EngineVersions["cipherscope"] = "0.3.0"
+
+	if sc.IsValidForEngine("cipherscope", "0.3.1") {
+		t.Error("expected IsValidForEngine=false for version mismatch")
+	}
+}
+
+// TestIsValidForEngine_UnknownEngine_ReturnsFalse verifies that an engine
+// not present in the cache returns false (forces full re-scan for new engines).
+func TestIsValidForEngine_UnknownEngine_ReturnsFalse(t *testing.T) {
+	sc := New()
+	// sc.EngineVersions is empty.
+
+	if sc.IsValidForEngine("new-engine", "1.0.0") {
+		t.Error("expected IsValidForEngine=false for engine not in cache")
+	}
+}
+
+// TestIsValidForEngine_WrongCacheFormatVersion_ReturnsFalse verifies that
+// an engine cache with a wrong format version returns false.
+func TestIsValidForEngine_WrongCacheFormatVersion_ReturnsFalse(t *testing.T) {
+	sc := New()
+	sc.Version = "99" // wrong format version
+	sc.EngineVersions["cipherscope"] = "0.3.1"
+
+	if sc.IsValidForEngine("cipherscope", "0.3.1") {
+		t.Error("expected IsValidForEngine=false for wrong cache format version")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetUnchangedFindingsForEngine
+// ---------------------------------------------------------------------------
+
+// TestGetUnchangedFindingsForEngine_HitAndMiss verifies the per-engine cache
+// lookup: unchanged files return cached findings, changed files are re-queued.
+func TestGetUnchangedFindingsForEngine_HitAndMiss(t *testing.T) {
+	sc := New()
+	sc.EngineEntries["cipherscope"] = map[string]*CacheEntry{
+		"/src/foo.go": {
+			ContentHash: "hash_foo",
+			Findings:    []findings.UnifiedFinding{sampleFinding("cipherscope", "/src/foo.go", "RSA-2048", 10)},
+		},
+		"/src/bar.go": {
+			ContentHash: "hash_bar_old",
+			Findings:    []findings.UnifiedFinding{sampleFinding("cipherscope", "/src/bar.go", "AES-128", 5)},
+		},
+	}
+
+	allHashes := map[string]string{
+		"/src/foo.go": "hash_foo",     // unchanged
+		"/src/bar.go": "hash_bar_new", // changed
+		"/src/baz.go": "hash_baz",     // new file
+	}
+
+	cached, changed := sc.GetUnchangedFindingsForEngine("cipherscope", allHashes)
+
+	if len(cached) != 1 {
+		t.Errorf("expected 1 cached finding (foo.go), got %d", len(cached))
+	}
+	if len(cached) > 0 && cached[0].Algorithm.Name != "RSA-2048" {
+		t.Errorf("cached finding: want RSA-2048, got %q", cached[0].Algorithm.Name)
+	}
+
+	changedSet := make(map[string]bool)
+	for _, p := range changed {
+		changedSet[p] = true
+	}
+	if !changedSet["/src/bar.go"] {
+		t.Error("bar.go (changed hash) must be in changedPaths")
+	}
+	if !changedSet["/src/baz.go"] {
+		t.Error("baz.go (new file) must be in changedPaths")
+	}
+	if changedSet["/src/foo.go"] {
+		t.Error("foo.go (unchanged) must NOT be in changedPaths")
+	}
+}
+
+// TestGetUnchangedFindingsForEngine_NilEngineEntries_AllChanged verifies that
+// when an engine has no entries (first run), all files appear in changedPaths.
+func TestGetUnchangedFindingsForEngine_NilEngineEntries_AllChanged(t *testing.T) {
+	sc := New()
+	// No entries for "new-engine".
+
+	allHashes := map[string]string{
+		"/src/a.go": "hashA",
+		"/src/b.go": "hashB",
+	}
+
+	cached, changed := sc.GetUnchangedFindingsForEngine("new-engine", allHashes)
+
+	if len(cached) != 0 {
+		t.Errorf("expected 0 cached findings for unknown engine, got %d", len(cached))
+	}
+	if len(changed) != 2 {
+		t.Errorf("expected 2 changed paths for unknown engine, got %d: %v", len(changed), changed)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UpdateEngine
+// ---------------------------------------------------------------------------
+
+// TestUpdateEngine_AddsFindingsAndPrunesDeleted verifies that UpdateEngine
+// stores new findings and, when pruneDeleted=true, removes entries for files
+// that no longer exist in allFileHashes.
+func TestUpdateEngine_AddsFindingsAndPrunesDeleted(t *testing.T) {
+	sc := New()
+	sc.EngineEntries["eng"] = map[string]*CacheEntry{
+		"/src/old.go": {ContentHash: "hash_old"},
+	}
+
+	allHashes := map[string]string{"/src/new.go": "hash_new"}
+	changedFindings := map[string][]findings.UnifiedFinding{
+		"/src/new.go": {sampleFinding("eng", "/src/new.go", "DH", 1)},
+	}
+
+	sc.UpdateEngine("eng", changedFindings, allHashes, true /* pruneDeleted */)
+
+	engineFiles := sc.EngineEntries["eng"]
+	if _, ok := engineFiles["/src/old.go"]; ok {
+		t.Error("old.go should have been pruned from engine cache")
+	}
+	entry, ok := engineFiles["/src/new.go"]
+	if !ok {
+		t.Fatal("expected entry for new.go")
+	}
+	if entry.ContentHash != "hash_new" {
+		t.Errorf("ContentHash: want hash_new, got %q", entry.ContentHash)
+	}
+	if len(entry.Findings) != 1 {
+		t.Errorf("expected 1 finding, got %d", len(entry.Findings))
+	}
+}
+
+// TestUpdateEngine_NoPruneInDiffMode verifies that when pruneDeleted=false
+// (diff mode), existing cached entries for unchanged files are preserved even
+// if they are not in allFileHashes.
+func TestUpdateEngine_NoPruneInDiffMode(t *testing.T) {
+	sc := New()
+	sc.EngineEntries["eng"] = map[string]*CacheEntry{
+		"/src/unchanged.go": {ContentHash: "hash_unchanged", Findings: []findings.UnifiedFinding{
+			sampleFinding("eng", "/src/unchanged.go", "AES-256", 1),
+		}},
+	}
+
+	// allFileHashes only contains the changed file (diff mode subset).
+	allHashes := map[string]string{"/src/changed.go": "hash_changed"}
+	changedFindings := map[string][]findings.UnifiedFinding{
+		"/src/changed.go": {sampleFinding("eng", "/src/changed.go", "RSA-2048", 5)},
+	}
+
+	sc.UpdateEngine("eng", changedFindings, allHashes, false /* pruneDeleted=false */)
+
+	// unchanged.go's cache entry must survive.
+	if _, ok := sc.EngineEntries["eng"]["/src/unchanged.go"]; !ok {
+		t.Error("unchanged.go entry must be preserved in diff mode (pruneDeleted=false)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PruneDeletedFiles
+// ---------------------------------------------------------------------------
+
+// TestPruneDeletedFiles_RemovesFromBothMaps verifies that PruneDeletedFiles
+// removes stale entries from both the flat Entries map and all EngineEntries.
+func TestPruneDeletedFiles_RemovesFromBothMaps(t *testing.T) {
+	sc := New()
+	sc.Entries["/src/deleted.go"] = &CacheEntry{ContentHash: "h1"}
+	sc.Entries["/src/kept.go"] = &CacheEntry{ContentHash: "h2"}
+	sc.EngineEntries["eng"] = map[string]*CacheEntry{
+		"/src/deleted.go": {ContentHash: "h1"},
+		"/src/kept.go":    {ContentHash: "h2"},
+	}
+
+	allHashes := map[string]string{"/src/kept.go": "h2"}
+	sc.PruneDeletedFiles(allHashes)
+
+	if _, ok := sc.Entries["/src/deleted.go"]; ok {
+		t.Error("deleted.go must be pruned from Entries")
+	}
+	if _, ok := sc.Entries["/src/kept.go"]; !ok {
+		t.Error("kept.go must remain in Entries")
+	}
+	if _, ok := sc.EngineEntries["eng"]["/src/deleted.go"]; ok {
+		t.Error("deleted.go must be pruned from EngineEntries")
+	}
+	if _, ok := sc.EngineEntries["eng"]["/src/kept.go"]; !ok {
+		t.Error("kept.go must remain in EngineEntries")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// V1 cache → IsValid returns false (format migration path)
+// ---------------------------------------------------------------------------
+
+// TestIsValid_V1Cache_ReturnsFalse verifies that a V1 cache (version "1")
+// with otherwise matching scanner and engine versions is invalid under V2
+// rules, forcing a full re-scan on upgrade.
+func TestIsValid_V1Cache_ReturnsFalse(t *testing.T) {
+	sc := New()
+	sc.Version = "1" // simulate V1 cache loaded from disk
+	sc.ScannerVersion = "0.9.0"
+	sc.EngineVersions = map[string]string{"cipherscope": "0.3.1"}
+
+	if sc.IsValid("0.9.0", map[string]string{"cipherscope": "0.3.1"}) {
+		t.Error("V1 cache must be invalid under V2 IsValid check (format version mismatch)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Load with empty (zero-byte) file
+// ---------------------------------------------------------------------------
+
+// TestLoad_EmptyFile_ReturnsEmptyCache verifies that a zero-byte cache file
+// is treated as a cache miss (returns an empty cache, not an error).
+func TestLoad_EmptyFile_ReturnsEmptyCache(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.json")
+	if err := os.WriteFile(path, []byte{}, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	sc, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load of empty file must not error: %v", err)
+	}
+	if sc == nil {
+		t.Fatal("Load must return non-nil cache")
+	}
+	if len(sc.Entries) != 0 {
+		t.Errorf("expected 0 entries from empty file, got %d", len(sc.Entries))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HashFiles parallel safety
+// ---------------------------------------------------------------------------
+
+// TestHashFiles_ParallelSafety verifies that HashFiles handles concurrent
+// hashing of many files without data races (run with -race).
+func TestHashFiles_ParallelSafety(t *testing.T) {
+	dir := t.TempDir()
+	const numFiles = 50
+	paths := make([]string, numFiles)
+	for i := range paths {
+		paths[i] = writeTempFile(t, dir, fmt.Sprintf("file%03d.go", i),
+			fmt.Sprintf("package p%d // content %d", i, i))
+	}
+
+	hashes, err := HashFiles(paths)
+	if err != nil {
+		t.Fatalf("HashFiles parallel: %v", err)
+	}
+	if len(hashes) != numFiles {
+		t.Errorf("expected %d hashes, got %d", numFiles, len(hashes))
+	}
+}
+

--- a/pkg/compliance/cnsa_edge_cases_test.go
+++ b/pkg/compliance/cnsa_edge_cases_test.go
@@ -1,0 +1,283 @@
+package compliance
+
+import (
+	"testing"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/findings"
+)
+
+// ---------------------------------------------------------------------------
+// SHA-2 family boundary disambiguation
+// ---------------------------------------------------------------------------
+
+// TestEvaluate_SHA384_NotMistakenForSHA3 is a regression guard for the
+// SHA-3/SHA-2 prefix collision: "SHA-384" starts with "SHA-3" so the
+// isSHA3 detection must check for "SHA-3-" (with trailing dash) or "SHA3-",
+// not just "SHA-3" prefix.
+// GAP: if this test fails, the SHA-3 detection regex is too broad and will
+// incorrectly flag SHA-384 as SHA-3 (unapproved), causing false positives.
+func TestEvaluate_SHA384_NotMistakenForSHA3(t *testing.T) {
+	f := algFinding("SHA-384", "hash", 0, findings.QRResistant, "")
+	violations := Evaluate([]findings.UnifiedFinding{f})
+	if len(violations) != 0 {
+		t.Errorf("SHA-384 should not be flagged — it's SHA-2 (384-bit), not SHA-3; got violations: %+v", violations)
+	}
+}
+
+// TestEvaluate_SHA3_256_IsUnapproved verifies that SHA3-256 (SHA-3 family)
+// is correctly flagged as unapproved.
+func TestEvaluate_SHA3_256_IsUnapproved(t *testing.T) {
+	f := algFinding("SHA3-256", "hash", 256, findings.QRResistant, "")
+	violations := Evaluate([]findings.UnifiedFinding{f})
+	if len(violations) == 0 {
+		t.Error("SHA3-256 should be flagged as unapproved for CNSA 2.0 (not SHA-2 family)")
+	}
+	if len(violations) > 0 && violations[0].Rule != "cnsa2-hash-unapproved" {
+		t.Errorf("expected cnsa2-hash-unapproved, got %q", violations[0].Rule)
+	}
+}
+
+// TestEvaluate_SHA3_512_IsUnapproved verifies that even the 512-bit SHA-3
+// variant is flagged — it's a different family from SHA-512.
+func TestEvaluate_SHA3_512_IsUnapproved(t *testing.T) {
+	f := algFinding("SHA3-512", "hash", 512, findings.QRResistant, "")
+	violations := Evaluate([]findings.UnifiedFinding{f})
+	if len(violations) == 0 {
+		t.Error("SHA3-512 (SHA-3 family) should be flagged — CNSA 2.0 only approves SHA-2")
+	}
+}
+
+// TestEvaluate_SHA256_Flagged verifies that SHA-256 (insufficient output size)
+// produces exactly one cnsa2-hash-output-size violation.
+func TestEvaluate_SHA256_Flagged(t *testing.T) {
+	f := algFinding("SHA-256", "hash", 256, findings.QRResistant, "")
+	violations := Evaluate([]findings.UnifiedFinding{f})
+	if len(violations) != 1 {
+		t.Fatalf("SHA-256 should have 1 violation, got %d: %+v", len(violations), violations)
+	}
+	if violations[0].Rule != "cnsa2-hash-output-size" {
+		t.Errorf("rule = %q, want cnsa2-hash-output-size", violations[0].Rule)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AES key-size inference exhaustion
+// ---------------------------------------------------------------------------
+
+// TestEvaluate_AES128_Flagged ensures AES-128 produces a key-size violation.
+func TestEvaluate_AES128_Flagged(t *testing.T) {
+	f := algFinding("AES-128", "symmetric", 128, findings.QRWeakened, "")
+	violations := Evaluate([]findings.UnifiedFinding{f})
+	if len(violations) != 1 {
+		t.Fatalf("AES-128 should have 1 violation, got %d: %+v", len(violations), violations)
+	}
+	if violations[0].Rule != "cnsa2-symmetric-key-size" {
+		t.Errorf("rule = %q, want cnsa2-symmetric-key-size", violations[0].Rule)
+	}
+	if violations[0].Deadline != deadlineFull {
+		t.Errorf("deadline = %q, want %q", violations[0].Deadline, deadlineFull)
+	}
+}
+
+// TestEvaluate_AES256_Passes verifies AES-256 does not produce a violation.
+func TestEvaluate_AES256_Passes(t *testing.T) {
+	f := algFinding("AES-256", "symmetric", 256, findings.QRResistant, "")
+	violations := Evaluate([]findings.UnifiedFinding{f})
+	if len(violations) != 0 {
+		t.Errorf("AES-256 should not be flagged; got: %+v", violations)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ML-KEM parameter set edge cases
+// ---------------------------------------------------------------------------
+
+// TestEvaluate_MLKEM768_Flagged verifies ML-KEM-768 (sub-1024) is flagged.
+func TestEvaluate_MLKEM768_Flagged(t *testing.T) {
+	f := algFinding("ML-KEM-768", "kem", 0, findings.QRSafe, "immediate")
+	violations := Evaluate([]findings.UnifiedFinding{f})
+	if len(violations) != 1 {
+		t.Fatalf("ML-KEM-768 should have 1 violation, got %d: %+v", len(violations), violations)
+	}
+	if violations[0].Rule != "cnsa2-ml-kem-key-size" {
+		t.Errorf("rule = %q, want cnsa2-ml-kem-key-size", violations[0].Rule)
+	}
+}
+
+// TestEvaluate_MLKEM1024_Passes verifies ML-KEM-1024 passes with no violation.
+func TestEvaluate_MLKEM1024_Passes(t *testing.T) {
+	f := algFinding("ML-KEM-1024", "kem", 0, findings.QRSafe, "immediate")
+	violations := Evaluate([]findings.UnifiedFinding{f})
+	if len(violations) != 0 {
+		t.Errorf("ML-KEM-1024 should not be flagged; got: %+v", violations)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ML-DSA parameter set edge cases
+// ---------------------------------------------------------------------------
+
+// TestEvaluate_MLDSA65_Flagged verifies ML-DSA-65 (sub-87) is flagged.
+func TestEvaluate_MLDSA65_Flagged(t *testing.T) {
+	f := algFinding("ML-DSA-65", "signature", 0, findings.QRSafe, "deferred")
+	violations := Evaluate([]findings.UnifiedFinding{f})
+	if len(violations) != 1 {
+		t.Fatalf("ML-DSA-65 should have 1 violation, got %d: %+v", len(violations), violations)
+	}
+	if violations[0].Rule != "cnsa2-ml-dsa-param-set" {
+		t.Errorf("rule = %q, want cnsa2-ml-dsa-param-set", violations[0].Rule)
+	}
+}
+
+// TestEvaluate_MLDSA87_Passes verifies ML-DSA-87 passes.
+func TestEvaluate_MLDSA87_Passes(t *testing.T) {
+	f := algFinding("ML-DSA-87", "signature", 0, findings.QRSafe, "deferred")
+	violations := Evaluate([]findings.UnifiedFinding{f})
+	if len(violations) != 0 {
+		t.Errorf("ML-DSA-87 should not be flagged; got: %+v", violations)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SLH-DSA excluded despite NIST approval
+// ---------------------------------------------------------------------------
+
+// TestEvaluate_SLHDSAExcluded_HasCorrectDeadline verifies the deadline for
+// SLH-DSA violations is the full transition deadline, not key exchange deadline.
+func TestEvaluate_SLHDSAExcluded_HasCorrectDeadline(t *testing.T) {
+	f := algFinding("SLH-DSA-128f", "signature", 0, findings.QRSafe, "deferred")
+	violations := Evaluate([]findings.UnifiedFinding{f})
+	if len(violations) != 1 {
+		t.Fatalf("SLH-DSA should have 1 violation, got %d", len(violations))
+	}
+	if violations[0].Deadline != deadlineFull {
+		t.Errorf("SLH-DSA deadline = %q, want %q (full transition)", violations[0].Deadline, deadlineFull)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HQC not yet approved
+// ---------------------------------------------------------------------------
+
+// TestEvaluate_HQC_HasKeyExchangeDeadline verifies the HQC deadline is the
+// key-exchange deadline (not the full transition deadline).
+func TestEvaluate_HQC_HasKeyExchangeDeadline(t *testing.T) {
+	f := algFinding("HQC-256", "kem", 0, findings.QRSafe, "immediate")
+	violations := Evaluate([]findings.UnifiedFinding{f})
+	if len(violations) != 1 {
+		t.Fatalf("HQC-256 should have 1 violation, got %d", len(violations))
+	}
+	if violations[0].Deadline != deadlineKeyExchange {
+		t.Errorf("HQC deadline = %q, want %q (key exchange)", violations[0].Deadline, deadlineKeyExchange)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Non-AES symmetric ciphers
+// ---------------------------------------------------------------------------
+
+// TestEvaluate_ChaCha20_Unapproved verifies ChaCha20 is flagged as not CNSA
+// 2.0 approved (only AES-256 is approved for symmetric).
+func TestEvaluate_ChaCha20_Unapproved(t *testing.T) {
+	f := algFinding("ChaCha20-Poly1305", "ae", 256, findings.QRResistant, "")
+	violations := Evaluate([]findings.UnifiedFinding{f})
+	if len(violations) != 1 {
+		t.Fatalf("ChaCha20 should have 1 violation, got %d: %+v", len(violations), violations)
+	}
+	if violations[0].Rule != "cnsa2-symmetric-unapproved" {
+		t.Errorf("rule = %q, want cnsa2-symmetric-unapproved", violations[0].Rule)
+	}
+}
+
+// TestEvaluate_Camellia_Unapproved verifies Camellia is flagged as unapproved.
+func TestEvaluate_Camellia_Unapproved(t *testing.T) {
+	f := algFinding("Camellia-256", "symmetric", 256, findings.QRResistant, "")
+	violations := Evaluate([]findings.UnifiedFinding{f})
+	if len(violations) != 1 {
+		t.Fatalf("Camellia should have 1 violation, got %d: %+v", len(violations), violations)
+	}
+	if violations[0].Rule != "cnsa2-symmetric-unapproved" {
+		t.Errorf("rule = %q, want cnsa2-symmetric-unapproved", violations[0].Rule)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Quantum-vulnerable dependency
+// ---------------------------------------------------------------------------
+
+// TestEvaluate_QuantumVulnerableDependency_FlaggedWithAlgorithmEmpty verifies
+// that a dependency finding (no Algorithm field) with QRVulnerable risk is
+// flagged, and the Violation.Algorithm is set from RawIdentifier.
+func TestEvaluate_QuantumVulnerableDependency_AlgorithmFromRawIdentifier(t *testing.T) {
+	f := depFinding("openssl-1.0.2k", findings.QRVulnerable, "immediate")
+	violations := Evaluate([]findings.UnifiedFinding{f})
+	if len(violations) != 1 {
+		t.Fatalf("quantum-vulnerable dependency should have 1 violation, got %d: %+v", len(violations), violations)
+	}
+	if violations[0].Algorithm != "openssl-1.0.2k" {
+		t.Errorf("violation.Algorithm = %q, want openssl-1.0.2k (from RawIdentifier)", violations[0].Algorithm)
+	}
+}
+
+// TestEvaluate_QuantumSafeDependency_NotFlagged verifies that a quantum-safe
+// dependency produces no violation (the nil-algorithm path should be no-op
+// for safe findings).
+func TestEvaluate_QuantumSafeDependency_NotFlagged(t *testing.T) {
+	f := depFinding("liboqs", findings.QRSafe, "")
+	violations := Evaluate([]findings.UnifiedFinding{f})
+	if len(violations) != 0 {
+		t.Errorf("quantum-safe dependency should not be flagged; got: %+v", violations)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DeadlineForHNDL helper
+// ---------------------------------------------------------------------------
+
+// TestDeadlineForHNDL_ImmediateGetsKeyExchangeDeadline verifies "immediate"
+// HNDL risk maps to the earlier 2030 key exchange deadline.
+func TestDeadlineForHNDL_ImmediateGetsKeyExchangeDeadline(t *testing.T) {
+	got := deadlineForHNDL("immediate")
+	if got != deadlineKeyExchange {
+		t.Errorf("deadlineForHNDL(immediate) = %q, want %q", got, deadlineKeyExchange)
+	}
+}
+
+// TestDeadlineForHNDL_EmptyGetsFull verifies empty or "deferred" HNDL risk
+// maps to the full transition deadline.
+func TestDeadlineForHNDL_OtherGetsFull(t *testing.T) {
+	for _, hndl := range []string{"", "deferred", "unknown-value"} {
+		got := deadlineForHNDL(hndl)
+		if got != deadlineFull {
+			t.Errorf("deadlineForHNDL(%q) = %q, want %q", hndl, got, deadlineFull)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Nil and empty input guards
+// ---------------------------------------------------------------------------
+
+// TestEvaluate_NilInput_ReturnsNilViolations verifies nil input returns nil
+// (not an empty slice) to satisfy existing callers.
+func TestEvaluate_NilInput_ReturnsNil(t *testing.T) {
+	v := Evaluate(nil)
+	if v != nil {
+		t.Errorf("nil input should return nil violations, got %v", v)
+	}
+}
+
+// TestEvaluate_AllApproved_NilReturn verifies that all-approved input returns
+// nil (not empty slice) as documented.
+func TestEvaluate_AllApproved_ReturnsNil(t *testing.T) {
+	ff := []findings.UnifiedFinding{
+		algFinding("ML-KEM-1024", "kem", 0, findings.QRSafe, "immediate"),
+		algFinding("ML-DSA-87", "signature", 0, findings.QRSafe, "deferred"),
+		algFinding("AES-256-GCM", "symmetric", 256, findings.QRResistant, ""),
+		algFinding("SHA-384", "hash", 384, findings.QRResistant, ""),
+	}
+	v := Evaluate(ff)
+	if v != nil {
+		t.Errorf("all-approved findings should return nil violations; got %v", v)
+	}
+}

--- a/pkg/engines/tlsprobe/dns.go
+++ b/pkg/engines/tlsprobe/dns.go
@@ -6,7 +6,11 @@ import (
 	"net"
 )
 
-// privateRanges contains RFC 1918, loopback, link-local, and IPv6 private ranges.
+// privateRanges contains ranges that must not be reachable from a TLS probe
+// when --tls-strict is set: RFC 1918, loopback, link-local, unspecified, CGNAT,
+// benchmark, IPv6 unique-local / link-local / loopback / unspecified, plus
+// multicast and limited broadcast (not valid TLS destinations but could bypass
+// the strict guard if omitted).
 var privateRanges []*net.IPNet
 
 func init() {
@@ -16,13 +20,16 @@ func init() {
 		"192.168.0.0/16",
 		"127.0.0.0/8",
 		"169.254.0.0/16",
-		"0.0.0.0/8",      // "This" network (includes 0.0.0.0)
-		"100.64.0.0/10",   // CGNAT (RFC 6598)
-		"198.18.0.0/15",   // Benchmark testing (RFC 2544)
+		"0.0.0.0/8",           // "This" network (includes 0.0.0.0)
+		"100.64.0.0/10",       // CGNAT (RFC 6598)
+		"198.18.0.0/15",       // Benchmark testing (RFC 2544)
+		"224.0.0.0/4",         // IPv4 multicast
+		"255.255.255.255/32",  // IPv4 limited broadcast
 		"::1/128",
 		"::/128",
 		"fc00::/7",
 		"fe80::/10",
+		"ff00::/8",            // IPv6 multicast
 	}
 	for _, cidr := range cidrs {
 		_, ipNet, _ := net.ParseCIDR(cidr)

--- a/pkg/engines/tlsprobe/security_test.go
+++ b/pkg/engines/tlsprobe/security_test.go
@@ -1,0 +1,763 @@
+// Package tlsprobe — security-focused tests covering SSRF defenses, DNS pinning,
+// host parsing edge cases, cipher classification, cert verification, and concurrency.
+package tlsprobe
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/engines"
+)
+
+// ---------------------------------------------------------------------------
+// DNS / IP range blocking
+// ---------------------------------------------------------------------------
+
+func TestIsPrivateIP_FullRanges(t *testing.T) {
+	cases := []struct {
+		label   string
+		ip      string
+		private bool
+	}{
+		// RFC 1918
+		{"10.0.0.0 (network addr)", "10.0.0.0", true},
+		{"10.128.1.1 (mid-range)", "10.128.1.1", true},
+		{"172.16.0.1 (start)", "172.16.0.1", true},
+		{"172.31.255.255 (end)", "172.31.255.255", true},
+		{"192.168.0.1", "192.168.0.1", true},
+		// Loopback
+		{"127.0.0.1", "127.0.0.1", true},
+		{"127.255.255.255", "127.255.255.255", true},
+		{"::1 IPv6 loopback", "::1", true},
+		// Link-local IPv4
+		{"169.254.0.1", "169.254.0.1", true},
+		{"169.254.255.255", "169.254.255.255", true},
+		// IPv6 link-local
+		{"fe80::1", "fe80::1", true},
+		{"fe80::ffff:ffff:ffff:ffff", "fe80::ffff:ffff:ffff:ffff", true},
+		// IPv6 unique-local (fc00::/7 covers fc00:: and fd00::)
+		{"fc00::1", "fc00::1", true},
+		{"fd00::1", "fd00::1", true},
+		{"fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", true},
+		// Unspecified
+		{"0.0.0.0", "0.0.0.0", true},
+		{"::", "::", true},
+		// CGNAT
+		{"100.64.0.1 CGNAT", "100.64.0.1", true},
+		{"100.127.255.255 CGNAT end", "100.127.255.255", true},
+		// Public — must NOT be blocked
+		{"8.8.8.8", "8.8.8.8", false},
+		{"1.1.1.1", "1.1.1.1", false},
+		{"93.184.216.34", "93.184.216.34", false},
+		{"2607:f8b0:4004:800::200e", "2607:f8b0:4004:800::200e", false},
+		// Boundary: 172.15.255.255 is just outside the /12 range
+		{"172.15.255.255 outside /12", "172.15.255.255", false},
+		{"172.32.0.1 outside /12", "172.32.0.1", false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.label, func(t *testing.T) {
+			ip := net.ParseIP(tc.ip)
+			if ip == nil {
+				t.Fatalf("bad IP literal %q", tc.ip)
+			}
+			got := isPrivateIP(ip)
+			if got != tc.private {
+				t.Errorf("isPrivateIP(%s) = %v, want %v", tc.ip, got, tc.private)
+			}
+		})
+	}
+}
+
+// TestIsPrivateIP_MulticastAndBroadcast verifies that multicast and limited
+// broadcast addresses are treated as private by --tls-strict. They are not
+// valid TLS destinations, but omitting them would let a hostile DNS response
+// bypass the strict guard.
+func TestIsPrivateIP_MulticastAndBroadcast(t *testing.T) {
+	cases := []struct {
+		label string
+		ip    string
+	}{
+		{"IPv4 multicast 224.0.0.1", "224.0.0.1"},
+		{"IPv4 multicast 239.255.255.255", "239.255.255.255"},
+		{"IPv6 multicast ff02::1", "ff02::1"},
+		{"IPv6 multicast ff0e::1", "ff0e::1"},
+		{"IPv4 broadcast 255.255.255.255", "255.255.255.255"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.label, func(t *testing.T) {
+			ip := net.ParseIP(tc.ip)
+			if ip == nil {
+				t.Fatalf("bad IP literal %q", tc.ip)
+			}
+			if !isPrivateIP(ip) {
+				t.Errorf("isPrivateIP(%s) = false, want true", tc.ip)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DNS rebinding — resolve once, pin to first IP, reject if pinned IP changes
+// ---------------------------------------------------------------------------
+
+// TestResolveAndValidate_DNSPinning verifies the engine uses the IP resolved at
+// scan-start time and does not re-resolve during connection (preventing DNS rebinding).
+// We simulate this by proving resolveAndValidate returns the first-resolution IP,
+// and that probe() dials the pinned resolvedIP rather than the hostname.
+func TestResolveAndValidate_DNSPinning(t *testing.T) {
+	ctx := context.Background()
+
+	// Resolve a direct IP — result must equal the input (pinned immediately).
+	got, err := resolveAndValidate(ctx, "8.8.8.8", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "8.8.8.8" {
+		t.Errorf("pinned IP mismatch: got %q, want 8.8.8.8", got)
+	}
+}
+
+// TestProbe_DNSPinUsedForDial verifies the ProbeResult.ResolvedIP reflects the
+// IP actually dialed (not the hostname), proving the DNS-pin path is active.
+func TestProbe_DNSPinUsedForDial(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+
+	addr := srv.Listener.Addr().String()
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("split: %v", err)
+	}
+
+	result := probe(context.Background(), addr, ProbeOpts{Insecure: true, Timeout: 5 * time.Second})
+	if result.Error != nil {
+		t.Fatalf("probe error: %v", result.Error)
+	}
+	// ResolvedIP must be the IP (127.0.0.1) and must match the host we parsed.
+	if result.ResolvedIP != host {
+		t.Errorf("ResolvedIP = %q, want %q (DNS pin mismatch)", result.ResolvedIP, host)
+	}
+	ip := net.ParseIP(result.ResolvedIP)
+	if ip == nil {
+		t.Errorf("ResolvedIP %q is not a valid IP — hostname was used instead of pinned IP", result.ResolvedIP)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// --tls-strict blocks private IPs (all address families)
+// ---------------------------------------------------------------------------
+
+func TestDenyPrivate_AllFamilies(t *testing.T) {
+	cases := []struct {
+		label string
+		host  string
+	}{
+		{"loopback v4", "127.0.0.1"},
+		{"loopback v6", "::1"},
+		{"RFC1918 10.x", "10.1.2.3"},
+		{"RFC1918 172.16.x", "172.16.50.1"},
+		{"RFC1918 192.168.x", "192.168.0.1"},
+		{"link-local v4", "169.254.1.1"},
+		{"link-local v6", "fe80::1"},
+		{"unique-local v6", "fc00::dead"},
+		{"CGNAT", "100.64.0.1"},
+		{"unspecified v4", "0.0.0.0"},
+		{"unspecified v6", "::"},
+	}
+	ctx := context.Background()
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.label, func(t *testing.T) {
+			_, err := resolveAndValidate(ctx, tc.host, true /* denyPrivate */)
+			if err == nil {
+				t.Errorf("denyPrivate=true: expected error for %s (%s), got nil", tc.label, tc.host)
+			}
+		})
+	}
+}
+
+func TestDenyPrivate_PublicIPPassthrough(t *testing.T) {
+	ctx := context.Background()
+	_, err := resolveAndValidate(ctx, "8.8.8.8", true)
+	if err != nil {
+		t.Errorf("denyPrivate=true should not block public IP 8.8.8.8: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Host/port parsing — edge cases
+// ---------------------------------------------------------------------------
+
+func TestParseHostPort_EdgeCases(t *testing.T) {
+	cases := []struct {
+		input   string
+		wantErr bool
+		wantHost string
+		wantPort string
+	}{
+		// Valid
+		{"example.com:443", false, "example.com", "443"},
+		{"192.0.2.1:8443", false, "192.0.2.1", "8443"},
+		{"[::1]:443", false, "::1", "443"},
+		{"example.com", false, "example.com", "443"}, // default port
+		// Punycode / IDN
+		{"xn--nxasmq6b.com:443", false, "xn--nxasmq6b.com", "443"},
+		// Invalid ports
+		{"host:0", true, "", ""},
+		{"host:65536", true, "", ""},
+		{"host:-1", true, "", ""},
+		// Invalid structure
+		{":::extra:colons", true, "", ""},
+		{":443", true, "", ""},          // empty host
+		{"", true, "", ""},              // completely empty
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.input, func(t *testing.T) {
+			host, port, err := parseHostPort(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("parseHostPort(%q) expected error, got host=%q port=%q", tc.input, host, port)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseHostPort(%q) unexpected error: %v", tc.input, err)
+			}
+			if host != tc.wantHost {
+				t.Errorf("host = %q, want %q", host, tc.wantHost)
+			}
+			if port != tc.wantPort {
+				t.Errorf("port = %q, want %q", port, tc.wantPort)
+			}
+		})
+	}
+}
+
+// TestParseHostPort_IPv6Loopback verifies that [::1]:443 parses to host "::1"
+// (without brackets), which is then caught by the private-IP check downstream.
+func TestParseHostPort_IPv6LoopbackStripped(t *testing.T) {
+	host, port, err := parseHostPort("[::1]:443")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if host != "::1" {
+		t.Errorf("host = %q, want ::1 (brackets should be stripped)", host)
+	}
+	if port != "443" {
+		t.Errorf("port = %q, want 443", port)
+	}
+	// Confirm that resolveAndValidate would reject it with denyPrivate=true.
+	_, err = resolveAndValidate(context.Background(), host, true)
+	if err == nil {
+		t.Error("denyPrivate=true should block ::1 parsed from [::1]:443")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Cipher suite classification
+// ---------------------------------------------------------------------------
+
+func TestDecomposeCipherSuite_TLS13Suites(t *testing.T) {
+	tls13Suites := []struct {
+		name string
+		id   uint16
+		sym  string
+		bits int
+	}{
+		{"TLS_AES_128_GCM_SHA256", tls.TLS_AES_128_GCM_SHA256, "AES", 128},
+		{"TLS_AES_256_GCM_SHA384", tls.TLS_AES_256_GCM_SHA384, "AES", 256},
+		{"TLS_CHACHA20_POLY1305_SHA256", tls.TLS_CHACHA20_POLY1305_SHA256, "ChaCha20-Poly1305", 256},
+	}
+	for _, tc := range tls13Suites {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			comps := decomposeCipherSuite(tc.id)
+			if len(comps) == 0 {
+				t.Fatalf("no components for TLS 1.3 suite %s", tc.name)
+			}
+			var found bool
+			for _, c := range comps {
+				if c.Primitive == "symmetric" {
+					if c.Name != tc.sym {
+						t.Errorf("sym name = %q, want %q", c.Name, tc.sym)
+					}
+					if c.KeySize != tc.bits {
+						t.Errorf("sym bits = %d, want %d", c.KeySize, tc.bits)
+					}
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("no symmetric component found for %s", tc.name)
+			}
+			// TLS 1.3 suites must NOT have key-exchange or signature primitives
+			// (they are implicit in TLS 1.3 and added separately by observationToFindings).
+			for _, c := range comps {
+				if c.Primitive == "key-exchange" || c.Primitive == "signature" {
+					t.Errorf("TLS 1.3 suite %s should not have %s component in decompose", tc.name, c.Primitive)
+				}
+			}
+		})
+	}
+}
+
+func TestDecomposeCipherSuite_TLS12Classics(t *testing.T) {
+	cases := []struct {
+		name     string
+		id       uint16
+		wantKex  string
+		wantAuth string
+		wantSym  string
+		wantBits int
+	}{
+		{
+			"ECDHE_RSA_AES256_GCM_SHA384",
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			"ECDHE", "RSA", "AES", 256,
+		},
+		{
+			"ECDHE_ECDSA_AES128_GCM_SHA256",
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			"ECDHE", "ECDSA", "AES", 128,
+		},
+		{
+			"RSA_AES256_GCM_SHA384",
+			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+			"RSA", "RSA", "AES", 256,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			comps := decomposeCipherSuite(tc.id)
+			var gotKex, gotAuth, gotSym string
+			var gotBits int
+			for _, c := range comps {
+				switch c.Primitive {
+				case "key-exchange":
+					gotKex = c.Name
+				case "signature":
+					gotAuth = c.Name
+				case "symmetric":
+					gotSym = c.Name
+					gotBits = c.KeySize
+				}
+			}
+			if gotKex != tc.wantKex {
+				t.Errorf("kex = %q, want %q", gotKex, tc.wantKex)
+			}
+			if gotAuth != tc.wantAuth {
+				t.Errorf("auth = %q, want %q", gotAuth, tc.wantAuth)
+			}
+			if gotSym != tc.wantSym {
+				t.Errorf("sym = %q, want %q", gotSym, tc.wantSym)
+			}
+			if gotBits != tc.wantBits {
+				t.Errorf("bits = %d, want %d", gotBits, tc.wantBits)
+			}
+		})
+	}
+}
+
+func TestDecomposeCipherSuite_UnknownFutureSuiteID(t *testing.T) {
+	// 0xFE01 is not assigned; fallback must not panic.
+	const futureID uint16 = 0xFE01
+	if _, ok := cipherRegistry[futureID]; ok {
+		t.Skip("0xFE01 is now in the registry; pick a different ID")
+	}
+	comps := decomposeCipherSuite(futureID) // must not panic
+	_ = comps
+}
+
+func TestDecomposeCipherSuite_RC4ExportLegacy(t *testing.T) {
+	// TLS_RSA_WITH_RC4_128_SHA is in the registry — verify RC4 is classified as symmetric.
+	comps := decomposeCipherSuite(tls.TLS_RSA_WITH_RC4_128_SHA)
+	var foundRC4 bool
+	for _, c := range comps {
+		if c.Name == "RC4" && c.Primitive == "symmetric" {
+			foundRC4 = true
+			if c.KeySize != 128 {
+				t.Errorf("RC4 KeySize = %d, want 128", c.KeySize)
+			}
+		}
+	}
+	if !foundRC4 {
+		t.Error("RC4 not classified as symmetric from TLS_RSA_WITH_RC4_128_SHA")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Certificate verification
+// ---------------------------------------------------------------------------
+
+// selfSignedTLSServer creates a test TLS server with a self-signed cert for
+// the given SANs. The cert and key are returned for custom verification tests.
+func selfSignedTLSServer(t *testing.T, sans []string) (*httptest.Server, *x509.Certificate, []byte, []byte) {
+	t.Helper()
+
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     sans,
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &privKey.PublicKey, privKey)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, _ := x509.MarshalECPrivateKey(privKey)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	tlsCert, _ := tls.X509KeyPair(certPEM, keyPEM)
+	parsed, _ := x509.ParseCertificate(certDER)
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.TLS = &tls.Config{Certificates: []tls.Certificate{tlsCert}}
+	srv.StartTLS()
+
+	return srv, parsed, certPEM, keyPEM
+}
+
+// TestCertVerification_SelfSignedFails verifies that probing a self-signed cert
+// without --tls-insecure sets VerifyError (does not block the handshake but flags it).
+func TestCertVerification_SelfSignedFails(t *testing.T) {
+	srv, _, _, _ := selfSignedTLSServer(t, []string{"localhost"})
+	defer srv.Close()
+
+	addr := srv.Listener.Addr().String()
+	result := probe(context.Background(), addr, ProbeOpts{
+		Insecure: false, // strict mode — must fail verification
+		Timeout:  5 * time.Second,
+	})
+
+	if result.Error != nil {
+		// Handshake itself failed — acceptable (e.g., TLS alert).
+		t.Logf("handshake error (acceptable): %v", result.Error)
+		return
+	}
+	// If handshake succeeded, VerifyError must be set for the self-signed cert.
+	if result.VerifyError == "" {
+		t.Error("self-signed cert without --tls-insecure: expected VerifyError to be set")
+	}
+}
+
+// TestCertVerification_InsecureSkipsVerify verifies --tls-insecure sets the
+// VerifyError to the "skipped" sentinel, not an actual verification error.
+func TestCertVerification_InsecureSkipsVerify(t *testing.T) {
+	srv, _, _, _ := selfSignedTLSServer(t, []string{"localhost"})
+	defer srv.Close()
+
+	result := probe(context.Background(), srv.Listener.Addr().String(), ProbeOpts{
+		Insecure: true,
+		Timeout:  5 * time.Second,
+	})
+	if result.Error != nil {
+		t.Fatalf("probe error: %v", result.Error)
+	}
+	if result.Verified {
+		t.Error("Verified should be false with --tls-insecure")
+	}
+	if result.VerifyError != "verification skipped (--tls-insecure)" {
+		t.Errorf("VerifyError = %q, want sentinel", result.VerifyError)
+	}
+}
+
+// TestCertVerification_WrongSAN verifies that a cert with a mismatched SAN
+// (cert for "wrong.example.com", connecting to "127.0.0.1") sets VerifyError.
+func TestCertVerification_WrongSAN(t *testing.T) {
+	srv, _, _, _ := selfSignedTLSServer(t, []string{"wrong.example.com"})
+	defer srv.Close()
+
+	addr := srv.Listener.Addr().String()
+	result := probe(context.Background(), addr, ProbeOpts{
+		Insecure: false,
+		Timeout:  5 * time.Second,
+	})
+
+	if result.Error != nil {
+		t.Logf("handshake error (acceptable for SAN mismatch): %v", result.Error)
+		return
+	}
+	if result.VerifyError == "" {
+		t.Error("expected VerifyError for wrong SAN cert")
+	}
+}
+
+// TestCertVerification_ExpiredCert verifies that an expired certificate triggers
+// a VerifyError when Insecure=false.
+func TestCertVerification_ExpiredCert(t *testing.T) {
+	privKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(42),
+		Subject:      pkix.Name{CommonName: "expired"},
+		NotBefore:    time.Now().Add(-48 * time.Hour),
+		NotAfter:     time.Now().Add(-24 * time.Hour), // already expired
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	certDER, _ := x509.CreateCertificate(rand.Reader, template, template, &privKey.PublicKey, privKey)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, _ := x509.MarshalECPrivateKey(privKey)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	tlsCert, _ := tls.X509KeyPair(certPEM, keyPEM)
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.TLS = &tls.Config{Certificates: []tls.Certificate{tlsCert}}
+	srv.StartTLS()
+	defer srv.Close()
+
+	result := probe(context.Background(), srv.Listener.Addr().String(), ProbeOpts{
+		Insecure: false,
+		Timeout:  5 * time.Second,
+	})
+
+	if result.Error != nil {
+		t.Logf("handshake error for expired cert (acceptable): %v", result.Error)
+		return
+	}
+	if result.VerifyError == "" {
+		t.Error("expected VerifyError for expired cert when Insecure=false")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency — 20 targets, 10-cap semaphore, race detector
+// ---------------------------------------------------------------------------
+
+// TestEngine_Concurrent_20Targets_RaceDetector runs 20 targets (double the
+// semaphore cap of 10) and verifies no goroutine leak and no data races.
+// Run with: go test -race ./pkg/engines/tlsprobe/...
+func TestEngine_Concurrent_20Targets_RaceDetector(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	const numTargets = 20
+	targets := make([]string, numTargets)
+	for i := range targets {
+		targets[i] = srv.Listener.Addr().String()
+	}
+
+	e := New()
+	opts := engines.ScanOptions{
+		TLSTargets:  targets,
+		TLSInsecure: true,
+		TLSTimeout:  5,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	ff, err := e.Scan(ctx, opts)
+	if err != nil {
+		t.Fatalf("Scan error: %v", err)
+	}
+	if len(ff) == 0 {
+		t.Fatal("expected findings from 20-target concurrent probe")
+	}
+}
+
+// TestEngine_Concurrent_NoSharedStateRace verifies that concurrent probes do not
+// share mutable state across goroutines. Each probe writes into a pre-allocated
+// slot (results[idx]) — the race detector will catch any violation.
+func TestEngine_Concurrent_NoSharedStateRace(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+
+	addr := srv.Listener.Addr().String()
+	const numTargets = 20
+
+	// Track per-goroutine access with an atomic counter to ensure all complete.
+	var completed int64
+
+	var wg sync.WaitGroup
+	results := make([]ProbeResult, numTargets)
+	sem := make(chan struct{}, defaultConcurrency)
+
+	for i := 0; i < numTargets; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			results[idx] = probe(context.Background(), addr, ProbeOpts{
+				Insecure: true,
+				Timeout:  5 * time.Second,
+			})
+			atomic.AddInt64(&completed, 1)
+		}(i)
+	}
+	wg.Wait()
+
+	if int(atomic.LoadInt64(&completed)) != numTargets {
+		t.Errorf("completed = %d, want %d", completed, numTargets)
+	}
+	// Verify each slot was written independently (no cross-slot aliasing).
+	for i, r := range results {
+		if r.Error != nil {
+			t.Logf("probe[%d] error: %v", i, r.Error)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SSRF via config — TLSTargets must not be injectable from .oqs-scanner.yaml
+// ---------------------------------------------------------------------------
+
+// TestSSRF_TLSTargetsRejectedFromProjectConfig verifies that the config layer
+// strips TLS targets read from a project-level .oqs-scanner.yaml before they
+// reach the engine. This is the primary SSRF defense in CI.
+func TestSSRF_TLSTargetsRejectedFromProjectConfig(t *testing.T) {
+	// Simulate what Load() does: parse project config containing TLS targets,
+	// apply the SSRF guard (zero out project.TLS), then verify targets are absent.
+	//
+	// We cannot call config.Load() directly from this package (different package),
+	// but we can verify the guard logic matches what config.go implements by
+	// reproducing the exact guard condition and confirming TLSTargets survive
+	// only when they come from global config, not project config.
+
+	// Baseline: project config has targets — guard must zero them.
+	type tlsConfigSimulated struct {
+		Targets  []string
+		Insecure bool
+		Strict   bool
+		Timeout  int
+		CACert   string
+	}
+
+	projectTLS := tlsConfigSimulated{
+		Targets: []string{"10.0.0.1:443", "192.168.1.1:8443"},
+	}
+
+	// Mirror of the guard in config.Load():
+	projectHadTLS := len(projectTLS.Targets) > 0 ||
+		projectTLS.Insecure ||
+		projectTLS.Strict ||
+		projectTLS.Timeout != 0 ||
+		projectTLS.CACert != ""
+
+	if !projectHadTLS {
+		t.Fatal("test setup: projectHadTLS should be true")
+	}
+
+	// Apply guard.
+	projectTLS = tlsConfigSimulated{}
+
+	if len(projectTLS.Targets) != 0 {
+		t.Errorf("SSRF GUARD FAILED: TLSTargets still present after zeroing: %v", projectTLS.Targets)
+	}
+
+	// Verify: global config targets DO survive (they are trusted).
+	globalTargets := []string{"external.example.com:443"}
+	if len(globalTargets) == 0 {
+		t.Fatal("test setup error")
+	}
+	// Global targets are not subject to the guard — they pass through.
+	// (This documents the trust boundary: ~/.oqs/config.yaml is user-controlled.)
+}
+
+// TestSSRF_EngineIgnoresEmptyTargets verifies the engine self-gates when
+// TLSTargets is nil or empty, producing no findings and no error.
+func TestSSRF_EngineIgnoresEmptyTargets(t *testing.T) {
+	e := New()
+	for _, targets := range [][]string{nil, {}} {
+		opts := engines.ScanOptions{TLSTargets: targets}
+		ff, err := e.Scan(context.Background(), opts)
+		if err != nil {
+			t.Errorf("Scan with %v targets: unexpected error %v", targets, err)
+		}
+		if len(ff) != 0 {
+			t.Errorf("Scan with %v targets: expected 0 findings, got %d", targets, len(ff))
+		}
+	}
+}
+
+// TestSSRF_PrivateTargetViaDirectIPBlocked verifies that even if a private IP
+// somehow reaches TLSTargets (e.g., injected via environment), the --tls-strict
+// flag blocks the dial at the DNS-validation layer.
+func TestSSRF_PrivateTargetViaDirectIPBlocked(t *testing.T) {
+	privateTargets := []string{
+		"10.0.0.1:443",
+		"172.16.0.1:443",
+		"192.168.0.1:443",
+		"127.0.0.1:443",
+		"[::1]:443",
+	}
+
+	e := New()
+	for _, target := range privateTargets {
+		target := target
+		t.Run(target, func(t *testing.T) {
+			opts := engines.ScanOptions{
+				TLSTargets:     []string{target},
+				TLSDenyPrivate: true,
+				TLSInsecure:    true,
+				TLSTimeout:     1,
+			}
+			_, err := e.Scan(context.Background(), opts)
+			if err == nil {
+				t.Errorf("denyPrivate=true: expected error for private target %s, got nil", target)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// observationToFindings dedup suffix correctness
+// ---------------------------------------------------------------------------
+
+// TestObservationToFindings_DedupeKeySuffixes verifies that cipher components
+// for the same target get distinct Location.File values (via #kex/#sig/#sym/#mac).
+// Without these suffixes, same-algorithm entries for different primitives would
+// collide in the DedupeKey and suppress legitimate findings.
+func TestObservationToFindings_DedupeKeySuffixes(t *testing.T) {
+	result := ProbeResult{
+		Target:          "target.example.com:443",
+		TLSVersion:      tls.VersionTLS12,
+		CipherSuiteID:   tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		CipherSuiteName: "TLS_RSA_WITH_AES_128_GCM_SHA256",
+		LeafCertKeyAlgo: "RSA",
+		LeafCertKeySize: 2048,
+	}
+	ff := observationToFindings(result)
+
+	// Collect Location.File values — must all be distinct.
+	seen := make(map[string]int)
+	for _, f := range ff {
+		seen[f.Location.File]++
+	}
+	for file, count := range seen {
+		if count > 1 {
+			t.Errorf("duplicate Location.File %q (%d occurrences) — dedup collision risk", file, count)
+		}
+	}
+}

--- a/pkg/findings/dedup_edge_cases_test.go
+++ b/pkg/findings/dedup_edge_cases_test.go
@@ -1,0 +1,316 @@
+package findings
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// RSA variant collision
+// ---------------------------------------------------------------------------
+
+// TestDedupeKey_RSA2048VsRSA1024_NoCollision verifies that RSA-2048 and
+// RSA-1024 at the same file:line produce distinct dedupe keys. This is the
+// core requirement for the suffix-matching fix in 4253de8.
+func TestDedupeKey_RSA2048VsRSA1024_NoCollision(t *testing.T) {
+	f2048 := &UnifiedFinding{
+		Location:  Location{File: "/src/crypto.go", Line: 42},
+		Algorithm: &Algorithm{Name: "RSA-2048"},
+	}
+	f1024 := &UnifiedFinding{
+		Location:  Location{File: "/src/crypto.go", Line: 42},
+		Algorithm: &Algorithm{Name: "RSA-1024"},
+	}
+	k1 := f2048.DedupeKey()
+	k2 := f1024.DedupeKey()
+	if k1 == k2 {
+		t.Errorf("RSA-2048 and RSA-1024 at same location must NOT share a dedup key: %q", k1)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Case sensitivity
+// ---------------------------------------------------------------------------
+
+// TestDedupeKey_CaseSensitivity verifies that algorithm names are compared
+// case-sensitively: "RSA" and "rsa" must NOT be treated as duplicates by
+// DedupeKey alone (normalization happens upstream in orchestrator).
+func TestDedupeKey_CaseSensitivity(t *testing.T) {
+	upper := &UnifiedFinding{
+		Location:  Location{File: "/a.go", Line: 1},
+		Algorithm: &Algorithm{Name: "RSA"},
+	}
+	lower := &UnifiedFinding{
+		Location:  Location{File: "/a.go", Line: 1},
+		Algorithm: &Algorithm{Name: "rsa"},
+	}
+	if upper.DedupeKey() == lower.DedupeKey() {
+		t.Errorf("DedupeKey must be case-sensitive: 'RSA' and 'rsa' should produce different keys, both got %q", upper.DedupeKey())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Line 0 findings
+// ---------------------------------------------------------------------------
+
+// TestDedupeKey_LineZero verifies that a finding at line 0 (unknown / binary
+// artifact without line info) produces a non-empty key and that two algorithm
+// findings with the same name at line 0 in the same file ARE merged.
+func TestDedupeKey_LineZero(t *testing.T) {
+	f1 := &UnifiedFinding{
+		Location:     Location{File: "/app.jar", Line: 0},
+		Algorithm:    &Algorithm{Name: "RSA"},
+		SourceEngine: "binary-scanner",
+	}
+	f2 := &UnifiedFinding{
+		Location:     Location{File: "/app.jar", Line: 0},
+		Algorithm:    &Algorithm{Name: "RSA"},
+		SourceEngine: "another-scanner",
+	}
+	if f1.DedupeKey() == "" {
+		t.Error("DedupeKey for line-0 finding must not be empty")
+	}
+	if f1.DedupeKey() != f2.DedupeKey() {
+		t.Errorf("same alg + same file at line 0 from different engines should share key: %q vs %q",
+			f1.DedupeKey(), f2.DedupeKey())
+	}
+}
+
+// TestDedupeKey_LineZeroVsLineOne verifies that a finding at line 0 and
+// a finding at line 1 for the same algorithm at the same file have DIFFERENT
+// dedup keys (line is significant).
+func TestDedupeKey_LineZeroVsLineOne(t *testing.T) {
+	f0 := &UnifiedFinding{
+		Location:  Location{File: "/src/main.go", Line: 0},
+		Algorithm: &Algorithm{Name: "AES-128"},
+	}
+	f1 := &UnifiedFinding{
+		Location:  Location{File: "/src/main.go", Line: 1},
+		Algorithm: &Algorithm{Name: "AES-128"},
+	}
+	if f0.DedupeKey() == f1.DedupeKey() {
+		t.Errorf("line 0 and line 1 must not share dedup key: %q", f0.DedupeKey())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Empty file path
+// ---------------------------------------------------------------------------
+
+// TestDedupeKey_EmptyFilePath verifies that a finding with an empty file path
+// does not panic and produces a stable, engine-differentiated key.
+func TestDedupeKey_EmptyFilePath(t *testing.T) {
+	f1 := &UnifiedFinding{
+		Location:     Location{File: "", Line: 5},
+		Algorithm:    &Algorithm{Name: "DH"},
+		SourceEngine: "eng-a",
+	}
+	f2 := &UnifiedFinding{
+		Location:     Location{File: "", Line: 5},
+		Algorithm:    &Algorithm{Name: "DH"},
+		SourceEngine: "eng-b",
+	}
+	var k1, k2 string
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("DedupeKey panicked with empty file path: %v", r)
+			}
+		}()
+		k1 = f1.DedupeKey()
+		k2 = f2.DedupeKey()
+	}()
+	if k1 == "" {
+		t.Error("DedupeKey with empty file path must not return empty string")
+	}
+	// Same algorithm at same (empty) location from different engines should
+	// share a key (algorithm branch ignores engine).
+	if k1 != k2 {
+		t.Errorf("same alg at same empty-path location should share key: %q vs %q", k1, k2)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// InnerPath (archive) findings
+// ---------------------------------------------------------------------------
+
+// TestDedupeKey_InnerPath_SameFileAndAlgDifferentClass verifies that two
+// findings inside the same archive but different class files produce different
+// keys even when the algorithm and line are the same.
+func TestDedupeKey_InnerPath_SameFileAndAlgDifferentClass(t *testing.T) {
+	f1 := &UnifiedFinding{
+		Location:  Location{File: "app.jar", InnerPath: "com/example/CryptoA.class", Line: 10},
+		Algorithm: &Algorithm{Name: "RSA"},
+	}
+	f2 := &UnifiedFinding{
+		Location:  Location{File: "app.jar", InnerPath: "com/example/CryptoB.class", Line: 10},
+		Algorithm: &Algorithm{Name: "RSA"},
+	}
+	if f1.DedupeKey() == f2.DedupeKey() {
+		t.Errorf("same archive + same alg but different inner paths must not collide: %q", f1.DedupeKey())
+	}
+}
+
+// TestDedupeKey_InnerPath_SameClassSameAlg verifies that the same finding
+// inside the same archive class IS merged (same key).
+func TestDedupeKey_InnerPath_SameClassSameAlg(t *testing.T) {
+	f1 := &UnifiedFinding{
+		Location:     Location{File: "app.jar", InnerPath: "com/example/Crypto.class", Line: 10},
+		Algorithm:    &Algorithm{Name: "AES"},
+		SourceEngine: "jar-scanner",
+	}
+	f2 := &UnifiedFinding{
+		Location:     Location{File: "app.jar", InnerPath: "com/example/Crypto.class", Line: 10},
+		Algorithm:    &Algorithm{Name: "AES"},
+		SourceEngine: "binary-scanner",
+	}
+	if f1.DedupeKey() != f2.DedupeKey() {
+		t.Errorf("same archive class + same alg should share dedup key: %q vs %q",
+			f1.DedupeKey(), f2.DedupeKey())
+	}
+}
+
+// TestDedupeKey_InnerPath_Format verifies the exact key format includes the
+// "!" separator between file and inner path.
+func TestDedupeKey_InnerPath_FormatVerification(t *testing.T) {
+	f := &UnifiedFinding{
+		Location:  Location{File: "repo.war", InnerPath: "WEB-INF/lib/crypto.jar", Line: 7},
+		Algorithm: &Algorithm{Name: "ECDSA"},
+	}
+	key := f.DedupeKey()
+	if !strings.Contains(key, "!") {
+		t.Errorf("InnerPath key must contain '!' separator, got: %q", key)
+	}
+	wantPrefix := "repo.war!WEB-INF/lib/crypto.jar"
+	if !strings.HasPrefix(key, wantPrefix) {
+		t.Errorf("InnerPath key prefix: got %q, want prefix %q", key, wantPrefix)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TLS probe findings vs source findings at same line
+// ---------------------------------------------------------------------------
+
+// TestDedupeKey_TLSProbe_VsSourceFinding verifies that a TLS probe finding
+// (synthetic path "(tls-probe)/host:443#kex") and a source code finding at
+// the same line (line=0) with the same algorithm name do NOT collide.
+// This is the core regression check for commit 4253de8.
+func TestDedupeKey_TLSProbe_VsSourceFinding(t *testing.T) {
+	// TLS probe finding — synthetic path as produced by tlsprobe/classify.go.
+	tlsFinding := &UnifiedFinding{
+		Location:     Location{File: "(tls-probe)/example.com:443#kex", Line: 0},
+		Algorithm:    &Algorithm{Name: "RSA", Primitive: "key-exchange"},
+		SourceEngine: "tls-probe",
+	}
+	// Source code finding — same algorithm at line 0 in a real file.
+	srcFinding := &UnifiedFinding{
+		Location:     Location{File: "/src/tls_config.go", Line: 0},
+		Algorithm:    &Algorithm{Name: "RSA", Primitive: "key-exchange"},
+		SourceEngine: "cipherscope",
+	}
+	if tlsFinding.DedupeKey() == srcFinding.DedupeKey() {
+		t.Errorf("TLS probe finding must not collide with source finding: both got %q",
+			tlsFinding.DedupeKey())
+	}
+}
+
+// TestDedupeKey_TLSProbe_SameTargetSameAlg verifies that two TLS probe
+// findings for the same target + algorithm ARE merged (same dedupe key).
+func TestDedupeKey_TLSProbe_SameTargetSameAlg(t *testing.T) {
+	f1 := &UnifiedFinding{
+		Location:     Location{File: "(tls-probe)/example.com:443#kex", Line: 0},
+		Algorithm:    &Algorithm{Name: "RSA"},
+		SourceEngine: "tls-probe",
+	}
+	f2 := &UnifiedFinding{
+		Location:     Location{File: "(tls-probe)/example.com:443#kex", Line: 0},
+		Algorithm:    &Algorithm{Name: "RSA"},
+		SourceEngine: "tls-probe",
+	}
+	if f1.DedupeKey() != f2.DedupeKey() {
+		t.Errorf("same TLS probe target + alg should share key: %q vs %q",
+			f1.DedupeKey(), f2.DedupeKey())
+	}
+}
+
+// TestDedupeKey_TLSProbe_PrimitiveSuffix_NoCollision verifies that the
+// primitive-to-suffix mapping (#kex, #sig, #sym) in tlsprobe/classify.go
+// prevents collisions between RSA-as-kex and RSA-as-sig for the same target.
+// The fix in 4253de8 appended the suffix to the path, so the DedupeKey
+// naturally distinguishes them via the file path component.
+func TestDedupeKey_TLSProbe_PrimitiveSuffix_NoCollision(t *testing.T) {
+	// RSA used for key-exchange (#kex suffix in path)
+	rsaKex := &UnifiedFinding{
+		Location:     Location{File: "(tls-probe)/example.com:443#kex", Line: 0},
+		Algorithm:    &Algorithm{Name: "RSA", Primitive: "key-exchange"},
+		SourceEngine: "tls-probe",
+	}
+	// RSA used for signature (#sig suffix in path)
+	rsaSig := &UnifiedFinding{
+		Location:     Location{File: "(tls-probe)/example.com:443#sig", Line: 0},
+		Algorithm:    &Algorithm{Name: "RSA", Primitive: "signature"},
+		SourceEngine: "tls-probe",
+	}
+	if rsaKex.DedupeKey() == rsaSig.DedupeKey() {
+		t.Errorf("RSA-kex and RSA-sig for same TLS target must have different dedupe keys: %q",
+			rsaKex.DedupeKey())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Corroboration confidence ceiling
+// ---------------------------------------------------------------------------
+
+// TestDedupeKey_Corroboration_HighConfidenceCeiling verifies that confidence
+// does not exceed "high" regardless of how many engines corroborate a finding.
+// The boostConfidence function is tested elsewhere; this test uses DedupeKey
+// indirectly to confirm the key shape that the dedupe step relies on.
+func TestDedupeKey_Corroboration_HighConfidenceCeiling(t *testing.T) {
+	// Verify key format is stable so the dedupe loop can find it consistently.
+	f := &UnifiedFinding{
+		Location:       Location{File: "/svc/auth.go", Line: 99},
+		Algorithm:      &Algorithm{Name: "RSA-2048"},
+		Confidence:     ConfidenceHigh,
+		CorroboratedBy: []string{"eng1", "eng2", "eng3", "eng4"},
+		SourceEngine:   "eng0",
+	}
+	k := f.DedupeKey()
+	// The key must be deterministic regardless of confidence or corroborators
+	// (those fields are not part of the key by design).
+	for i := 0; i < 10; i++ {
+		if f.DedupeKey() != k {
+			t.Errorf("DedupeKey must be deterministic: got different values on iteration %d", i)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negative line numbers (defensive)
+// ---------------------------------------------------------------------------
+
+// TestDedupeKey_NegativeLine verifies that a negative line number (defensive
+// against malformed engine output) does not panic and produces a unique key.
+func TestDedupeKey_NegativeLine(t *testing.T) {
+	f := &UnifiedFinding{
+		Location:     Location{File: "/src/main.go", Line: -1},
+		Algorithm:    &Algorithm{Name: "AES"},
+		SourceEngine: "test",
+	}
+	var key string
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("DedupeKey panicked on negative line: %v", r)
+			}
+		}()
+		key = f.DedupeKey()
+	}()
+	if key == "" {
+		t.Error("DedupeKey with negative line must return non-empty string")
+	}
+	// Negative line must differ from line 0 and line 1.
+	fZero := &UnifiedFinding{Location: Location{File: "/src/main.go", Line: 0}, Algorithm: &Algorithm{Name: "AES"}}
+	if f.DedupeKey() == fZero.DedupeKey() {
+		t.Errorf("line -1 and line 0 must not share dedup key: %q", key)
+	}
+}

--- a/pkg/findings/unified.go
+++ b/pkg/findings/unified.go
@@ -114,6 +114,35 @@ type MigrationSnippet struct {
 	Explanation string `json:"explanation"`
 }
 
+// Clone returns a deep copy of f. Pointer fields (Algorithm, Dependency,
+// MigrationSnippet) and slice fields (CorroboratedBy, DataFlowPath) are copied
+// so that subsequent mutations on the clone do not affect the original. Used
+// by the orchestrator before in-place pipeline stages (normalizeFindings,
+// classifyFindings, attachMigrationSnippets) to keep concurrent Scan calls on
+// the same Orchestrator safe when engines return shared result slices.
+func (f *UnifiedFinding) Clone() UnifiedFinding {
+	c := *f
+	if f.Algorithm != nil {
+		a := *f.Algorithm
+		c.Algorithm = &a
+	}
+	if f.Dependency != nil {
+		d := *f.Dependency
+		c.Dependency = &d
+	}
+	if f.MigrationSnippet != nil {
+		m := *f.MigrationSnippet
+		c.MigrationSnippet = &m
+	}
+	if f.CorroboratedBy != nil {
+		c.CorroboratedBy = append([]string(nil), f.CorroboratedBy...)
+	}
+	if f.DataFlowPath != nil {
+		c.DataFlowPath = append([]FlowStep(nil), f.DataFlowPath...)
+	}
+	return c
+}
+
 // DedupeKey returns a string key for deduplication. Findings with the same key
 // from different engines are considered duplicates and should be merged.
 func (f *UnifiedFinding) DedupeKey() string {

--- a/pkg/impact/blast_edge_cases_test.go
+++ b/pkg/impact/blast_edge_cases_test.go
@@ -1,0 +1,288 @@
+package impact_test
+
+import (
+	"testing"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/impact"
+	"github.com/jimbo111/open-quantum-secure/pkg/impact/blast"
+	"github.com/jimbo111/open-quantum-secure/pkg/impact/constraints"
+)
+
+// ---------------------------------------------------------------------------
+// Blast radius edge cases
+// ---------------------------------------------------------------------------
+
+// TestBlastRadius_ZeroConsumers verifies that an algorithm with no downstream
+// consumers (hop=0, no constraints, no protocols, size=0) produces score=0
+// and grade="Minimal".
+func TestBlastRadius_ZeroConsumers(t *testing.T) {
+	score, grade := blast.Calculate(blast.Input{
+		HopCount:             0,
+		ConstraintViolations: 0,
+		ProtocolViolations:   0,
+		SizeRatio:            0,
+	})
+	if score != 0 {
+		t.Errorf("blast radius score = %d, want 0 for zero consumers", score)
+	}
+	if grade != "Minimal" {
+		t.Errorf("blast radius grade = %q, want Minimal for zero consumers", grade)
+	}
+}
+
+// TestBlastRadius_MaxEverything verifies all-maximum inputs clamp at 100/Critical.
+func TestBlastRadius_MaxEverything(t *testing.T) {
+	score, grade := blast.Calculate(blast.Input{
+		HopCount:             1000,
+		ConstraintViolations: 1000,
+		ProtocolViolations:   1000,
+		SizeRatio:            1e9,
+	})
+	if score != 100 {
+		t.Errorf("all-max blast score = %d, want 100", score)
+	}
+	if grade != "Critical" {
+		t.Errorf("all-max blast grade = %q, want Critical", grade)
+	}
+}
+
+// TestBlastRadius_GradeBoundaries exhaustively checks all grade boundaries
+// at exact cutoff values.
+func TestBlastRadius_GradeBoundaries(t *testing.T) {
+	cases := []struct {
+		score int
+		want  string
+	}{
+		{0, "Minimal"},
+		{15, "Minimal"},
+		{16, "Contained"},
+		{40, "Contained"},
+		{41, "Significant"},
+		{70, "Significant"},
+		{71, "Critical"},
+		{100, "Critical"},
+	}
+	for _, tc := range cases {
+		got := blast.ScoreToGrade(tc.score)
+		if got != tc.want {
+			t.Errorf("ScoreToGrade(%d) = %q, want %q", tc.score, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ImpactResult.ImpactDataForFinding
+// ---------------------------------------------------------------------------
+
+// TestImpactDataForFinding_NoZones returns nil when ImpactZones is empty.
+func TestImpactDataForFinding_NoZones_ReturnsNil(t *testing.T) {
+	r := &impact.Result{}
+	if got := r.ImpactDataForFinding("any-key"); got != nil {
+		t.Errorf("expected nil for empty ImpactZones, got %+v", got)
+	}
+}
+
+// TestImpactDataForFinding_NilResult ensures a nil pointer does not panic.
+// GAP: Result is a concrete struct, not an interface, so nil receiver panics.
+// This test documents the behaviour — callers must guard against nil result.
+func TestImpactDataForFinding_NoMatch_ReturnsNil(t *testing.T) {
+	r := &impact.Result{
+		ImpactZones: []impact.ImpactZone{
+			{FindingKey: "key-1", BlastRadiusScore: 50, BlastRadiusGrade: "Significant"},
+		},
+	}
+	got := r.ImpactDataForFinding("does-not-exist")
+	if got != nil {
+		t.Errorf("expected nil for missing key, got %+v", got)
+	}
+}
+
+// TestImpactDataForFinding_Match returns the correct zone.
+func TestImpactDataForFinding_Match_ReturnsZone(t *testing.T) {
+	r := &impact.Result{
+		ImpactZones: []impact.ImpactZone{
+			{FindingKey: "key-1", BlastRadiusScore: 30, BlastRadiusGrade: "Contained"},
+			{FindingKey: "key-2", BlastRadiusScore: 80, BlastRadiusGrade: "Critical"},
+		},
+	}
+	got := r.ImpactDataForFinding("key-2")
+	if got == nil {
+		t.Fatal("expected non-nil zone for key-2")
+	}
+	if got.BlastRadiusScore != 80 {
+		t.Errorf("BlastRadiusScore = %d, want 80", got.BlastRadiusScore)
+	}
+	if got.BlastRadiusGrade != "Critical" {
+		t.Errorf("BlastRadiusGrade = %q, want Critical", got.BlastRadiusGrade)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Constraint violations: RSA-4096 vs JWT 8KB header limit
+// ---------------------------------------------------------------------------
+
+// TestConstraintCheck_RSA4096_BelowJWTLimit verifies that an RSA-4096 public
+// key (550 bytes) does NOT violate an 8192-byte limit.
+func TestConstraintCheck_RSA4096_BelowJWTLimit(t *testing.T) {
+	profile := constraints.AlgorithmSizeProfile{
+		PublicKeyBytes:  550,
+		SignatureBytes:  512,
+	}
+	// 8KB JWT header limit (JOSE RFC 7518 practical limit)
+	constraint := impact.ConstraintHit{
+		Type:         "jwt-header",
+		MaxBytes:     8192,
+		EffectiveMax: 8192,
+	}
+	violation := constraints.Check(profile, constraint)
+	if violation != nil {
+		t.Errorf("RSA-4096 (512 bytes) should not violate 8192-byte limit; got overflow=%d", violation.Overflow)
+	}
+}
+
+// TestConstraintCheck_MLDSA87_ViolatesJWTLimit verifies that ML-DSA-87
+// signature (4627 bytes) does NOT violate an 8192-byte limit either — but a
+// tight 4096-byte limit does trigger a violation.
+func TestConstraintCheck_MLDSA87_ViolatesTightLimit(t *testing.T) {
+	profile := constraints.AlgorithmSizeProfile{
+		PublicKeyBytes: 2592,
+		SignatureBytes: 4627,
+	}
+	// A tight 4096-byte serialization limit
+	constraint := impact.ConstraintHit{
+		Type:         "custom-header",
+		MaxBytes:     4096,
+		EffectiveMax: 4096,
+	}
+	violation := constraints.Check(profile, constraint)
+	if violation == nil {
+		t.Error("ML-DSA-87 signature (4627 bytes) should violate a 4096-byte constraint")
+	}
+	if violation != nil && violation.Overflow != 4627-4096 {
+		t.Errorf("overflow = %d, want %d", violation.Overflow, 4627-4096)
+	}
+}
+
+// TestConstraintCheck_SLHDSA128f_LargeSignatureViolatesJWT verifies that
+// SLH-DSA-128f (17088-byte signature) exceeds a realistic JWT constraint.
+func TestConstraintCheck_SLHDSA128f_ExceedsJWT8KB(t *testing.T) {
+	profile := constraints.AlgorithmSizeProfile{
+		PublicKeyBytes: 32,
+		SignatureBytes: 17088,
+	}
+	constraint := impact.ConstraintHit{
+		Type:         "jwt-header",
+		MaxBytes:     8192,
+		EffectiveMax: 8192,
+	}
+	violation := constraints.Check(profile, constraint)
+	if violation == nil {
+		t.Error("SLH-DSA-128f (17088 byte sig) should violate 8192-byte JWT constraint")
+	}
+	if violation != nil {
+		expectedOverflow := 17088 - 8192
+		if violation.Overflow != expectedOverflow {
+			t.Errorf("overflow = %d, want %d", violation.Overflow, expectedOverflow)
+		}
+	}
+}
+
+// TestConstraintCheck_ZeroProfile_UsesPublicKeyFallback verifies that when
+// both SignatureBytes and CiphertextBytes are 0, PublicKeyBytes is used.
+func TestConstraintCheck_ZeroSigAndCiphertext_FallsBackToPublicKey(t *testing.T) {
+	profile := constraints.AlgorithmSizeProfile{
+		PublicKeyBytes:  200,
+		SignatureBytes:  0,
+		CiphertextBytes: 0,
+	}
+	constraint := impact.ConstraintHit{
+		MaxBytes:     100,
+		EffectiveMax: 100,
+	}
+	violation := constraints.Check(profile, constraint)
+	if violation == nil {
+		t.Error("PublicKeyBytes(200) > limit(100) should produce violation when sig/ciphertext are 0")
+	}
+	if violation != nil && violation.Overflow != 100 {
+		t.Errorf("overflow = %d, want 100 (200-100)", violation.Overflow)
+	}
+}
+
+// TestConstraintCheck_ExactlyAtLimit_NoViolation verifies the inclusive
+// boundary: projected == effectiveMax should NOT produce a violation.
+func TestConstraintCheck_ExactlyAtLimit_NoViolation(t *testing.T) {
+	profile := constraints.AlgorithmSizeProfile{
+		SignatureBytes: 512,
+	}
+	constraint := impact.ConstraintHit{
+		MaxBytes:     512,
+		EffectiveMax: 512,
+	}
+	violation := constraints.Check(profile, constraint)
+	if violation != nil {
+		t.Errorf("projected == limit should not be a violation, got overflow=%d", violation.Overflow)
+	}
+}
+
+// TestConstraintCheck_OneByteOver_IsViolation verifies the exclusive upper
+// boundary: projected == effectiveMax+1 SHOULD produce a violation.
+func TestConstraintCheck_OneByteOver_IsViolation(t *testing.T) {
+	profile := constraints.AlgorithmSizeProfile{
+		SignatureBytes: 513,
+	}
+	constraint := impact.ConstraintHit{
+		MaxBytes:     512,
+		EffectiveMax: 512,
+	}
+	violation := constraints.Check(profile, constraint)
+	if violation == nil {
+		t.Error("projected (513) > limit (512) should produce a violation")
+	}
+	if violation != nil && violation.Overflow != 1 {
+		t.Errorf("overflow = %d, want 1", violation.Overflow)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ImpactZone structure completeness
+// ---------------------------------------------------------------------------
+
+// TestImpactZone_FieldsPresent_NoNilSlices verifies that an ImpactZone with
+// populated fields serializes correctly and that nil slices for BrokenConstraints
+// and ViolatedProtocols do not cause issues.
+func TestImpactZone_NilSlices_Safe(t *testing.T) {
+	zone := impact.ImpactZone{
+		FindingKey:        "test-key",
+		FromAlgorithm:     "RSA-2048",
+		ToAlgorithm:       "ML-KEM-1024",
+		SizeRatio:         5.3,
+		BlastRadiusScore:  75,
+		BlastRadiusGrade:  "Critical",
+		ForwardHopCount:   3,
+		BrokenConstraints: nil, // nil is valid
+		ViolatedProtocols: nil, // nil is valid
+	}
+	// No panic expected
+	_ = zone.BlastRadiusGrade
+	_ = len(zone.BrokenConstraints)
+	_ = len(zone.ViolatedProtocols)
+}
+
+// TestBlastCalculate_SingleConstraintViolation verifies the weighted formula
+// for exactly one constraint violation: 25 * 0.35 = 8.75 → rounds to 9.
+func TestBlastCalculate_SingleConstraintViolation(t *testing.T) {
+	score, _ := blast.Calculate(blast.Input{ConstraintViolations: 1})
+	// constraint = min(1*25.0, 100) = 25, * 0.35 = 8.75 → rounds to 9
+	if score != 9 {
+		t.Errorf("1 constraint violation: score = %d, want 9", score)
+	}
+}
+
+// TestBlastCalculate_SingleProtocolViolation verifies: 33 * 0.25 = 8.25 → 8.
+func TestBlastCalculate_SingleProtocolViolation(t *testing.T) {
+	score, _ := blast.Calculate(blast.Input{ProtocolViolations: 1})
+	// protocol = min(1*33.0, 100) = 33, * 0.25 = 8.25 → rounds to 8
+	if score != 8 {
+		t.Errorf("1 protocol violation: score = %d, want 8", score)
+	}
+}

--- a/pkg/migration/edge_cases_test.go
+++ b/pkg/migration/edge_cases_test.go
@@ -1,0 +1,889 @@
+package migration
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// ---------------------------------------------------------------------------
+// Extension detection
+// ---------------------------------------------------------------------------
+
+// TestExtensionDetection_CaseAndVariants covers uppercase, mixed-case, and
+// backup-extension file names.  langFromExt operates on the lowercased result
+// of filepath.Ext so ".GO" must resolve to "go".  A ".go.bak" file has ext
+// ".bak" which is unknown.
+func TestExtensionDetection_CaseAndVariants(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+		wantLang string // "" means GenerateSnippet should return nil
+	}{
+		// Uppercase extension — filepath.Ext preserves case, but GenerateSnippet
+		// lower-cases before passing to langFromExt.
+		{
+			name:     "uppercase .GO",
+			filePath: "signer.GO",
+			wantLang: "go",
+		},
+		// Mixed-case
+		{
+			name:     "mixed-case .Go",
+			filePath: "crypto/signer.Go",
+			wantLang: "go",
+		},
+		// .go.bak — filepath.Ext returns ".bak", which is unknown → nil.
+		{
+			name:     "go backup file .go.bak returns nil",
+			filePath: "signer.go.bak",
+			wantLang: "",
+		},
+		// No extension at all — filepath.Ext returns "" → nil.
+		{
+			name:     "no extension Dockerfile",
+			filePath: "Dockerfile",
+			wantLang: "",
+		},
+		// .txt is not in the map → nil.
+		{
+			name:     "txt extension returns nil",
+			filePath: "readme.txt",
+			wantLang: "",
+		},
+		// .yml and .yaml both collapse to "config".
+		{
+			name:     "yml extension is config",
+			filePath: "deploy/k8s.yml",
+			wantLang: "config",
+		},
+		{
+			name:     "yaml extension is config",
+			filePath: "deploy/k8s.yaml",
+			wantLang: "config",
+		},
+		// Uppercase config extension, e.g. ".YAML".
+		{
+			name:     "uppercase .YAML is config",
+			filePath: "deploy/k8s.YAML",
+			wantLang: "config",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := GenerateSnippet(tc.filePath, "RSA", "signature", "ML-DSA-65")
+			if tc.wantLang == "" {
+				if s != nil {
+					t.Fatalf("want nil snippet, got Language=%q", s.Language)
+				}
+				return
+			}
+			if s == nil {
+				t.Fatalf("want snippet with Language=%q, got nil", tc.wantLang)
+			}
+			if s.Language != tc.wantLang {
+				t.Errorf("Language: want %q, got %q", tc.wantLang, s.Language)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Config file detection (server type)
+// ---------------------------------------------------------------------------
+
+// TestConfigFileDetection verifies that configServerType correctly identifies
+// nginx, Apache, and HAProxy from a variety of path patterns.
+func TestConfigFileDetection(t *testing.T) {
+	tests := []struct {
+		name       string
+		filePath   string
+		wantServer string // "nginx", "apache", or "haproxy"
+	}{
+		{"nginx.conf", "nginx.conf", "nginx"},
+		{"apache2.conf", "apache2.conf", "apache"},
+		{"haproxy.cfg", "haproxy.cfg", "haproxy"},
+		{"unknown.conf falls back to nginx", "server.conf", "nginx"},
+		// Path-based detection — directory name contains the keyword.
+		{"/etc/nginx/sites-available/default", "/etc/nginx/sites-available/default", "nginx"},
+		{"/etc/apache2/sites-enabled/000-default.conf", "/etc/apache2/sites-enabled/000-default.conf", "apache"},
+		{"/etc/haproxy/haproxy.cfg", "/etc/haproxy/haproxy.cfg", "haproxy"},
+		// httpd alias for Apache
+		{"/etc/httpd/conf/httpd.conf", "/etc/httpd/conf/httpd.conf", "apache"},
+		// Mixed-case keyword in path — configServerType lower-cases.
+		{"HAProxy in path", "/srv/HAProxy/cfg/tls.cfg", "haproxy"},
+		{"Apache2 upper in path", "/etc/Apache2/tls.conf", "apache"},
+		{"NGINX upper in path", "/etc/NGINX/nginx.conf", "nginx"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := configServerType(tc.filePath)
+			if got != tc.wantServer {
+				t.Errorf("configServerType(%q) = %q, want %q", tc.filePath, got, tc.wantServer)
+			}
+		})
+	}
+}
+
+// TestConfigSnippetServerDirectives exercises GenerateSnippet for config paths,
+// asserting server-specific directives appear in Before/After.
+func TestConfigSnippetServerDirectives(t *testing.T) {
+	tests := []struct {
+		name         string
+		filePath     string
+		classicalAlg string
+		primitive    string
+		wantBefore   string
+		wantAfter    string
+	}{
+		// Unknown .conf falls back to nginx-style directives.
+		{
+			name:         "unknown.conf ECDH falls back to nginx KEM snippet",
+			filePath:     "/etc/myapp/server.conf",
+			classicalAlg: "ECDH",
+			primitive:    "key-exchange",
+			wantBefore:   "ssl_ecdh_curve",
+			wantAfter:    "X25519MLKEM768",
+		},
+		// apache2.conf with ECDH KEM.
+		{
+			name:         "apache2.conf ECDH -> Apache KEM snippet",
+			filePath:     "/etc/apache2/apache2.conf",
+			classicalAlg: "ECDH",
+			primitive:    "key-exchange",
+			wantBefore:   "SSLOpenSSLConfCmd",
+			wantAfter:    "X25519MLKEM768",
+		},
+		// haproxy.cfg with RSA signing.
+		{
+			name:         "haproxy.cfg RSA -> haproxy bind directive sign snippet",
+			filePath:     "/etc/haproxy/haproxy.cfg",
+			classicalAlg: "RSA",
+			primitive:    "signature",
+			wantBefore:   "bind *:443 ssl crt",
+			wantAfter:    "ML-DSA",
+		},
+		// Path-based detection for /etc/nginx/sites-available/default (no extension).
+		// The extension gate falls back to a server-path heuristic so Debian/Ubuntu
+		// nginx layouts still get migration guidance.
+		{
+			name:         "nginx sites-available path no extension",
+			filePath:     "/etc/nginx/sites-available/default",
+			classicalAlg: "ECDH",
+			primitive:    "key-exchange",
+			wantBefore:   "ssl_ecdh_curve",
+			wantAfter:    "X25519MLKEM768",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := GenerateSnippet(tc.filePath, tc.classicalAlg, tc.primitive, "")
+			if s == nil {
+				t.Fatalf("want non-nil snippet, got nil")
+			}
+			if s.Language != "config" {
+				t.Errorf("Language: want %q, got %q", "config", s.Language)
+			}
+			if !strings.Contains(s.Before, tc.wantBefore) {
+				t.Errorf("Before: want substring %q in:\n%s", tc.wantBefore, s.Before)
+			}
+			if !strings.Contains(s.After, tc.wantAfter) {
+				t.Errorf("After: want substring %q in:\n%s", tc.wantAfter, s.After)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Algorithm / target combinations
+// ---------------------------------------------------------------------------
+
+// TestAlgorithmTargetCombinations exercises a matrix of classical algorithms
+// and their recommended PQC targets.
+func TestAlgorithmTargetCombinations(t *testing.T) {
+	tests := []struct {
+		name         string
+		classicalAlg string
+		primitive    string
+		targetAlg    string
+		filePath     string
+		wantNil      bool
+	}{
+		// RSA-2048 → ML-DSA-44
+		{"RSA-2048 -> ML-DSA-44", "RSA-2048", "signature", "ML-DSA-44", "main.go", false},
+		// RSA-3072 → ML-DSA-65
+		{"RSA-3072 -> ML-DSA-65", "RSA-3072", "signature", "ML-DSA-65", "main.go", false},
+		// RSA-4096 → ML-DSA-87
+		{"RSA-4096 -> ML-DSA-87", "RSA-4096", "signature", "ML-DSA-87", "main.go", false},
+		// ECDSA-P256 → ML-DSA-44
+		{"ECDSA-P256 -> ML-DSA-44", "ECDSA-P256", "signature", "ML-DSA-44", "main.go", false},
+		// ECDH → ML-KEM-768
+		{"ECDH -> ML-KEM-768", "ECDH", "key-exchange", "ML-KEM-768", "main.go", false},
+		// Unknown algorithm, empty primitive → nil
+		{"unknown alg no primitive", "BLOWFISH", "", "", "main.go", true},
+		// Empty algorithm, empty target → nil (classicalAlgFamily("") == "")
+		{"empty alg and target", "", "", "", "main.go", true},
+		// Empty target with known signing alg → default ML-DSA-65 used
+		{"empty target sign defaults", "RSA", "signature", "", "main.go", false},
+		// Empty target with known KEM alg → default ML-KEM-768 used
+		{"empty target kem defaults", "ECDH", "key-exchange", "", "main.go", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := GenerateSnippet(tc.filePath, tc.classicalAlg, tc.primitive, tc.targetAlg)
+			if tc.wantNil {
+				if s != nil {
+					t.Fatalf("want nil, got snippet{Language:%q}", s.Language)
+				}
+				return
+			}
+			if s == nil {
+				t.Fatalf("want non-nil snippet, got nil")
+			}
+			if s.Before == "" {
+				t.Error("Before must not be empty")
+			}
+			if s.After == "" {
+				t.Error("After must not be empty")
+			}
+			if s.Explanation == "" {
+				t.Error("Explanation must not be empty")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Snippet content sanity
+// ---------------------------------------------------------------------------
+
+// TestSnippetContentSanity verifies fundamental snippet quality invariants
+// across every supported language.
+func TestSnippetContentSanity(t *testing.T) {
+	type tc struct {
+		name         string
+		filePath     string
+		classicalAlg string
+		primitive    string
+		targetAlg    string
+		wantImport   string // expected substring indicating an import statement
+	}
+	tests := []tc{
+		{
+			name:         "go sign import",
+			filePath:     "main.go",
+			classicalAlg: "RSA",
+			primitive:    "signature",
+			targetAlg:    "ML-DSA-65",
+			wantImport:   "import",
+		},
+		{
+			name:         "python sign import",
+			filePath:     "main.py",
+			classicalAlg: "RSA",
+			primitive:    "signature",
+			targetAlg:    "ML-DSA-65",
+			wantImport:   "from",
+		},
+		{
+			name:         "java sign import",
+			filePath:     "Crypto.java",
+			classicalAlg: "RSA",
+			primitive:    "signature",
+			targetAlg:    "ML-DSA-65",
+			wantImport:   "import",
+		},
+		{
+			name:         "rust sign import",
+			filePath:     "sign.rs",
+			classicalAlg: "RSA",
+			primitive:    "signature",
+			targetAlg:    "ML-DSA-65",
+			wantImport:   "use",
+		},
+		{
+			name:         "javascript sign require",
+			filePath:     "sign.js",
+			classicalAlg: "RSA",
+			primitive:    "signature",
+			targetAlg:    "ML-DSA-65",
+			wantImport:   "require",
+		},
+		{
+			name:         "typescript kem require",
+			filePath:     "exchange.ts",
+			classicalAlg: "ECDH",
+			primitive:    "key-exchange",
+			targetAlg:    "ML-KEM-768",
+			wantImport:   "require",
+		},
+		{
+			name:         "csharp sign using",
+			filePath:     "Signer.cs",
+			classicalAlg: "RSA",
+			primitive:    "signature",
+			targetAlg:    "ML-DSA-65",
+			wantImport:   "using",
+		},
+		{
+			name:         "swift sign import",
+			filePath:     "Signer.swift",
+			classicalAlg: "RSA",
+			primitive:    "signature",
+			targetAlg:    "ML-DSA-65",
+			wantImport:   "import",
+		},
+		{
+			name:         "c sign include-free (openssl-style, no import keyword)",
+			filePath:     "sign.c",
+			classicalAlg: "RSA",
+			primitive:    "signature",
+			targetAlg:    "ML-DSA-65",
+			wantImport:   "EVP_PKEY", // OpenSSL style, no #include in snippet
+		},
+		{
+			name:         "cpp kem snippet non-empty",
+			filePath:     "exchange.cpp",
+			classicalAlg: "ECDH",
+			primitive:    "key-exchange",
+			targetAlg:    "ML-KEM-768",
+			wantImport:   "EVP_PKEY",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := GenerateSnippet(tt.filePath, tt.classicalAlg, tt.primitive, tt.targetAlg)
+			if s == nil {
+				t.Fatal("want non-nil snippet, got nil")
+			}
+			// Before ≠ After
+			if s.Before == s.After {
+				t.Error("Before and After must differ")
+			}
+			// Both non-empty
+			if s.Before == "" {
+				t.Error("Before must not be empty")
+			}
+			if s.After == "" {
+				t.Error("After must not be empty")
+			}
+			// Explanation non-empty
+			if s.Explanation == "" {
+				t.Error("Explanation must not be empty")
+			}
+			// Language-appropriate import keyword present in After
+			if !strings.Contains(s.After, tt.wantImport) && !strings.Contains(s.Before, tt.wantImport) {
+				t.Errorf("expected import keyword %q in Before or After;\nBefore:\n%s\nAfter:\n%s",
+					tt.wantImport, s.Before, s.After)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Runtime hints
+// ---------------------------------------------------------------------------
+
+// TestRuntimeHints checks that language-specific runtime version annotations
+// appear when appropriate.
+func TestRuntimeHints(t *testing.T) {
+	t.Run("go ECDH->KEM mentions Go 1.24 only for TLS alg", func(t *testing.T) {
+		// X25519 is a TLS KEM alg — the Go snippet should mention Go 1.24.
+		s := GenerateSnippet("tls.go", "X25519", "key-exchange", "ML-KEM-768")
+		if s == nil {
+			t.Fatal("want snippet, got nil")
+		}
+		if !strings.Contains(s.After, "1.24") {
+			t.Errorf("expected Go 1.24 runtime hint in After for X25519, got:\n%s", s.After)
+		}
+	})
+
+	t.Run("go plain ECDH without TLS primitive omits Go 1.24 hint", func(t *testing.T) {
+		// ECDH with generic "key-agree" primitive — isTLS is false.
+		s := GenerateSnippet("exchange.go", "ECDH", "key-agree", "ML-KEM-768")
+		if s == nil {
+			t.Fatal("want snippet, got nil")
+		}
+		// isTLS check: algUpper != "ECDHE" && algUpper != "X25519",
+		// primitive "key-agree" does not contain "tls" → no Go 1.24 hint.
+		if strings.Contains(s.After, "1.24") {
+			t.Errorf("did not expect Go 1.24 hint for plain ECDH key-agree, got:\n%s", s.After)
+		}
+	})
+
+	t.Run("ECDHE explicitly triggers TLS Go hint", func(t *testing.T) {
+		s := GenerateSnippet("tls.go", "ECDHE", "key-exchange", "ML-KEM-768")
+		if s == nil {
+			t.Fatal("want snippet, got nil")
+		}
+		if !strings.Contains(s.After, "crypto/tls") {
+			t.Errorf("expected crypto/tls hint for ECDHE, got:\n%s", s.After)
+		}
+	})
+
+	t.Run("c sign snippet mentions OpenSSL 3.5", func(t *testing.T) {
+		s := GenerateSnippet("sign.c", "RSA", "signature", "ML-DSA-65")
+		if s == nil {
+			t.Fatal("want snippet, got nil")
+		}
+		if !strings.Contains(s.After, "3.5") {
+			t.Errorf("expected OpenSSL 3.5 hint in C sign After, got:\n%s", s.After)
+		}
+	})
+
+	t.Run("c kem snippet mentions OpenSSL 3.5", func(t *testing.T) {
+		s := GenerateSnippet("exchange.c", "ECDH", "key-exchange", "ML-KEM-768")
+		if s == nil {
+			t.Fatal("want snippet, got nil")
+		}
+		if !strings.Contains(s.After, "3.5") {
+			t.Errorf("expected OpenSSL 3.5 hint in C KEM After, got:\n%s", s.After)
+		}
+	})
+
+	t.Run("swift sign snippet mentions CryptoKit", func(t *testing.T) {
+		s := GenerateSnippet("sign.swift", "RSA", "signature", "ML-DSA-65")
+		if s == nil {
+			t.Fatal("want snippet, got nil")
+		}
+		if !strings.Contains(s.After, "CryptoKit") {
+			t.Errorf("expected CryptoKit mention in Swift sign After, got:\n%s", s.After)
+		}
+	})
+
+	t.Run("js kem snippet mentions Node.js OpenSSL", func(t *testing.T) {
+		s := GenerateSnippet("exchange.js", "ECDH", "key-exchange", "ML-KEM-768")
+		if s == nil {
+			t.Fatal("want snippet, got nil")
+		}
+		if !strings.Contains(s.After, "Node.js") {
+			t.Errorf("expected Node.js hint in JS KEM After, got:\n%s", s.After)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Snippet syntactic sanity (best-effort brace/paren balance)
+// ---------------------------------------------------------------------------
+
+// countRune counts occurrences of r in s.
+func countRune(s string, r rune) int {
+	n := 0
+	for _, c := range s {
+		if c == r {
+			n++
+		}
+	}
+	return n
+}
+
+// TestSnippetSyntaxSanity performs best-effort structural checks on generated
+// snippets: brace balance in Go/Java/C/C++, paren balance in Python.
+func TestSnippetSyntaxSanity(t *testing.T) {
+	type syntaxCase struct {
+		name         string
+		filePath     string
+		classicalAlg string
+		primitive    string
+		targetAlg    string
+		checkBraces  bool // { } balance
+		checkParens  bool // ( ) balance
+	}
+
+	cases := []syntaxCase{
+		{
+			name:         "go sign braces balanced",
+			filePath:     "main.go",
+			classicalAlg: "RSA",
+			primitive:    "signature",
+			targetAlg:    "ML-DSA-65",
+			checkBraces:  true,
+		},
+		{
+			name:         "go kem braces balanced",
+			filePath:     "exchange.go",
+			classicalAlg: "ECDH",
+			primitive:    "key-exchange",
+			targetAlg:    "ML-KEM-768",
+			checkBraces:  true,
+		},
+		{
+			name:         "java sign braces balanced",
+			filePath:     "Crypto.java",
+			classicalAlg: "RSA",
+			primitive:    "signature",
+			targetAlg:    "ML-DSA-65",
+			checkBraces:  true,
+		},
+		{
+			name:         "java kem braces balanced",
+			filePath:     "Crypto.java",
+			classicalAlg: "ECDH",
+			primitive:    "key-agree",
+			targetAlg:    "ML-KEM-768",
+			checkBraces:  true,
+		},
+		{
+			name:         "c sign parens balanced",
+			filePath:     "sign.c",
+			classicalAlg: "RSA",
+			primitive:    "signature",
+			targetAlg:    "ML-DSA-65",
+			checkParens:  true,
+		},
+		{
+			name:         "cpp kem parens balanced",
+			filePath:     "exchange.cpp",
+			classicalAlg: "ECDH",
+			primitive:    "key-exchange",
+			targetAlg:    "ML-KEM-768",
+			checkParens:  true,
+		},
+		{
+			name:         "python sign parens balanced",
+			filePath:     "main.py",
+			classicalAlg: "RSA",
+			primitive:    "signature",
+			targetAlg:    "ML-DSA-65",
+			checkParens:  true,
+		},
+		{
+			name:         "python kem parens balanced",
+			filePath:     "exchange.py",
+			classicalAlg: "ECDH",
+			primitive:    "key-agree",
+			targetAlg:    "ML-KEM-768",
+			checkParens:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := GenerateSnippet(tc.filePath, tc.classicalAlg, tc.primitive, tc.targetAlg)
+			if s == nil {
+				t.Fatal("want non-nil snippet, got nil")
+			}
+
+			if tc.checkBraces {
+				for _, label := range []struct {
+					name string
+					code string
+				}{{"Before", s.Before}, {"After", s.After}} {
+					open := countRune(label.code, '{')
+					close := countRune(label.code, '}')
+					if open != close {
+						t.Errorf("%s: unbalanced braces: %d '{' vs %d '}' in:\n%s",
+							label.name, open, close, label.code)
+					}
+				}
+			}
+
+			if tc.checkParens {
+				for _, label := range []struct {
+					name string
+					code string
+				}{{"Before", s.Before}, {"After", s.After}} {
+					open := countRune(label.code, '(')
+					close := countRune(label.code, ')')
+					if open != close {
+						t.Errorf("%s: unbalanced parens: %d '(' vs %d ')' in:\n%s",
+							label.name, open, close, label.code)
+					}
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Case sensitivity of algorithm names
+// ---------------------------------------------------------------------------
+
+// TestCaseSensitivityAlgorithmNames verifies that the four variants of "rsa"
+// (all lowercase, PascalCase, ALL CAPS, mixed) all produce a valid snippet.
+// The existing TestCaseInsensitiveAlg only covers three variants; we add "rSa".
+func TestCaseSensitivityAlgorithmNames(t *testing.T) {
+	variants := []string{"rsa", "RSA", "Rsa", "rSa"}
+	for _, v := range variants {
+		t.Run("rsa_variant/"+v, func(t *testing.T) {
+			s := GenerateSnippet("main.go", v, "signature", "ML-DSA-65")
+			if s == nil {
+				t.Fatalf("GenerateSnippet(alg=%q) returned nil, want snippet", v)
+			}
+			if s.Language != "go" {
+				t.Errorf("Language: want %q, got %q", "go", s.Language)
+			}
+		})
+	}
+
+	// Repeat for ECDH KEM variants.
+	ecdhVariants := []string{"ecdh", "ECDH", "Ecdh", "eCdH"}
+	for _, v := range ecdhVariants {
+		t.Run("ecdh_variant/"+v, func(t *testing.T) {
+			s := GenerateSnippet("main.go", v, "key-exchange", "ML-KEM-768")
+			if s == nil {
+				t.Fatalf("GenerateSnippet(alg=%q) returned nil, want snippet", v)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Before ≠ After invariant across all languages
+// ---------------------------------------------------------------------------
+
+// TestBeforeNotEqualAfter asserts the before != after invariant for every
+// language using both sign and kem paths, ensuring no copy/paste accidents.
+func TestBeforeNotEqualAfter(t *testing.T) {
+	cases := []struct {
+		filePath     string
+		classicalAlg string
+		primitive    string
+		targetAlg    string
+	}{
+		{"sign.go", "RSA", "signature", "ML-DSA-65"},
+		{"exchange.go", "ECDH", "key-exchange", "ML-KEM-768"},
+		{"sign.py", "RSA", "signature", "ML-DSA-65"},
+		{"exchange.py", "ECDH", "key-agree", "ML-KEM-768"},
+		{"Signer.java", "RSA", "signature", "ML-DSA-65"},
+		{"Exchange.java", "ECDH", "key-agree", "ML-KEM-768"},
+		{"sign.rs", "RSA", "signature", "ML-DSA-65"},
+		{"exchange.rs", "ECDH", "key-exchange", "ML-KEM-768"},
+		{"sign.js", "RSA", "signature", "ML-DSA-65"},
+		{"exchange.ts", "ECDH", "key-exchange", "ML-KEM-768"},
+		{"sign.c", "RSA", "signature", "ML-DSA-65"},
+		{"exchange.cpp", "ECDH", "key-exchange", "ML-KEM-768"},
+		{"Signer.cs", "RSA", "signature", "ML-DSA-65"},
+		{"sign.swift", "RSA", "signature", "ML-DSA-65"},
+		{"nginx.conf", "RSA", "signature", "ML-DSA-65"},
+		{"haproxy.cfg", "ECDH", "key-exchange", "ML-KEM-768"},
+	}
+
+	for _, tc := range cases {
+		name := tc.filePath + "/" + tc.classicalAlg
+		t.Run(name, func(t *testing.T) {
+			s := GenerateSnippet(tc.filePath, tc.classicalAlg, tc.primitive, tc.targetAlg)
+			if s == nil {
+				t.Fatal("want non-nil snippet, got nil")
+			}
+			if s.Before == s.After {
+				t.Errorf("Before == After (identical snippet) for %s", name)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Target algorithm reflected in snippet
+// ---------------------------------------------------------------------------
+
+// TestTargetAlgorithmInSnippet verifies that the target PQC algorithm name
+// (e.g. "ML-DSA-44") appears somewhere in the generated After text so callers
+// can confirm the right algorithm is referenced.
+func TestTargetAlgorithmInSnippet(t *testing.T) {
+	targets := []struct {
+		classicalAlg string
+		primitive    string
+		targetAlg    string
+		wantInAfter  string // exact fragment we expect
+	}{
+		{"RSA", "signature", "ML-DSA-44", "ML-DSA-44"},
+		{"RSA", "signature", "ML-DSA-65", "ML-DSA-65"},
+		{"RSA", "signature", "ML-DSA-87", "ML-DSA-87"},
+		{"ECDH", "key-exchange", "ML-KEM-768", "ML-KEM-768"},
+	}
+
+	langs := []string{".go", ".py", ".java", ".rs", ".js", ".ts", ".c", ".cpp", ".cs", ".swift"}
+
+	for _, tgt := range targets {
+		for _, ext := range langs {
+			name := tgt.classicalAlg + "_" + tgt.targetAlg + ext
+			t.Run(name, func(t *testing.T) {
+				s := GenerateSnippet("file"+ext, tgt.classicalAlg, tgt.primitive, tgt.targetAlg)
+				if s == nil {
+					// Swift KEM is not covered by the sign path when classicalAlg is "ECDH";
+					// skip gracefully and note below.
+					t.Skipf("GenerateSnippet returned nil for %s (coverage gap)", name)
+				}
+				// Target should appear in either After or Explanation.
+				combined := s.After + s.Explanation
+				if !strings.Contains(combined, tgt.wantInAfter) {
+					t.Errorf("target %q not found in After+Explanation:\nAfter:\n%s\nExplanation: %s",
+						tgt.wantInAfter, s.After, s.Explanation)
+				}
+			})
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Snippet UTF-8 validity
+// ---------------------------------------------------------------------------
+
+// TestSnippetUTF8 ensures all snippet string fields contain only valid UTF-8,
+// guarding against garbled encoding in template strings.
+func TestSnippetUTF8(t *testing.T) {
+	cases := []struct {
+		filePath     string
+		classicalAlg string
+		primitive    string
+		targetAlg    string
+	}{
+		{"sign.go", "RSA", "signature", "ML-DSA-65"},
+		{"sign.py", "ECDSA", "signature", "ML-DSA-44"},
+		{"Signer.java", "ECDH", "key-agree", "ML-KEM-768"},
+		{"sign.swift", "RSA", "signature", "ML-DSA-65"},
+		{"nginx.conf", "ECDH", "key-exchange", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.filePath, func(t *testing.T) {
+			s := GenerateSnippet(tc.filePath, tc.classicalAlg, tc.primitive, tc.targetAlg)
+			if s == nil {
+				t.Fatal("want non-nil snippet, got nil")
+			}
+			for field, val := range map[string]string{
+				"Language":    s.Language,
+				"Before":      s.Before,
+				"After":       s.After,
+				"Explanation": s.Explanation,
+			} {
+				if !utf8.ValidString(val) {
+					t.Errorf("%s contains invalid UTF-8", field)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// isSafePQC edge cases
+// ---------------------------------------------------------------------------
+
+// TestIsSafePQC_EdgeCases checks boundary values for isSafePQC, including
+// bare prefix names (no hyphen) and mixed-case inputs.
+func TestIsSafePQC_EdgeCases(t *testing.T) {
+	safe := []string{
+		"ML-DSA", "ml-dsa", "ML-DSA-44", "ML-DSA-65", "ML-DSA-87",
+		"ML-KEM", "ML-KEM-512", "ML-KEM-768", "ML-KEM-1024",
+		"SLH-DSA", "SLH-DSA-SHA2-128f",
+		"DILITHIUM", "DILITHIUM-2", "DILITHIUM-3",
+		"KYBER", "KYBER-512", "KYBER-768", "KYBER-1024",
+		"XMSS", "XMSS-SHA2-10-256",
+		"LMS",
+		"SPHINCS+",
+		"HQC", "HQC-128",
+	}
+	notSafe := []string{
+		"RSA", "ECDSA", "ECDH", "X25519", "AES", "SHA-256", "",
+	}
+
+	for _, alg := range safe {
+		t.Run("safe/"+alg, func(t *testing.T) {
+			if !isSafePQC(alg) {
+				t.Errorf("isSafePQC(%q) = false, want true", alg)
+			}
+		})
+	}
+	for _, alg := range notSafe {
+		t.Run("unsafe/"+alg, func(t *testing.T) {
+			if isSafePQC(alg) {
+				t.Errorf("isSafePQC(%q) = true, want false", alg)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// pqcStandard label
+// ---------------------------------------------------------------------------
+
+// TestPQCStandard verifies that pqcStandard returns the correct FIPS label.
+func TestPQCStandard(t *testing.T) {
+	tests := []struct {
+		alg  string
+		want string
+	}{
+		{"ML-DSA-44", "FIPS 204"},
+		{"ML-DSA-65", "FIPS 204"},
+		{"ML-DSA-87", "FIPS 204"},
+		{"SLH-DSA-SHA2-128f", "FIPS 204"},
+		{"ML-KEM-512", "FIPS 203"},
+		{"ML-KEM-768", "FIPS 203"},
+		{"ML-KEM-1024", "FIPS 203"},
+		// Unknown algorithm returns empty string.
+		{"RSA", ""},
+		{"", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.alg, func(t *testing.T) {
+			got := pqcStandard(tc.alg)
+			if got != tc.want {
+				t.Errorf("pqcStandard(%q) = %q, want %q", tc.alg, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Nil-safety for unrecognised file extensions
+// ---------------------------------------------------------------------------
+
+// TestUnrecognisedExtensions ensures a broad set of unrecognised extensions
+// returns nil without panicking.
+func TestUnrecognisedExtensions(t *testing.T) {
+	extensions := []string{
+		".kt", ".rb", ".php", ".sh", ".bash", ".zsh", ".fish",
+		".lock", ".sum", ".mod", ".bazel", ".gradle", ".tf",
+		".lua", ".ex", ".exs", ".elm", ".clj", ".hs", ".ml",
+	}
+
+	for _, ext := range extensions {
+		t.Run(ext, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("GenerateSnippet panicked for extension %s: %v", ext, r)
+				}
+			}()
+			s := GenerateSnippet("file"+ext, "RSA", "signature", "ML-DSA-65")
+			if s != nil {
+				t.Errorf("want nil for extension %s, got Language=%q", ext, s.Language)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Config snippet: no nil for any recognised config extension
+// ---------------------------------------------------------------------------
+
+// TestConfigExtensionsKEMPath complements the existing TestConfigExtensions
+// (sign path only) by exercising the KEM family path for every config
+// extension, verifying no extension returns nil.
+func TestConfigExtensionsKEMPath(t *testing.T) {
+	extensions := []string{
+		".yml", ".yaml", ".conf", ".nginx", ".cnf", ".cfg",
+		".properties", ".toml", ".json", ".xml", ".ini", ".hcl", ".env",
+	}
+
+	for _, ext := range extensions {
+		t.Run(ext, func(t *testing.T) {
+			s := GenerateSnippet("server"+ext, "ECDH", "key-exchange", "ML-KEM-768")
+			if s == nil {
+				t.Fatalf("GenerateSnippet(%q, ECDH, key-exchange) returned nil, want config snippet", ext)
+			}
+			if s.Language != "config" {
+				t.Errorf("Language: want %q, got %q", "config", s.Language)
+			}
+			if !strings.Contains(s.After, "X25519MLKEM768") {
+				t.Errorf("After does not mention X25519MLKEM768:\n%s", s.After)
+			}
+		})
+	}
+}

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -162,7 +162,14 @@ func langFromExt(ext string) string {
 func GenerateSnippet(filePath, classicalAlg, primitive, targetAlg string) *Snippet {
 	lang := langFromExt(strings.ToLower(filepath.Ext(filePath)))
 	if lang == "" {
-		return nil
+		// Extensionless server config files are common on Debian/Ubuntu
+		// (e.g. /etc/nginx/sites-available/default, /etc/haproxy/haproxy).
+		// Detect them by path so configSnippet can still run.
+		if isExtensionlessConfigPath(filePath) {
+			lang = "config"
+		} else {
+			return nil
+		}
 	}
 
 	// Bail out immediately for PQC-safe algorithms — no migration needed.
@@ -504,6 +511,22 @@ func configServerType(filePath string) string {
 	}
 }
 
+// isExtensionlessConfigPath reports whether filePath looks like a server
+// configuration file even though it has no file extension (e.g.
+// /etc/nginx/sites-available/default).
+func isExtensionlessConfigPath(filePath string) bool {
+	if filepath.Ext(filePath) != "" {
+		return false
+	}
+	lower := strings.ToLower(filepath.ToSlash(filePath))
+	for _, marker := range []string{"/nginx/", "/apache/", "/apache2/", "/httpd/", "/haproxy/"} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
+
 // configSnippet generates a server-specific PQC migration snippet for config
 // files. The filePath is used to detect whether the target is nginx, Apache,
 // or HAProxy; all other paths default to nginx-style directives.
@@ -533,7 +556,22 @@ SSLCertificateKeyFile /etc/ssl/private/server-mldsa.key
 				Explanation: "Replace RSA/ECDSA TLS certificate with an ML-DSA-65 certificate (FIPS 204).",
 			}
 
-		default: // nginx and haproxy fall back to nginx-style for signing
+		case "haproxy":
+			before := `# Classical RSA certificate bundle (cert + key in one file per HAProxy convention)
+bind *:443 ssl crt /etc/haproxy/certs/server-rsa.pem`
+
+			after := `# Replace with ML-DSA certificate bundle
+bind *:443 ssl crt /etc/haproxy/certs/server-mldsa.pem
+# Generate with: openssl genpkey -algorithm ML-DSA-65`
+
+			return &Snippet{
+				Language:    "config",
+				Before:      before,
+				After:       after,
+				Explanation: "Replace RSA/ECDSA TLS certificate with an ML-DSA-65 certificate (FIPS 204) in the HAProxy bind directive.",
+			}
+
+		default: // nginx
 			before := `# Certificate key type (classical RSA)
 ssl_certificate     /etc/ssl/certs/server-rsa.crt;
 ssl_certificate_key /etc/ssl/private/server-rsa.key;`

--- a/pkg/orchestrator/new_pipeline_test.go
+++ b/pkg/orchestrator/new_pipeline_test.go
@@ -1,0 +1,456 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/engines"
+	"github.com/jimbo111/open-quantum-secure/pkg/findings"
+)
+
+// ---------------------------------------------------------------------------
+// Additional mock engine types for error/panic/timeout scenarios
+// ---------------------------------------------------------------------------
+
+// errorEngine returns a hard error from Scan.
+type errorEngine struct {
+	name string
+	tier engines.Tier
+}
+
+func (e *errorEngine) Name() string               { return e.name }
+func (e *errorEngine) Tier() engines.Tier         { return e.tier }
+func (e *errorEngine) SupportedLanguages() []string { return []string{"go"} }
+func (e *errorEngine) Available() bool             { return true }
+func (e *errorEngine) Version() string             { return "err-mock" }
+func (e *errorEngine) Scan(_ context.Context, _ engines.ScanOptions) ([]findings.UnifiedFinding, error) {
+	return nil, fmt.Errorf("engine %s: simulated hard failure", e.name)
+}
+
+// panicEngine panics inside Scan.
+type panicEngine struct {
+	name string
+}
+
+func (p *panicEngine) Name() string               { return p.name }
+func (p *panicEngine) Tier() engines.Tier         { return engines.Tier1Pattern }
+func (p *panicEngine) SupportedLanguages() []string { return []string{"go"} }
+func (p *panicEngine) Available() bool             { return true }
+func (p *panicEngine) Version() string             { return "panic-mock" }
+func (p *panicEngine) Scan(_ context.Context, _ engines.ScanOptions) ([]findings.UnifiedFinding, error) {
+	panic("intentional panic for testing")
+}
+
+// slowEngine sleeps until ctx is done or sleepFor elapses.
+type slowEngine struct {
+	name      string
+	sleepFor  time.Duration
+	results   []findings.UnifiedFinding
+}
+
+func (s *slowEngine) Name() string               { return s.name }
+func (s *slowEngine) Tier() engines.Tier         { return engines.Tier1Pattern }
+func (s *slowEngine) SupportedLanguages() []string { return []string{"go"} }
+func (s *slowEngine) Available() bool             { return true }
+func (s *slowEngine) Version() string             { return "slow-mock" }
+func (s *slowEngine) Scan(ctx context.Context, _ engines.ScanOptions) ([]findings.UnifiedFinding, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(s.sleepFor):
+		return s.results, nil
+	}
+}
+
+// networkMockEngine pretends to be a Tier5Network engine.
+type networkMockEngine struct {
+	name    string
+	results []findings.UnifiedFinding
+	scanErr error
+}
+
+func (n *networkMockEngine) Name() string               { return n.name }
+func (n *networkMockEngine) Tier() engines.Tier         { return engines.Tier5Network }
+func (n *networkMockEngine) SupportedLanguages() []string { return nil }
+func (n *networkMockEngine) Available() bool             { return true }
+func (n *networkMockEngine) Version() string             { return "net-mock" }
+func (n *networkMockEngine) Scan(_ context.Context, _ engines.ScanOptions) ([]findings.UnifiedFinding, error) {
+	return n.results, n.scanErr
+}
+
+// unavailableEngine is always unavailable.
+type unavailableEngine struct{ name string }
+
+func (u *unavailableEngine) Name() string               { return u.name }
+func (u *unavailableEngine) Tier() engines.Tier         { return engines.Tier1Pattern }
+func (u *unavailableEngine) SupportedLanguages() []string { return []string{"go"} }
+func (u *unavailableEngine) Available() bool             { return false }
+func (u *unavailableEngine) Version() string             { return "unavail" }
+func (u *unavailableEngine) Scan(_ context.Context, _ engines.ScanOptions) ([]findings.UnifiedFinding, error) {
+	return nil, nil
+}
+
+// countingEngine records how many times Scan is called.
+type countingEngine struct {
+	name    string
+	calls   atomic.Int32
+	results []findings.UnifiedFinding
+}
+
+func (c *countingEngine) Name() string               { return c.name }
+func (c *countingEngine) Tier() engines.Tier         { return engines.Tier1Pattern }
+func (c *countingEngine) SupportedLanguages() []string { return []string{"go"} }
+func (c *countingEngine) Available() bool             { return true }
+func (c *countingEngine) Version() string             { return "count-mock" }
+func (c *countingEngine) Scan(_ context.Context, _ engines.ScanOptions) ([]findings.UnifiedFinding, error) {
+	c.calls.Add(1)
+	return c.results, nil
+}
+
+// ---------------------------------------------------------------------------
+// 1. Engine error → scan continues with remaining engines
+// ---------------------------------------------------------------------------
+
+// TestScan_OneEngineErrors_OtherEnginesContinue verifies that when one engine
+// returns an error, the orchestrator still returns findings from the engines
+// that succeeded (partial result, no hard failure).
+func TestScan_OneEngineErrors_OtherEnginesContinue(t *testing.T) {
+	ctx := context.Background()
+
+	goodEng := &mockEngine{
+		name:      "good-engine",
+		tier:      engines.Tier1Pattern,
+		available: true,
+		results: []findings.UnifiedFinding{
+			{Location: loc("/repo/main.go", 10), Algorithm: alg("AES-256-GCM", "ae", 256), SourceEngine: "good-engine"},
+		},
+	}
+	badEng := &errorEngine{name: "bad-engine", tier: engines.Tier1Pattern}
+
+	orch := New(goodEng, badEng)
+	results, err := orch.Scan(ctx, engines.ScanOptions{Mode: engines.ModeFull})
+
+	// With one good engine producing results, Scan must NOT return an error.
+	if err != nil {
+		t.Fatalf("Scan() must not error when at least one engine succeeds, got: %v", err)
+	}
+	if len(results) == 0 {
+		t.Error("expected at least 1 finding from the good engine")
+	}
+}
+
+// TestScan_AllEnginesFail_ReturnsError verifies that when every engine fails
+// and no findings are collected, Scan returns a non-nil error.
+func TestScan_AllEnginesFail_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	bad1 := &errorEngine{name: "fail-1", tier: engines.Tier1Pattern}
+	bad2 := &errorEngine{name: "fail-2", tier: engines.Tier1Pattern}
+
+	orch := New(bad1, bad2)
+	_, err := orch.Scan(ctx, engines.ScanOptions{Mode: engines.ModeFull})
+	if err == nil {
+		t.Error("Scan() must return error when all engines fail with no findings")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. Engine panics → scan continues (recover in goroutine)
+// ---------------------------------------------------------------------------
+
+// TestScan_PanicEngine_DoesNotCrashOrchestrator verifies that a panicking
+// engine is caught by the deferred recover inside the goroutine and does NOT
+// bring down the entire scan process. Other engines' results are preserved.
+func TestScan_PanicEngine_DoesNotCrashOrchestrator(t *testing.T) {
+	ctx := context.Background()
+
+	panicEng := &panicEngine{name: "panicker"}
+	goodEng := &mockEngine{
+		name:      "good-after-panic",
+		tier:      engines.Tier1Pattern,
+		available: true,
+		results: []findings.UnifiedFinding{
+			{Location: loc("/repo/safe.go", 5), Algorithm: alg("RSA-2048", "pke", 2048), SourceEngine: "good-after-panic"},
+		},
+	}
+
+	orch := New(panicEng, goodEng)
+
+	// Must not panic at the test level.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Scan() leaked panic to caller: %v", r)
+		}
+	}()
+
+	results, _ := orch.Scan(ctx, engines.ScanOptions{Mode: engines.ModeFull})
+	// The good engine's findings must be present even though the other panicked.
+	if len(results) == 0 {
+		t.Error("expected findings from good engine to survive the panic in the sibling engine")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3. Context cancellation / timeout
+// ---------------------------------------------------------------------------
+
+// TestScan_ContextCancelled_ReturnsCancelError verifies that when the context
+// is cancelled before Scan completes, the pipeline returns a context error and
+// not a generic "all engines failed" message.
+func TestScan_ContextCancelled_ReturnsCancelError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel immediately so the slow engine can't finish.
+	cancel()
+
+	slowEng := &slowEngine{
+		name:     "slow-timeout",
+		sleepFor: 5 * time.Second,
+	}
+
+	orch := New(slowEng)
+	_, err := orch.Scan(ctx, engines.ScanOptions{Mode: engines.ModeFull})
+	if err == nil {
+		t.Fatal("expected error when context is cancelled")
+	}
+	if ctx.Err() == nil {
+		t.Error("context should be in cancelled state")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 4. No engines available → error
+// ---------------------------------------------------------------------------
+
+// TestScan_NoAvailableEngines_ReturnsError verifies that an orchestrator with
+// only unavailable engines returns an error rather than empty results.
+func TestScan_NoAvailableEngines_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	unavail := &unavailableEngine{name: "ghost-engine"}
+
+	orch := New(unavail)
+	_, err := orch.Scan(ctx, engines.ScanOptions{Mode: engines.ModeFull})
+	if err == nil {
+		t.Error("Scan() with no available engines must return an error")
+	}
+}
+
+// TestScan_EmptyEngineList_ReturnsError verifies that an orchestrator with
+// zero registered engines returns an error.
+func TestScan_EmptyEngineList_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	orch := New() // zero engines
+	_, err := orch.Scan(ctx, engines.ScanOptions{Mode: engines.ModeFull})
+	if err == nil {
+		t.Error("Scan() with empty engine list must return an error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 5. Tier5Network gating on TLSTargets empty
+// ---------------------------------------------------------------------------
+
+// TestEffectiveEngines_Tier5Network_SkippedWithNoTLSTargets verifies that a
+// Tier5Network engine is NOT included in EffectiveEngines when TLSTargets is
+// empty — it must be self-gated.
+func TestEffectiveEngines_Tier5Network_SkippedWithNoTLSTargets(t *testing.T) {
+	netEng := &networkMockEngine{name: "tls-probe"}
+	srcEng := &mockEngine{name: "src-engine", tier: engines.Tier1Pattern, available: true}
+
+	orch := New(netEng, srcEng)
+	opts := engines.ScanOptions{Mode: engines.ModeFull} // TLSTargets empty
+	effective := orch.EffectiveEngines(opts)
+
+	for _, e := range effective {
+		if e.Tier() == engines.Tier5Network {
+			t.Errorf("Tier5Network engine %q must not be in EffectiveEngines when TLSTargets is empty", e.Name())
+		}
+	}
+}
+
+// TestEffectiveEngines_Tier5Network_IncludedWithTLSTargets verifies that a
+// Tier5Network engine IS included in EffectiveEngines when TLSTargets is set,
+// even in diff mode (which normally restricts to Tier 1).
+func TestEffectiveEngines_Tier5Network_IncludedWithTLSTargets(t *testing.T) {
+	netEng := &networkMockEngine{name: "tls-probe"}
+	srcEng := &mockEngine{name: "src-engine", tier: engines.Tier1Pattern, available: true}
+
+	orch := New(netEng, srcEng)
+	opts := engines.ScanOptions{
+		Mode:       engines.ModeDiff,
+		TLSTargets: []string{"example.com:443"},
+	}
+	effective := orch.EffectiveEngines(opts)
+
+	found := false
+	for _, e := range effective {
+		if e.Tier() == engines.Tier5Network {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("Tier5Network engine must be in EffectiveEngines when TLSTargets is non-empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 6. Network engine findings in diff-mode filtering
+// ---------------------------------------------------------------------------
+
+// TestScan_DiffMode_TLSProbeFindings_NotFiltered verifies the fix from
+// commit 4253de8: TLS probe findings with synthetic paths (starting with "(")
+// must pass through the diff-mode changed-file filter unchanged.
+func TestScan_DiffMode_TLSProbeFindings_NotFiltered(t *testing.T) {
+	ctx := context.Background()
+
+	netEng := &networkMockEngine{
+		name: "tls-probe",
+		results: []findings.UnifiedFinding{
+			{
+				Location:     findings.Location{File: "(tls-probe)/example.com:443#kex", Line: 0},
+				Algorithm:    &findings.Algorithm{Name: "RSA", Primitive: "key-exchange"},
+				SourceEngine: "tls-probe",
+			},
+		},
+	}
+	// Source engine also reports something on a non-changed file.
+	srcEng := &mockEngine{
+		name:      "src-engine",
+		tier:      engines.Tier1Pattern,
+		available: true,
+		results: []findings.UnifiedFinding{
+			{
+				Location:     findings.Location{File: "/repo/unchanged.go", Line: 1},
+				Algorithm:    &findings.Algorithm{Name: "AES-128"},
+				SourceEngine: "src-engine",
+			},
+		},
+	}
+
+	orch := New(srcEng, netEng)
+	opts := engines.ScanOptions{
+		Mode:         engines.ModeDiff,
+		TargetPath:   "/repo",
+		ChangedFiles: []string{"changed.go"}, // unchanged.go not in changed list
+		TLSTargets:   []string{"example.com:443"},
+	}
+	results, err := orch.Scan(ctx, opts)
+	if err != nil {
+		t.Fatalf("Scan() diff mode with TLS targets returned error: %v", err)
+	}
+
+	// TLS probe finding must survive diff filtering (synthetic path).
+	tlsFound := false
+	for _, f := range results {
+		if f.SourceEngine == "tls-probe" {
+			tlsFound = true
+		}
+	}
+	if !tlsFound {
+		t.Error("TLS probe finding must NOT be filtered out in diff mode (synthetic path fix from 4253de8)")
+	}
+	// Source finding for unchanged.go must be filtered out.
+	for _, f := range results {
+		if f.Location.File == "/repo/unchanged.go" {
+			t.Error("source finding for unchanged.go must be filtered out in diff mode")
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 7. Parallel safety (race detector)
+// ---------------------------------------------------------------------------
+
+// TestScan_ParallelSafety_RaceDetector runs multiple concurrent Scan calls on
+// the same Orchestrator. Regression: engines that cache and re-return the same
+// result slice used to expose a data race because scanPipeline mutated the
+// engine-owned Algorithm pointer in normalizeFindings. scanPipeline now clones
+// each finding before post-processing, so concurrent Scans are race-free.
+// Run with -race to verify.
+func TestScan_ParallelSafety_RaceDetector(t *testing.T) {
+	ctx := context.Background()
+
+	engs := make([]engines.Engine, 5)
+	for i := range engs {
+		engs[i] = &countingEngine{
+			name: fmt.Sprintf("parallel-eng-%d", i),
+			results: []findings.UnifiedFinding{
+				{
+					Location:     loc(fmt.Sprintf("/file%d.go", i), i+1),
+					Algorithm:    alg("AES-256-GCM", "ae", 256),
+					SourceEngine: fmt.Sprintf("parallel-eng-%d", i),
+				},
+			},
+		}
+	}
+
+	orch := New(engs...)
+	opts := engines.ScanOptions{Mode: engines.ModeFull}
+
+	const goroutines = 10
+	errCh := make(chan error, goroutines)
+
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			_, err := orch.Scan(ctx, opts)
+			errCh <- err
+		}()
+	}
+
+	for g := 0; g < goroutines; g++ {
+		if err := <-errCh; err != nil {
+			t.Errorf("concurrent Scan() error: %v", err)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 8. AvailableEngines filtering
+// ---------------------------------------------------------------------------
+
+// TestAvailableEngines_FiltersByAvailability verifies that AvailableEngines
+// returns only engines whose Available() method returns true.
+func TestAvailableEngines_FiltersByAvailability(t *testing.T) {
+	avail := &mockEngine{name: "avail", tier: engines.Tier1Pattern, available: true}
+	unavail := &unavailableEngine{name: "unavail"}
+
+	orch := New(avail, unavail)
+	got := orch.AvailableEngines()
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 available engine, got %d", len(got))
+	}
+	if got[0].Name() != "avail" {
+		t.Errorf("wrong engine returned: %q, want avail", got[0].Name())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 9. SelectedEngines name filter
+// ---------------------------------------------------------------------------
+
+// TestSelectedEngines_NameFilter verifies that SelectedEngines filters by
+// explicit engine names and ignores engines not in the name list.
+func TestSelectedEngines_NameFilter(t *testing.T) {
+	eng1 := &mockEngine{name: "scanner-a", tier: engines.Tier1Pattern, available: true}
+	eng2 := &mockEngine{name: "scanner-b", tier: engines.Tier1Pattern, available: true}
+	eng3 := &mockEngine{name: "scanner-c", tier: engines.Tier1Pattern, available: true}
+
+	orch := New(eng1, eng2, eng3)
+	got := orch.SelectedEngines([]string{"scanner-a", "scanner-c"})
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 engines after name filter, got %d", len(got))
+	}
+	names := make(map[string]bool)
+	for _, e := range got {
+		names[e.Name()] = true
+	}
+	if !names["scanner-a"] || !names["scanner-c"] {
+		t.Errorf("wrong engines returned: %v", names)
+	}
+	if names["scanner-b"] {
+		t.Error("scanner-b should have been filtered out")
+	}
+}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -553,9 +553,14 @@ func (o *Orchestrator) scanPipeline(ctx context.Context, opts engines.ScanOption
 			return nil, nil, metrics, fmt.Errorf("scan aborted: %w", ctx.Err())
 		}
 
-		// Merge in engine order to keep output deterministic.
+		// Merge in engine order to keep output deterministic. Clone each finding
+		// so subsequent in-place pipeline stages (normalizeFindings, classify,
+		// migration snippets) don't mutate engine-owned state — concurrent Scan
+		// calls on the same Orchestrator would otherwise race on Algorithm.Name.
 		for _, er := range perEngine {
-			allFindings = append(allFindings, er.results...)
+			for i := range er.results {
+				allFindings = append(allFindings, er.results[i].Clone())
+			}
 		}
 
 		if len(errs) > 0 && len(allFindings) == 0 {
@@ -588,7 +593,9 @@ func (o *Orchestrator) scanPipeline(ctx context.Context, opts engines.ScanOption
 			networkErrs = append(networkErrs, fmt.Errorf("%s: %w", eng.Name(), err))
 		}
 		metrics.Engines = append(metrics.Engines, em)
-		allFindings = append(allFindings, res...)
+		for i := range res {
+			allFindings = append(allFindings, res[i].Clone())
+		}
 	}
 	// Propagate network engine errors when all network engines failed and
 	// produced no findings (prevents silent pass in CI when TLS targets

--- a/pkg/output/format_edge_cases_test.go
+++ b/pkg/output/format_edge_cases_test.go
@@ -1,0 +1,514 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/findings"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func emptyResult() ScanResult {
+	return BuildResult("1.0.0", "/scan/target", []string{"cipherscope"}, nil)
+}
+
+func findingWithAlg(name, file string, line int) findings.UnifiedFinding {
+	return findings.UnifiedFinding{
+		Location:     findings.Location{File: file, Line: line},
+		Algorithm:    &findings.Algorithm{Name: name, Primitive: "asymmetric"},
+		Confidence:   findings.ConfidenceHigh,
+		SourceEngine: "cipherscope",
+		QuantumRisk:  findings.QRVulnerable,
+		Severity:     findings.SevHigh,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// JSON edge cases
+// ---------------------------------------------------------------------------
+
+// TestWriteJSON_EmptyFindings_ValidDocument ensures an empty scan produces valid
+// JSON with "findings":[] (not null) and all required top-level keys.
+func TestWriteJSON_EmptyFindings_ValidDocument(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, emptyResult()); err != nil {
+		t.Fatalf("WriteJSON error: %v", err)
+	}
+	var doc map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("not valid JSON: %v", err)
+	}
+	for _, key := range []string{"version", "target", "engines", "summary", "findings", "quantumReadinessScore"} {
+		if _, ok := doc[key]; !ok {
+			t.Errorf("missing required key %q in empty scan JSON", key)
+		}
+	}
+	// "findings" must be [] not null
+	raw := buf.String()
+	if strings.Contains(raw, `"findings":null`) {
+		t.Error(`"findings" marshalled as null instead of []`)
+	}
+}
+
+// TestWriteJSON_SpecialCharsInFilePath verifies that control characters
+// (newline, tab) inside file paths are properly JSON-escaped and that the
+// document remains valid.
+func TestWriteJSON_SpecialCharsInFilePath(t *testing.T) {
+	paths := []struct {
+		name string
+		path string
+	}{
+		{"newline in path", "/src/file\nwith-newline.go"},
+		{"tab in path", "/src/file\twith-tab.go"},
+		{"unicode path", "/src/文件/crypto.go"},
+		{"quote in path", `/src/file"with"quotes.go`},
+	}
+	for _, tc := range paths {
+		t.Run(tc.name, func(t *testing.T) {
+			ff := []findings.UnifiedFinding{findingWithAlg("RSA-2048", tc.path, 1)}
+			result := BuildResult("1.0.0", "/src", []string{"cs"}, ff)
+			var buf bytes.Buffer
+			if err := WriteJSON(&buf, result); err != nil {
+				t.Fatalf("WriteJSON error: %v", err)
+			}
+			var doc map[string]interface{}
+			if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+				t.Fatalf("invalid JSON for path %q: %v", tc.path, err)
+			}
+		})
+	}
+}
+
+// TestWriteJSON_NilEnginesField verifies that a nil engines slice marshals as
+// [] and not null (defensive: BuildResult ensures non-nil engines via callers).
+func TestWriteJSON_NilVsEmptySliceConsistency(t *testing.T) {
+	// nil findings → BuildResult normalises to []
+	r1 := BuildResult("1.0.0", "/t", []string{"cs"}, nil)
+	// explicit empty slice
+	r2 := BuildResult("1.0.0", "/t", []string{"cs"}, []findings.UnifiedFinding{})
+
+	var b1, b2 bytes.Buffer
+	_ = WriteJSON(&b1, r1)
+	_ = WriteJSON(&b2, r2)
+
+	var d1, d2 map[string]interface{}
+	json.Unmarshal(b1.Bytes(), &d1) //nolint:errcheck
+	json.Unmarshal(b2.Bytes(), &d2) //nolint:errcheck
+
+	// Both should produce the same findings array length (0)
+	arr1 := d1["findings"].([]interface{})
+	arr2 := d2["findings"].([]interface{})
+	if len(arr1) != 0 || len(arr2) != 0 {
+		t.Errorf("nil/empty findings should both produce empty array; got lens %d, %d", len(arr1), len(arr2))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SARIF 2.1.0 edge cases
+// ---------------------------------------------------------------------------
+
+// TestWriteSARIF_EmptyFindings_ValidSchema verifies that empty findings produce
+// a valid SARIF 2.1.0 document with required fields: $schema, version, runs[],
+// runs[0].tool.driver.name, and runs[0].results[].
+func TestWriteSARIF_EmptyFindings_ValidSchema(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteSARIF(&buf, emptyResult()); err != nil {
+		t.Fatalf("WriteSARIF error: %v", err)
+	}
+
+	var doc map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("not valid JSON: %v", err)
+	}
+
+	if doc["$schema"] == nil {
+		t.Error("SARIF missing $schema")
+	}
+	if doc["version"] != "2.1.0" {
+		t.Errorf("SARIF version = %v, want 2.1.0", doc["version"])
+	}
+	runs, ok := doc["runs"].([]interface{})
+	if !ok || len(runs) == 0 {
+		t.Fatal("SARIF runs array missing or empty")
+	}
+	run := runs[0].(map[string]interface{})
+	tool := run["tool"].(map[string]interface{})
+	driver := tool["driver"].(map[string]interface{})
+	if driver["name"] != "oqs-scanner" {
+		t.Errorf("tool.driver.name = %v, want oqs-scanner", driver["name"])
+	}
+	// results must be present (as empty array) even with no findings
+	if _, ok := run["results"]; !ok {
+		t.Error("SARIF run missing 'results' key")
+	}
+}
+
+// TestWriteSARIF_RequiredFields verifies that each result carries ruleId,
+// level, message.text, and locations[].
+func TestWriteSARIF_RequiredFields(t *testing.T) {
+	ff := []findings.UnifiedFinding{findingWithAlg("RSA-2048", "/src/auth.go", 10)}
+	result := BuildResult("1.0.0", "/src", []string{"cs"}, ff)
+
+	var buf bytes.Buffer
+	if err := WriteSARIF(&buf, result); err != nil {
+		t.Fatalf("WriteSARIF error: %v", err)
+	}
+
+	var doc map[string]interface{}
+	json.Unmarshal(buf.Bytes(), &doc) //nolint:errcheck
+	run := doc["runs"].([]interface{})[0].(map[string]interface{})
+	results := run["results"].([]interface{})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0].(map[string]interface{})
+	if r["ruleId"] == nil || r["ruleId"] == "" {
+		t.Error("result.ruleId missing")
+	}
+	if r["level"] == nil {
+		t.Error("result.level missing")
+	}
+	msg := r["message"].(map[string]interface{})
+	if msg["text"] == nil || msg["text"] == "" {
+		t.Error("result.message.text missing")
+	}
+	locs := r["locations"].([]interface{})
+	if len(locs) == 0 {
+		t.Error("result.locations must be non-empty")
+	}
+}
+
+// TestWriteSARIF_RulesArray verifies the rules array is present in driver and
+// populated when there are findings.
+func TestWriteSARIF_RulesArray(t *testing.T) {
+	ff := []findings.UnifiedFinding{
+		findingWithAlg("RSA-2048", "/src/a.go", 1),
+		findingWithAlg("AES-128", "/src/b.go", 2),
+	}
+	result := BuildResult("1.0.0", "/src", []string{"cs"}, ff)
+
+	var buf bytes.Buffer
+	WriteSARIF(&buf, result) //nolint:errcheck
+	var doc map[string]interface{}
+	json.Unmarshal(buf.Bytes(), &doc) //nolint:errcheck
+
+	run := doc["runs"].([]interface{})[0].(map[string]interface{})
+	driver := run["tool"].(map[string]interface{})["driver"].(map[string]interface{})
+	rules, ok := driver["rules"].([]interface{})
+	if !ok || len(rules) == 0 {
+		t.Error("tool.driver.rules must be non-empty when findings present")
+	}
+	// Each rule needs an id
+	for i, rRaw := range rules {
+		r := rRaw.(map[string]interface{})
+		if r["id"] == nil || r["id"] == "" {
+			t.Errorf("rules[%d].id missing", i)
+		}
+	}
+}
+
+// TestWriteSARIF_PropertyBagMigrationSnippet verifies the migrationSnippet
+// property is serialized in the SARIF properties bag.
+func TestWriteSARIF_PropertyBagMigrationSnippet(t *testing.T) {
+	f := findingWithAlg("RSA-2048", "/src/auth.go", 5)
+	f.MigrationSnippet = &findings.MigrationSnippet{
+		Language:    "go",
+		Before:      "rsa.GenerateKey(...)",
+		After:       "mlkem.GenerateKey()",
+		Explanation: "use ML-KEM",
+	}
+	result := BuildResult("1.0.0", "/src", []string{"cs"}, []findings.UnifiedFinding{f})
+
+	var buf bytes.Buffer
+	WriteSARIF(&buf, result) //nolint:errcheck
+	var doc map[string]interface{}
+	json.Unmarshal(buf.Bytes(), &doc) //nolint:errcheck
+
+	run := doc["runs"].([]interface{})[0].(map[string]interface{})
+	res := run["results"].([]interface{})[0].(map[string]interface{})
+	props, ok := res["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatal("result.properties missing")
+	}
+	snippet, ok := props["migrationSnippet"]
+	if !ok {
+		t.Fatal("properties.migrationSnippet missing")
+	}
+	snippetMap := snippet.(map[string]interface{})
+	if snippetMap["language"] != "go" {
+		t.Errorf("migrationSnippet.language = %v, want go", snippetMap["language"])
+	}
+}
+
+// TestWriteSARIF_StartLineMustBePositive verifies that a finding with Line=0
+// produces no region (SARIF spec: startLine >= 1).
+func TestWriteSARIF_StartLineMustBePositive(t *testing.T) {
+	f := findings.UnifiedFinding{
+		Location:     findings.Location{File: "/src/file.go", Line: 0},
+		Algorithm:    &findings.Algorithm{Name: "AES-128"},
+		SourceEngine: "cs",
+		Confidence:   findings.ConfidenceHigh,
+	}
+	result := BuildResult("1.0.0", "/src", []string{"cs"}, []findings.UnifiedFinding{f})
+
+	var buf bytes.Buffer
+	WriteSARIF(&buf, result) //nolint:errcheck
+	var doc map[string]interface{}
+	json.Unmarshal(buf.Bytes(), &doc) //nolint:errcheck
+
+	run := doc["runs"].([]interface{})[0].(map[string]interface{})
+	res := run["results"].([]interface{})[0].(map[string]interface{})
+	locs := res["locations"].([]interface{})
+	physLoc := locs[0].(map[string]interface{})["physicalLocation"].(map[string]interface{})
+	if _, hasRegion := physLoc["region"]; hasRegion {
+		t.Error("SARIF region must be omitted when startLine is 0 (SARIF spec: startLine >= 1)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CBOM (CycloneDX 1.7) edge cases
+// ---------------------------------------------------------------------------
+
+// TestWriteCBOM_EmptyFindings_SchemaFields verifies the empty-scan CBOM has
+// bomFormat, specVersion=1.7, and components as an empty array.
+func TestWriteCBOM_EmptyFindings_SchemaFields(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteCBOM(&buf, emptyResult()); err != nil {
+		t.Fatalf("WriteCBOM error: %v", err)
+	}
+	bom := parseCBOM(t, &buf)
+
+	if bom.BOMFormat != "CycloneDX" {
+		t.Errorf("bomFormat = %q, want CycloneDX", bom.BOMFormat)
+	}
+	if bom.SpecVersion != "1.7" {
+		t.Errorf("specVersion = %q, want 1.7", bom.SpecVersion)
+	}
+	if bom.SerialNumber == "" {
+		t.Error("serialNumber must be non-empty")
+	}
+	if !strings.HasPrefix(bom.SerialNumber, "urn:uuid:") {
+		t.Errorf("serialNumber must start with urn:uuid:, got %q", bom.SerialNumber)
+	}
+	if bom.Components == nil {
+		t.Error("components must not be nil (should be empty slice)")
+	}
+}
+
+// TestWriteCBOM_CryptoProperties verifies that an algorithm finding produces a
+// component with cryptoProperties.assetType = "algorithm" as required by
+// CycloneDX 1.7 CBOM spec.
+func TestWriteCBOM_CryptoProperties(t *testing.T) {
+	ff := []findings.UnifiedFinding{findingWithAlg("RSA-2048", "/src/auth.go", 10)}
+	result := BuildResult("1.0.0", "/src", []string{"cs"}, ff)
+	buf := writeCBOMOrFatal(t, result)
+	bom := parseCBOM(t, buf)
+
+	if len(bom.Components) == 0 {
+		t.Fatal("expected at least 1 component")
+	}
+	comp := bom.Components[0]
+	if comp.CryptoProperties == nil {
+		t.Fatal("component.cryptoProperties must not be nil")
+	}
+	if comp.CryptoProperties.AssetType != "algorithm" {
+		t.Errorf("cryptoProperties.assetType = %q, want algorithm", comp.CryptoProperties.AssetType)
+	}
+}
+
+// TestWriteCBOM_SerialNumberDeterministic verifies identical inputs produce the
+// same serialNumber (content-addressed hash).
+func TestWriteCBOM_SerialNumberDeterministic(t *testing.T) {
+	ff := []findings.UnifiedFinding{findingWithAlg("RSA-2048", "/src/a.go", 1)}
+	r := BuildResult("1.0.0", "/src", []string{"cs"}, ff)
+
+	var b1, b2 bytes.Buffer
+	WriteCBOM(&b1, r) //nolint:errcheck
+	WriteCBOM(&b2, r) //nolint:errcheck
+
+	bom1 := parseCBOM(t, &b1)
+	bom2 := parseCBOM(t, &b2)
+	if bom1.SerialNumber != bom2.SerialNumber {
+		t.Errorf("serialNumber not deterministic: %q vs %q", bom1.SerialNumber, bom2.SerialNumber)
+	}
+}
+
+// TestWriteCBOM_MetadataToolPresent verifies metadata.tools.components contains
+// oqs-scanner with a version.
+func TestWriteCBOM_MetadataToolPresent(t *testing.T) {
+	result := BuildResult("2.0.0", "/src", []string{"cs"}, nil)
+	buf := writeCBOMOrFatal(t, result)
+	bom := parseCBOM(t, buf)
+
+	if bom.Metadata.Tools == nil || len(bom.Metadata.Tools.Components) == 0 {
+		t.Fatal("metadata.tools.components must be present")
+	}
+	tool := bom.Metadata.Tools.Components[0]
+	if tool.Name != "oqs-scanner" {
+		t.Errorf("tool.name = %q, want oqs-scanner", tool.Name)
+	}
+	if tool.Version != "2.0.0" {
+		t.Errorf("tool.version = %q, want 2.0.0", tool.Version)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HTML XSS injection surface
+// ---------------------------------------------------------------------------
+
+// TestWriteHTML_XSS_AlgorithmName verifies that an algorithm name containing
+// an HTML script tag is escaped and does NOT appear unescaped in the output.
+// go's html/template escapes by default — if this fails it indicates a
+// template using |safe or equivalent that bypasses escaping.
+func TestWriteHTML_XSS_AlgorithmName(t *testing.T) {
+	xssAlg := `<script>alert(1)</script>`
+	result := basicResult()
+	result.Findings = []findings.UnifiedFinding{
+		algFinding(xssAlg, findings.QRVulnerable, findings.SevHigh),
+	}
+	result.Summary.TotalFindings = 1
+
+	var buf bytes.Buffer
+	if err := WriteHTML(&buf, result); err != nil {
+		t.Fatalf("WriteHTML error: %v", err)
+	}
+	out := buf.String()
+
+	// The raw script tag must NOT appear literally in the output
+	if strings.Contains(out, "<script>alert(1)</script>") {
+		t.Error("XSS: algorithm name '<script>alert(1)</script>' was not escaped in HTML output")
+	}
+	// The escaped form should be present instead
+	if !strings.Contains(out, "&lt;script&gt;") && !strings.Contains(out, "&#60;script&#62;") {
+		t.Log("note: escaped form not found (may be double-encoded or omitted) — verify manually")
+	}
+}
+
+// TestWriteHTML_XSS_FilePath verifies that a file path containing an img
+// onerror XSS payload is escaped in the HTML output.
+func TestWriteHTML_XSS_FilePath(t *testing.T) {
+	xssPath := `/src/<img src=x onerror=alert(1)>.go`
+	result := basicResult()
+	result.Findings = []findings.UnifiedFinding{
+		{
+			Location:     findings.Location{File: xssPath, Line: 1},
+			Algorithm:    &findings.Algorithm{Name: "RSA-2048", Primitive: "asymmetric"},
+			QuantumRisk:  findings.QRVulnerable,
+			Severity:     findings.SevHigh,
+			Confidence:   findings.ConfidenceHigh,
+			SourceEngine: "cipherscope",
+		},
+	}
+	result.Summary.TotalFindings = 1
+
+	var buf bytes.Buffer
+	if err := WriteHTML(&buf, result); err != nil {
+		t.Fatalf("WriteHTML error: %v", err)
+	}
+	out := buf.String()
+
+	if strings.Contains(out, "<img src=x onerror=alert(1)>") {
+		t.Error("XSS: img onerror payload was not escaped in HTML output for file path")
+	}
+}
+
+// TestWriteHTML_XSS_RecommendationField verifies that the recommendation
+// string (user-controlled in some workflows) is HTML-escaped.
+func TestWriteHTML_XSS_RecommendationField(t *testing.T) {
+	result := basicResult()
+	f := algFinding("RSA-2048", findings.QRVulnerable, findings.SevHigh)
+	f.Recommendation = `Use <b onmouseover="alert(1)">ML-KEM</b>`
+	result.Findings = []findings.UnifiedFinding{f}
+	result.Summary.TotalFindings = 1
+
+	var buf bytes.Buffer
+	if err := WriteHTML(&buf, result); err != nil {
+		t.Fatalf("WriteHTML error: %v", err)
+	}
+	out := buf.String()
+
+	if strings.Contains(out, `onmouseover="alert(1)"`) {
+		t.Error("XSS: recommendation onmouseover payload was not escaped in HTML output")
+	}
+}
+
+// TestWriteHTML_EmptyFindings_ValidDocument ensures HTML renders without error
+// and contains minimal structural elements when there are no findings.
+func TestWriteHTML_EmptyFindings_ValidDocument(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteHTML(&buf, emptyResult()); err != nil {
+		t.Fatalf("WriteHTML error for empty findings: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "<!DOCTYPE html>") {
+		t.Error("HTML output missing DOCTYPE")
+	}
+}
+
+// TestWriteHTML_LongAlgorithmName verifies that very long algorithm names (e.g.
+// 200+ chars from malformed input) do not cause a template panic or truncation
+// error — the output should still be valid HTML.
+func TestWriteHTML_LongAlgorithmName(t *testing.T) {
+	longName := strings.Repeat("A", 250)
+	result := basicResult()
+	result.Findings = []findings.UnifiedFinding{
+		algFinding(longName, findings.QRVulnerable, findings.SevHigh),
+	}
+	result.Summary.TotalFindings = 1
+
+	var buf bytes.Buffer
+	if err := WriteHTML(&buf, result); err != nil {
+		t.Fatalf("WriteHTML error with long algorithm name: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "<!DOCTYPE html>") {
+		t.Error("HTML output structurally broken for long algorithm name")
+	}
+}
+
+// TestSanitizeID_SpecialChars verifies that sanitizeID handles characters
+// that might otherwise produce invalid SARIF rule IDs.
+func TestSanitizeID_SpecialChars(t *testing.T) {
+	cases := []struct {
+		input   string
+		mustNot []string // substrings that must NOT appear in output
+	}{
+		{
+			// GAP: sanitizeID does not strip '<' or '>' — angle brackets survive
+			// ToUpper+Replace, meaning XSS-style algorithm names produce SARIF rule
+			// IDs containing literal '<' and '>' characters (invalid per SARIF spec).
+			// This test documents the current (buggy) behaviour; fix sanitizeID to
+			// strip or encode angle brackets.
+			input:   "RSA/2048 (PKCS#1)",
+			mustNot: []string{"/", " ", "(", ")"},
+		},
+	}
+	for _, tc := range cases {
+		got := sanitizeID(tc.input)
+		for _, bad := range tc.mustNot {
+			if strings.Contains(got, bad) {
+				t.Errorf("sanitizeID(%q) = %q; must not contain %q", tc.input, got, bad)
+			}
+		}
+	}
+}
+
+// TestSanitizeID_XMLUnsafeCharsStripped verifies that XML/HTML-unsafe
+// characters are removed from SARIF rule IDs. Regression: an algorithm name
+// like "<script>alert(1)</script>" used to produce a rule ID containing
+// literal angle brackets, violating SARIF 2.1.0 §3.49.3 and injecting into
+// any consumer that forwarded the ID into HTML/XML without escaping.
+func TestSanitizeID_XMLUnsafeCharsStripped(t *testing.T) {
+	input := `<script>alert("1")&'x</script>`
+	got := sanitizeID(input)
+	for _, bad := range []string{"<", ">", `"`, "'", "&"} {
+		if strings.Contains(got, bad) {
+			t.Errorf("sanitizeID(%q) = %q; must not contain %q", input, got, bad)
+		}
+	}
+}

--- a/pkg/output/sarif.go
+++ b/pkg/output/sarif.go
@@ -378,6 +378,9 @@ func joinEngines(source string, corroboratedBy []string) string {
 }
 
 // sanitizeID converts an algorithm/library name into a valid SARIF rule ID.
+// SARIF 2.1.0 §3.49.3 requires ruleId to be a "stable, opaque identifier",
+// which in practice means no angle brackets or quoting characters that
+// would need XML/HTML escaping in downstream consumers.
 func sanitizeID(name string) string {
 	r := strings.NewReplacer(
 		" ", "-",
@@ -385,6 +388,11 @@ func sanitizeID(name string) string {
 		".", "-",
 		"(", "",
 		")", "",
+		"<", "",
+		">", "",
+		`"`, "",
+		"'", "",
+		"&", "-",
 		"+", "PLUS",
 	)
 	return strings.ToUpper(r.Replace(name))

--- a/pkg/policy/edge_cases_test.go
+++ b/pkg/policy/edge_cases_test.go
@@ -1,0 +1,270 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/findings"
+)
+
+// ---------------------------------------------------------------------------
+// AllowedAlgorithms overriding BlockedAlgorithms interaction
+// ---------------------------------------------------------------------------
+
+// TestEvaluate_AllowedOverridesBlocked verifies that when the same algorithm is
+// in both AllowedAlgorithms and BlockedAlgorithms, both rules fire independently.
+// The policy engine doesn't short-circuit: a blocked finding also fails the
+// allowed-algorithms check, producing two violations.
+func TestEvaluate_AllowedAndBlockedBothSet_BothFire(t *testing.T) {
+	ff := []findings.UnifiedFinding{
+		algFinding("RSA-2048", findings.SevHigh, findings.QRVulnerable),
+	}
+	p := Policy{
+		AllowedAlgorithms: []string{"AES-256"},      // RSA-2048 not allowed
+		BlockedAlgorithms: []string{"RSA-2048"},      // RSA-2048 explicitly blocked
+	}
+	result := Evaluate(p, ff, nil, summaryFrom(ff))
+	if result.Pass {
+		t.Error("should fail: RSA-2048 is both blocked and not in allowed list")
+	}
+	rulesSeen := make(map[string]bool)
+	for _, v := range result.Violations {
+		rulesSeen[v.Rule] = true
+	}
+	if !rulesSeen["blocked-algorithm"] {
+		t.Error("expected blocked-algorithm violation")
+	}
+	if !rulesSeen["allowed-algorithms"] {
+		t.Error("expected allowed-algorithms violation")
+	}
+}
+
+// TestEvaluate_AllowedAlgorithms_EmptyListIsNoOp verifies that an empty
+// AllowedAlgorithms list (nil) does not trigger violations for any algorithm.
+func TestEvaluate_AllowedAlgorithms_EmptyListIsNoOp(t *testing.T) {
+	ff := []findings.UnifiedFinding{
+		algFinding("RSA-2048", findings.SevHigh, findings.QRVulnerable),
+		algFinding("DES", findings.SevHigh, findings.QRDeprecated),
+	}
+	p := Policy{AllowedAlgorithms: nil}
+	result := Evaluate(p, ff, nil, summaryFrom(ff))
+	if !result.Pass {
+		t.Errorf("empty AllowedAlgorithms should be no-op; violations: %v", result.Violations)
+	}
+}
+
+// TestEvaluate_BlockedAlgorithms_EmptyListIsNoOp verifies that an empty
+// BlockedAlgorithms list (nil) does not trigger violations.
+func TestEvaluate_BlockedAlgorithms_EmptyListIsNoOp(t *testing.T) {
+	ff := []findings.UnifiedFinding{
+		algFinding("RSA-2048", findings.SevHigh, findings.QRVulnerable),
+	}
+	p := Policy{BlockedAlgorithms: nil}
+	result := Evaluate(p, ff, nil, summaryFrom(ff))
+	if !result.Pass {
+		t.Errorf("empty BlockedAlgorithms should be no-op; violations: %v", result.Violations)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FailOn severity boundary exhaustion
+// ---------------------------------------------------------------------------
+
+// TestEvaluate_FailOn_InfoDoesNotTriggerAnyThreshold verifies that an info-
+// severity finding does not trip any threshold including "info" (which is not
+// a valid FailOn value — only critical/high/medium/low are documented).
+func TestEvaluate_FailOn_InfoFindingBelowLowThreshold(t *testing.T) {
+	ff := []findings.UnifiedFinding{
+		algFinding("AES-128", findings.SevInfo, findings.QRWeakened),
+	}
+	p := Policy{FailOn: "low"}
+	result := Evaluate(p, ff, nil, summaryFrom(ff))
+	if !result.Pass {
+		t.Errorf("info severity should not trigger 'low' threshold; violations: %v", result.Violations)
+	}
+}
+
+// TestEvaluate_FailOn_HighFindingTriggersMediumThreshold verifies that high
+// severity findings trigger medium-and-above threshold.
+func TestEvaluate_FailOn_HighFindingTriggersMediumThreshold(t *testing.T) {
+	ff := []findings.UnifiedFinding{
+		algFinding("RSA-2048", findings.SevHigh, findings.QRVulnerable),
+	}
+	p := Policy{FailOn: "medium"}
+	result := Evaluate(p, ff, nil, summaryFrom(ff))
+	if result.Pass {
+		t.Error("high finding should trigger medium threshold (high >= medium)")
+	}
+}
+
+// TestEvaluate_FailOn_CriticalTriggersMediumThreshold tests upward triggering.
+func TestEvaluate_FailOn_CriticalTriggersMediumThreshold(t *testing.T) {
+	ff := []findings.UnifiedFinding{
+		algFinding("RSA-2048", findings.SevCritical, findings.QRVulnerable),
+	}
+	p := Policy{FailOn: "medium"}
+	result := Evaluate(p, ff, nil, summaryFrom(ff))
+	if result.Pass {
+		t.Error("critical finding should trigger medium threshold")
+	}
+	if len(result.Violations) != 1 || result.Violations[0].Rule != "fail-on" {
+		t.Errorf("unexpected violations: %v", result.Violations)
+	}
+}
+
+// TestEvaluate_FailOn_FindingWithNoSeveritySkipped verifies that a finding
+// with empty Severity does not trigger the fail-on rule (no rank in the map).
+func TestEvaluate_FailOn_FindingWithNoSeveritySkipped(t *testing.T) {
+	ff := []findings.UnifiedFinding{
+		{
+			Algorithm:   &findings.Algorithm{Name: "RSA-2048"},
+			QuantumRisk: findings.QRVulnerable,
+			// Severity intentionally empty
+		},
+	}
+	p := Policy{FailOn: "low"}
+	result := Evaluate(p, ff, nil, summaryFrom(ff))
+	if !result.Pass {
+		t.Errorf("finding with no severity should not trigger fail-on; violations: %v", result.Violations)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MinQRS edge cases
+// ---------------------------------------------------------------------------
+
+// TestEvaluate_MinQRS100_Score100_Passes verifies the exact boundary case.
+func TestEvaluate_MinQRS100_Score100_Passes(t *testing.T) {
+	p := Policy{MinQRS: 100}
+	result := Evaluate(p, nil, qrs(100), ScanSummary{})
+	if !result.Pass {
+		t.Errorf("minQRS=100 with score=100 should pass; violations: %v", result.Violations)
+	}
+}
+
+// TestEvaluate_MinQRS100_Score99_Fails verifies off-by-one boundary.
+func TestEvaluate_MinQRS100_Score99_Fails(t *testing.T) {
+	p := Policy{MinQRS: 100}
+	result := Evaluate(p, nil, qrs(99), ScanSummary{})
+	if result.Pass {
+		t.Error("minQRS=100 with score=99 should fail")
+	}
+	if len(result.Violations) == 0 || result.Violations[0].Rule != "min-qrs" {
+		t.Errorf("expected min-qrs violation; got: %v", result.Violations)
+	}
+}
+
+// TestEvaluate_MinQRS_ZeroDisabled verifies that MinQRS=0 never triggers a
+// violation regardless of QRS score (including nil).
+func TestEvaluate_MinQRS_ZeroIsDisabled(t *testing.T) {
+	p := Policy{MinQRS: 0}
+	// nil QRS with MinQRS=0 must not produce a violation
+	result := Evaluate(p, nil, nil, ScanSummary{})
+	if !result.Pass {
+		t.Errorf("MinQRS=0 (disabled) with nil QRS should pass; violations: %v", result.Violations)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RequirePQC edge cases
+// ---------------------------------------------------------------------------
+
+// TestEvaluate_RequirePQC_OnlySafeFindings_Passes verifies that a codebase
+// with all-safe findings satisfies the RequirePQC requirement.
+func TestEvaluate_RequirePQC_OnlySafeFindings_Passes(t *testing.T) {
+	ff := []findings.UnifiedFinding{
+		algFinding("ML-KEM-768", findings.SevInfo, findings.QRSafe),
+		algFinding("ML-DSA-65", findings.SevInfo, findings.QRSafe),
+	}
+	p := Policy{RequirePQC: true}
+	result := Evaluate(p, ff, nil, summaryFrom(ff))
+	if !result.Pass {
+		t.Errorf("all-safe findings should satisfy RequirePQC; violations: %v", result.Violations)
+	}
+}
+
+// TestEvaluate_RequirePQC_DepFindingWithSafeSummary verifies that when the
+// summary already counts safe entries (from algo findings), RequirePQC passes
+// even if this particular finding is a dependency (not algo).
+func TestEvaluate_RequirePQC_SummaryWithSafeCount_Passes(t *testing.T) {
+	ff := []findings.UnifiedFinding{
+		{Dependency: &findings.Dependency{Library: "openssl"}, QuantumRisk: findings.QRVulnerable},
+	}
+	p := Policy{RequirePQC: true}
+	// Manually provide summary indicating 1 safe (e.g. from another algo finding)
+	summary := ScanSummary{QuantumSafe: 1}
+	result := Evaluate(p, ff, nil, summary)
+	if !result.Pass {
+		t.Errorf("RequirePQC should pass when summary.QuantumSafe > 0; violations: %v", result.Violations)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MaxQuantumVulnerable edge cases
+// ---------------------------------------------------------------------------
+
+// TestEvaluate_MaxQuantumVulnerable_ExactlyAtLimit_Passes tests the boundary
+// where count equals max (should pass — limit is inclusive).
+func TestEvaluate_MaxQuantumVulnerable_AtLimit_Passes(t *testing.T) {
+	ff := make([]findings.UnifiedFinding, 3)
+	for i := range ff {
+		ff[i] = algFinding("RSA-2048", findings.SevHigh, findings.QRVulnerable)
+	}
+	p := Policy{MaxQuantumVulnerable: intPtr(3)}
+	result := Evaluate(p, ff, nil, summaryFrom(ff))
+	if !result.Pass {
+		t.Errorf("count==max should pass (limit is inclusive); violations: %v", result.Violations)
+	}
+}
+
+// TestEvaluate_MaxQuantumVulnerable_OneOverLimit_Fails tests the boundary
+// where count exceeds max by exactly one.
+func TestEvaluate_MaxQuantumVulnerable_OneOver_Fails(t *testing.T) {
+	ff := make([]findings.UnifiedFinding, 4)
+	for i := range ff {
+		ff[i] = algFinding("RSA-2048", findings.SevHigh, findings.QRVulnerable)
+	}
+	p := Policy{MaxQuantumVulnerable: intPtr(3)}
+	result := Evaluate(p, ff, nil, summaryFrom(ff))
+	if result.Pass {
+		t.Error("count > max should fail")
+	}
+}
+
+// TestEvaluate_WhitespaceOnlyAllowedEntry verifies that " " (space) entries in
+// AllowedAlgorithms are silently dropped and don't create false matches.
+func TestEvaluate_AllowedAlgorithms_WhitespaceEntryDropped(t *testing.T) {
+	ff := []findings.UnifiedFinding{
+		algFinding("RSA-2048", findings.SevHigh, findings.QRVulnerable),
+	}
+	// AllowedAlgorithms with only whitespace should be treated as nil (no-op)
+	p := Policy{AllowedAlgorithms: []string{"  ", "\t"}}
+	result := Evaluate(p, ff, nil, summaryFrom(ff))
+	// All whitespace entries → nil set → no allowed-algorithms rule fires
+	for _, v := range result.Violations {
+		if v.Rule == "allowed-algorithms" {
+			t.Errorf("whitespace-only AllowedAlgorithms should not trigger allowed-algorithms rule; violations: %v", result.Violations)
+		}
+	}
+}
+
+// TestEvaluate_MultipleRulesAccumulate verifies that when multiple rules
+// independently fire on the same finding, all violations are collected (not
+// short-circuited after the first).
+func TestEvaluate_MultipleViolationsPerFinding_AllCollected(t *testing.T) {
+	ff := []findings.UnifiedFinding{
+		algFinding("DES", findings.SevCritical, findings.QRVulnerable),
+	}
+	p := Policy{
+		FailOn:            "high",     // triggers: critical >= high
+		BlockedAlgorithms: []string{"DES"}, // triggers: DES blocked
+		AllowedAlgorithms: []string{"AES-256"}, // triggers: DES not allowed
+	}
+	result := Evaluate(p, ff, nil, summaryFrom(ff))
+	if result.Pass {
+		t.Error("expected failure with three rules firing")
+	}
+	// Must have at least 3 violations: fail-on, blocked-algorithm, allowed-algorithms
+	if len(result.Violations) < 3 {
+		t.Errorf("expected at least 3 violations, got %d: %v", len(result.Violations), result.Violations)
+	}
+}

--- a/pkg/quantum/classify.go
+++ b/pkg/quantum/classify.go
@@ -126,6 +126,9 @@ var deprecatedAlgorithms = map[string]bool{
 
 // ClassifyAlgorithm assesses the quantum risk of a cryptographic algorithm.
 func ClassifyAlgorithm(name, primitive string, keySize int) Classification {
+	// Trim surrounding whitespace that AST/grep engines sometimes surface on
+	// tokenised names. Without this, " RSA " fell through to RiskUnknown.
+	name = strings.TrimSpace(name)
 	upperName := strings.ToUpper(name)
 	baseName := extractBaseName(name)
 

--- a/pkg/quantum/edge_cases_test.go
+++ b/pkg/quantum/edge_cases_test.go
@@ -1,0 +1,885 @@
+package quantum
+
+// edge_cases_test.go — New edge-case tests for pkg/quantum.
+// Covers input parsing, key-size boundaries, K-PQC candidates,
+// QRS formula math, grade thresholds, and HNDL classification.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/findings"
+)
+
+// ---------------------------------------------------------------------------
+// 1. Input parsing — curve aliases, hash aliases, case sensitivity, whitespace
+// ---------------------------------------------------------------------------
+
+// TestClassify_CurveAliasNormalization verifies that common alternative names
+// for elliptic curves are all recognised as quantum-vulnerable.
+// The NIST curve P-256 appears as secp256r1 and prime256v1 in real-world code.
+func TestClassify_CurveAliasNormalization(t *testing.T) {
+	tests := []struct {
+		name      string
+		algName   string
+		primitive string
+		wantRisk  Risk
+		wantSev   Severity
+	}{
+		// Canonical name
+		{"P-256 ecdsa", "ECDSA", "signature", RiskVulnerable, SeverityHigh},
+		// Common OpenSSL alias — extractBaseName splits at '-', first segment is "secp256r1"
+		// No map hit → falls through to primitive path → signature → RiskVulnerable/High
+		{"secp256r1 signature", "secp256r1", "signature", RiskVulnerable, SeverityHigh},
+		// Another OpenSSL alias
+		{"prime256v1 signature", "prime256v1", "signature", RiskVulnerable, SeverityHigh},
+		// P-384 canonical via ECDSA primitive
+		{"P-384 ecdsa", "ECDSA", "signature", RiskVulnerable, SeverityHigh},
+		// secp384r1 alias
+		{"secp384r1 signature", "secp384r1", "signature", RiskVulnerable, SeverityHigh},
+		// brainpoolP256r1 — unknown curve, signature primitive → deferred HNDL
+		{"brainpoolP256r1 signature", "brainpoolP256r1", "signature", RiskVulnerable, SeverityHigh},
+		// P-224 via ECDH — key-exchange primitive → immediate HNDL
+		{"P-224 key-exchange", "secp224r1", "key-exchange", RiskVulnerable, SeverityCritical},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyAlgorithm(tt.algName, tt.primitive, 0)
+			if got.Risk != tt.wantRisk {
+				t.Errorf("ClassifyAlgorithm(%q, %q, 0).Risk = %q, want %q",
+					tt.algName, tt.primitive, got.Risk, tt.wantRisk)
+			}
+			if got.Severity != tt.wantSev {
+				t.Errorf("ClassifyAlgorithm(%q, %q, 0).Severity = %q, want %q",
+					tt.algName, tt.primitive, got.Severity, tt.wantSev)
+			}
+		})
+	}
+}
+
+// TestClassify_HashAliasNormalization verifies that SHA-1 and its common aliases
+// are all classified as deprecated (classically broken regardless of quantum).
+func TestClassify_HashAliasNormalization(t *testing.T) {
+	aliases := []struct {
+		name    string
+		algName string
+	}{
+		{"SHA-1 canonical", "SHA-1"},
+		{"SHA1 no-hyphen", "SHA1"},
+		// SHA-1 with extra casing
+		{"sha-1 lowercase", "sha-1"},
+		{"sha1 lowercase", "sha1"},
+		{"Sha-1 mixed case", "Sha-1"},
+		{"SHA1 all-caps", "SHA1"},
+	}
+
+	for _, tt := range aliases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyAlgorithm(tt.algName, "hash", 0)
+			if got.Risk != RiskDeprecated {
+				t.Errorf("ClassifyAlgorithm(%q).Risk = %q, want %q (SHA-1 is deprecated)",
+					tt.algName, got.Risk, RiskDeprecated)
+			}
+			if got.Severity != SeverityCritical {
+				t.Errorf("ClassifyAlgorithm(%q).Severity = %q, want %q",
+					tt.algName, got.Severity, SeverityCritical)
+			}
+		})
+	}
+}
+
+// TestClassify_CaseSensitivity checks that algorithm names are matched
+// case-insensitively for all the major families.
+func TestClassify_CaseSensitivity(t *testing.T) {
+	tests := []struct {
+		name      string
+		algName   string
+		primitive string
+		wantRisk  Risk
+	}{
+		// RSA variants
+		{"rsa lowercase", "rsa", "", RiskVulnerable},
+		{"Rsa mixed", "Rsa", "", RiskVulnerable},
+		{"RSA-2048 embedded size", "RSA-2048", "", RiskVulnerable},
+		// AES variants
+		{"aes-256-gcm lowercase", "aes-256-gcm", "ae", RiskResistant},
+		{"AES-256-GCM uppercase", "AES-256-GCM", "ae", RiskResistant},
+		// MD5 deprecated
+		{"md5 lowercase", "md5", "hash", RiskDeprecated},
+		{"Md5 mixed", "Md5", "hash", RiskDeprecated},
+		// ML-KEM safe
+		{"ml-kem-768 lowercase", "ml-kem-768", "kem", RiskSafe},
+		{"ML-KEM-768 uppercase", "ML-KEM-768", "kem", RiskSafe},
+		// ECDH
+		{"ecdh lowercase", "ecdh", "key-agree", RiskVulnerable},
+		{"ECDH uppercase", "ECDH", "key-agree", RiskVulnerable},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyAlgorithm(tt.algName, tt.primitive, 0)
+			if got.Risk != tt.wantRisk {
+				t.Errorf("ClassifyAlgorithm(%q, %q, 0).Risk = %q, want %q",
+					tt.algName, tt.primitive, got.Risk, tt.wantRisk)
+			}
+		})
+	}
+}
+
+// TestClassify_EmptyAndWhitespaceName verifies graceful handling of empty
+// or whitespace-only algorithm names.
+func TestClassify_EmptyAndWhitespaceName(t *testing.T) {
+	tests := []struct {
+		name      string
+		algName   string
+		primitive string
+		wantRisk  Risk
+	}{
+		// Empty name, no primitive → RiskUnknown
+		{"empty name no primitive", "", "", RiskUnknown},
+		// Empty name with kem primitive → unknown alg with kem → RiskVulnerable (HNDL immediate)
+		{"empty name kem", "", "kem", RiskVulnerable},
+		// Empty name with signature primitive → RiskVulnerable (HNDL deferred)
+		{"empty name signature", "", "signature", RiskVulnerable},
+		// Whitespace-padded names should be trimmed before lookup.
+		{"padded RSA", "  RSA  ", "", RiskVulnerable},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("ClassifyAlgorithm panicked with name=%q: %v", tt.algName, r)
+				}
+			}()
+			got := ClassifyAlgorithm(tt.algName, tt.primitive, 0)
+			if got.Risk != tt.wantRisk {
+				t.Errorf("ClassifyAlgorithm(%q, %q, 0).Risk = %q, want %q",
+					tt.algName, tt.primitive, got.Risk, tt.wantRisk)
+			}
+		})
+	}
+}
+
+// TestClassify_WhitespacePaddedName verifies that whitespace-padded names are
+// trimmed before classification. AST and grep engines regularly surface
+// algorithm tokens with surrounding whitespace; leaving them unclassified was
+// a silent false-negative in production scans.
+func TestClassify_WhitespacePaddedName(t *testing.T) {
+	t.Run("leading_trailing_space_RSA", func(t *testing.T) {
+		got := ClassifyAlgorithm(" RSA ", "", 0)
+		if got.Risk != RiskVulnerable {
+			t.Errorf("ClassifyAlgorithm(\" RSA \").Risk = %q, want %q", got.Risk, RiskVulnerable)
+		}
+	})
+
+	t.Run("tab_padded_SHA1", func(t *testing.T) {
+		got := ClassifyAlgorithm("\tSHA-1\t", "hash", 0)
+		if got.Risk != RiskDeprecated {
+			t.Errorf("ClassifyAlgorithm(\"\\tSHA-1\\t\").Risk = %q, want %q", got.Risk, RiskDeprecated)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 2. Key-size boundaries — RSA, AES, unusual ECC curves
+// ---------------------------------------------------------------------------
+
+// TestClassify_RSAKeySizeLadder verifies that RSA classifications follow the
+// CNSA 2.0 key-size thresholds and that unusual sizes (0, negative, 1023,
+// 2049, 8192) are handled without panic.
+func TestClassify_RSAKeySizeLadder(t *testing.T) {
+	tests := []struct {
+		name        string
+		keySize     int
+		wantRisk    Risk
+		wantSev     Severity
+		wantHNDL    string
+		wantTarget  string
+	}{
+		// Standard NIST-recommended sizes
+		{"RSA-1024 default prim", 1024, RiskVulnerable, SeverityHigh, HNDLImmediate, "ML-DSA-44"},
+		{"RSA-2048 default prim", 2048, RiskVulnerable, SeverityHigh, HNDLImmediate, "ML-DSA-44"},
+		{"RSA-3072 default prim", 3072, RiskVulnerable, SeverityHigh, HNDLImmediate, "ML-DSA-65"},
+		{"RSA-4096 default prim", 4096, RiskVulnerable, SeverityHigh, HNDLImmediate, "ML-DSA-87"},
+		{"RSA-8192 large key", 8192, RiskVulnerable, SeverityHigh, HNDLImmediate, "ML-DSA-87"},
+		// Off-by-one boundaries
+		{"RSA-1023 unusual", 1023, RiskVulnerable, SeverityHigh, HNDLImmediate, "ML-DSA-44"},
+		{"RSA-2049 unusual", 2049, RiskVulnerable, SeverityHigh, HNDLImmediate, "ML-DSA-44"},
+		// Edge: zero keySize → no key-size info, still vulnerable
+		{"RSA-0 no size", 0, RiskVulnerable, SeverityHigh, HNDLImmediate, "ML-DSA-44"},
+		// Edge: negative keySize — must not panic
+		{"RSA negative size", -1, RiskVulnerable, SeverityHigh, HNDLImmediate, "ML-DSA-44"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("ClassifyAlgorithm panicked with RSA keySize=%d: %v", tt.keySize, r)
+				}
+			}()
+			// No explicit primitive so it hits the "unknown primitive → conservative" path
+			got := ClassifyAlgorithm("RSA", "", tt.keySize)
+			if got.Risk != tt.wantRisk {
+				t.Errorf("RSA keySize=%d Risk = %q, want %q", tt.keySize, got.Risk, tt.wantRisk)
+			}
+			if got.Severity != tt.wantSev {
+				t.Errorf("RSA keySize=%d Severity = %q, want %q", tt.keySize, got.Severity, tt.wantSev)
+			}
+			if got.HNDLRisk != tt.wantHNDL {
+				t.Errorf("RSA keySize=%d HNDLRisk = %q, want %q", tt.keySize, got.HNDLRisk, tt.wantHNDL)
+			}
+			if got.TargetAlgorithm != tt.wantTarget {
+				t.Errorf("RSA keySize=%d TargetAlgorithm = %q, want %q", tt.keySize, got.TargetAlgorithm, tt.wantTarget)
+			}
+		})
+	}
+}
+
+// TestClassify_AESKeySizeBoundaries probes AES at every significant boundary.
+func TestClassify_AESKeySizeBoundaries(t *testing.T) {
+	tests := []struct {
+		name      string
+		algName   string
+		keySize   int
+		wantRisk  Risk
+		wantSev   Severity
+	}{
+		// < 128 bits → RiskWeakened/Medium (key too small)
+		{"AES key<128", "AES", 64, RiskWeakened, SeverityMedium},
+		{"AES key=127", "AES", 127, RiskWeakened, SeverityMedium},
+		// 128-bit → weakened by Grover
+		{"AES-128", "AES-128", 128, RiskWeakened, SeverityLow},
+		// 192-bit → still weakened
+		{"AES-192", "AES-192", 192, RiskWeakened, SeverityLow},
+		// 256-bit → resistant
+		{"AES-256", "AES-256", 256, RiskResistant, SeverityInfo},
+		// 512-bit (hypothetical) → resistant
+		{"AES-512 hypothetical", "AES", 512, RiskResistant, SeverityInfo},
+		// 0 keySize, no suffix → cannot infer → RiskUnknown
+		{"AES bare no size", "AES", 0, RiskUnknown, SeverityLow},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyAlgorithm(tt.algName, "symmetric", tt.keySize)
+			if got.Risk != tt.wantRisk {
+				t.Errorf("AES keySize=%d Risk = %q, want %q", tt.keySize, got.Risk, tt.wantRisk)
+			}
+			if got.Severity != tt.wantSev {
+				t.Errorf("AES keySize=%d Severity = %q, want %q", tt.keySize, got.Severity, tt.wantSev)
+			}
+		})
+	}
+}
+
+// TestClassify_UnusualECCCurves checks P-224 and brainpool curves which are
+// not in the canonical NIST set but appear in real-world deployments.
+func TestClassify_UnusualECCCurves(t *testing.T) {
+	tests := []struct {
+		name      string
+		algName   string
+		primitive string
+		wantRisk  Risk
+		wantSev   Severity
+		wantHNDL  string
+	}{
+		// P-224 via explicit ECDSA
+		{"ECDSA P-224 size", "ECDSA", "signature", RiskVulnerable, SeverityHigh, HNDLDeferred},
+		// P-224 via explicit ECDH
+		{"ECDH P-224 size", "ECDH", "key-agree", RiskVulnerable, SeverityCritical, HNDLImmediate},
+		// brainpoolP256r1 — unrecognised name, signature primitive
+		{"brainpoolP256r1", "brainpoolP256r1", "signature", RiskVulnerable, SeverityHigh, HNDLDeferred},
+		// brainpoolP384r1 — unrecognised name, key-exchange primitive
+		{"brainpoolP384r1 key-exchange", "brainpoolP384r1", "key-exchange", RiskVulnerable, SeverityCritical, HNDLImmediate},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyAlgorithm(tt.algName, tt.primitive, 224)
+			if got.Risk != tt.wantRisk {
+				t.Errorf("ClassifyAlgorithm(%q, %q, 224).Risk = %q, want %q",
+					tt.algName, tt.primitive, got.Risk, tt.wantRisk)
+			}
+			if got.Severity != tt.wantSev {
+				t.Errorf("ClassifyAlgorithm(%q, %q, 224).Severity = %q, want %q",
+					tt.algName, tt.primitive, got.Severity, tt.wantSev)
+			}
+			if got.HNDLRisk != tt.wantHNDL {
+				t.Errorf("ClassifyAlgorithm(%q, %q, 224).HNDLRisk = %q, want %q",
+					tt.algName, tt.primitive, got.HNDLRisk, tt.wantHNDL)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3. K-PQC candidates — safe finalists vs eliminated candidates
+// ---------------------------------------------------------------------------
+
+// TestClassify_KPQCFinalistsAreSafe verifies that every K-PQC Round 4 finalist
+// is classified as RiskSafe regardless of primitive tag.
+func TestClassify_KPQCFinalistsAreSafe(t *testing.T) {
+	finalists := []struct {
+		algName   string
+		primitive string
+	}{
+		{"SMAUG-T", "kem"},
+		{"SMAUG-T-128", "kem"},
+		{"SMAUG-T-192", "kem"},
+		{"SMAUG-T-256", "kem"},
+		{"HAETAE", "signature"},
+		{"HAETAE-2", "signature"},
+		{"HAETAE-3", "signature"},
+		{"HAETAE-5", "signature"},
+		{"AIMer", "signature"},
+		{"AIMer-128f", "signature"},
+		{"AIMer-128s", "signature"},
+		{"AIMer-256f", "signature"},
+		{"NTRU+", "kem"},
+		{"NTRU+-576", "kem"},
+		{"NTRU+-768", "kem"},
+		{"NTRU+-864", "kem"},
+	}
+
+	for _, alg := range finalists {
+		alg := alg
+		t.Run(alg.algName, func(t *testing.T) {
+			got := ClassifyAlgorithm(alg.algName, alg.primitive, 0)
+			if got.Risk != RiskSafe {
+				t.Errorf("K-PQC finalist %q should be RiskSafe, got %q", alg.algName, got.Risk)
+			}
+			if got.Severity != SeverityInfo {
+				t.Errorf("K-PQC finalist %q should be SeverityInfo, got %q", alg.algName, got.Severity)
+			}
+			// Safe finalists must have no HNDL tag
+			if got.HNDLRisk != "" {
+				t.Errorf("K-PQC finalist %q should have empty HNDLRisk, got %q", alg.algName, got.HNDLRisk)
+			}
+		})
+	}
+}
+
+// TestClassify_KPQCEliminatedAreVulnerable verifies all eliminated K-PQC candidates
+// return RiskVulnerable with SeverityMedium and a migration recommendation.
+func TestClassify_KPQCEliminatedAreVulnerable(t *testing.T) {
+	eliminated := []struct {
+		algName   string
+		primitive string
+	}{
+		{"GCKSign", "signature"},
+		{"NCC-Sign", "signature"},
+		{"SOLMAE", "kem"},
+		{"TiGER", "kem"},
+		{"PALOMA", "kem"},
+		{"REDOG", "kem"},
+	}
+
+	for _, alg := range eliminated {
+		alg := alg
+		t.Run(alg.algName, func(t *testing.T) {
+			got := ClassifyAlgorithm(alg.algName, alg.primitive, 0)
+			if got.Risk != RiskVulnerable {
+				t.Errorf("eliminated candidate %q should be RiskVulnerable, got %q", alg.algName, got.Risk)
+			}
+			if got.Severity != SeverityMedium {
+				t.Errorf("eliminated candidate %q should be SeverityMedium, got %q", alg.algName, got.Severity)
+			}
+			if got.Recommendation == "" {
+				t.Errorf("eliminated candidate %q should have a non-empty Recommendation", alg.algName)
+			}
+			upperRec := strings.ToUpper(got.Recommendation)
+			if !strings.Contains(upperRec, "SMAUG-T") && !strings.Contains(upperRec, "HAETAE") {
+				t.Errorf("eliminated candidate %q recommendation should mention SMAUG-T or HAETAE, got: %s",
+					alg.algName, got.Recommendation)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 4. QRS formula — exact arithmetic verification
+// ---------------------------------------------------------------------------
+
+// TestQRS_ZeroFindingsIs100 confirms the base case is exactly 100/A+.
+func TestQRS_ZeroFindingsIs100(t *testing.T) {
+	for _, ff := range [][]findings.UnifiedFinding{nil, {}} {
+		qrs := CalculateQRS(ff)
+		if qrs.Score != 100 {
+			t.Errorf("zero findings: Score = %d, want 100", qrs.Score)
+		}
+		if qrs.Grade != "A+" {
+			t.Errorf("zero findings: Grade = %q, want A+", qrs.Grade)
+		}
+	}
+}
+
+// TestQRS_AllPQCSafe_DoesNotExceed100 confirms PQC bonuses never push the score above 100.
+func TestQRS_AllPQCSafe_DoesNotExceed100(t *testing.T) {
+	for _, n := range []int{1, 10, 100, 1000} {
+		ff := make([]findings.UnifiedFinding, n)
+		for i := range ff {
+			ff[i] = findings.UnifiedFinding{
+				Algorithm:   &findings.Algorithm{Name: "ML-KEM-768"},
+				QuantumRisk: findings.QRSafe,
+				Severity:    findings.SevInfo,
+			}
+		}
+		qrs := CalculateQRS(ff)
+		if qrs.Score > 100 {
+			t.Errorf("%d safe findings: Score = %d, exceeds cap of 100", n, qrs.Score)
+		}
+		if qrs.Score != 100 {
+			t.Errorf("%d safe findings: Score = %d, want 100", n, qrs.Score)
+		}
+	}
+}
+
+// TestQRS_AllVulnerable_FloorIsZero confirms score floors at 0 regardless of count.
+func TestQRS_AllVulnerable_FloorIsZero(t *testing.T) {
+	// 51 critical findings: 100 - 51*2.0 = -2 → clamped to 0
+	ff := make([]findings.UnifiedFinding, 51)
+	for i := range ff {
+		ff[i] = findings.UnifiedFinding{
+			Algorithm:   &findings.Algorithm{Name: "RSA-2048"},
+			QuantumRisk: findings.QRVulnerable,
+			Severity:    findings.SevCritical,
+		}
+	}
+	qrs := CalculateQRS(ff)
+	if qrs.Score != 0 {
+		t.Errorf("51 critical findings: Score = %d, want 0 (clamped)", qrs.Score)
+	}
+	if qrs.Grade != "F" {
+		t.Errorf("51 critical findings: Grade = %q, want F", qrs.Grade)
+	}
+}
+
+// TestQRS_Exact1Point5xCorroborationMath verifies the exact 1.5x multiplier
+// arithmetic for each severity level.
+func TestQRS_Exact1Point5xCorroborationMath(t *testing.T) {
+	tests := []struct {
+		name          string
+		sev           findings.Severity
+		basePenalty   float64
+		plainScore    int // 100 - basePenalty
+		corrScore     int // 100 - basePenalty*1.5 (rounded)
+	}{
+		// Critical: base penalty 2.0, corroborated 3.0
+		{"critical", findings.SevCritical, 2.0, 98, 97},
+		// High: base penalty 1.5, corroborated 2.25 → 100-2.25=97.75 → round=98
+		{"high", findings.SevHigh, 1.5, 99, 98},
+		// Medium: base penalty 1.0, corroborated 1.5 → 100-1.5=98.5 → round=99
+		//   NOTE: math.Round(98.5) in Go rounds half away from zero = 99
+		{"medium", findings.SevMedium, 1.0, 99, 99},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			plain := findings.UnifiedFinding{
+				Algorithm:   &findings.Algorithm{Name: "RSA"},
+				QuantumRisk: findings.QRVulnerable,
+				Severity:    tt.sev,
+			}
+			corr := plain
+			corr.CorroboratedBy = []string{"engine-b"}
+
+			qrsPlain := CalculateQRS([]findings.UnifiedFinding{plain})
+			qrsCorr := CalculateQRS([]findings.UnifiedFinding{corr})
+
+			if qrsPlain.Score != tt.plainScore {
+				t.Errorf("%s plain: Score = %d, want %d (100 - %.1f)",
+					tt.name, qrsPlain.Score, tt.plainScore, tt.basePenalty)
+			}
+			if qrsCorr.Score != tt.corrScore {
+				t.Errorf("%s corroborated: Score = %d, want %d (100 - %.1f*1.5)",
+					tt.name, qrsCorr.Score, tt.corrScore, tt.basePenalty)
+			}
+			// Corroborated must be <= plain (larger penalty → lower or equal score)
+			if qrsCorr.Score > qrsPlain.Score {
+				t.Errorf("%s: corroborated score (%d) must not exceed plain score (%d)",
+					tt.name, qrsCorr.Score, qrsPlain.Score)
+			}
+		})
+	}
+}
+
+// TestQRS_HighSeverityPlainScore verifies the single-finding plain (non-corroborated)
+// score for high severity: 100 - 1.5 = 98.5 → math.Round = 99.
+func TestQRS_HighSeverityPlainScore(t *testing.T) {
+	f := findings.UnifiedFinding{
+		Algorithm:   &findings.Algorithm{Name: "ECDSA"},
+		QuantumRisk: findings.QRVulnerable,
+		Severity:    findings.SevHigh,
+	}
+	qrs := CalculateQRS([]findings.UnifiedFinding{f})
+	if qrs.Score != 99 {
+		t.Errorf("single high-severity finding: Score = %d, want 99 (100 - 1.5 rounded)", qrs.Score)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 5. Data lifetime multiplier boundary values
+// ---------------------------------------------------------------------------
+
+// TestDataLifetimeMultiplier_BoundaryValues probes the exact boundary values
+// including 0, 1, 4, 5, 10, 11, 30, 100, and negative inputs.
+func TestDataLifetimeMultiplier_BoundaryValues(t *testing.T) {
+	tests := []struct {
+		years int
+		want  float64
+	}{
+		// Negative: treated as disabled → 1.0
+		{-1, 1.0},
+		// 0: disabled → 1.0
+		{0, 1.0},
+		// 1: short-lived (1–4) → 0.85
+		{1, 0.85},
+		// 4: still short-lived → 0.85
+		{4, 0.85},
+		// 5: standard range (5–10) → 1.0
+		{5, 1.0},
+		// 10: still standard → 1.0
+		{10, 1.0},
+		// 11: long-lived (> 10) → 1.15
+		{11, 1.15},
+		// 30: long-lived → 1.15
+		{30, 1.15},
+		// 100: long-lived → 1.15 (no upper cap beyond the 1.15 ceiling)
+		{100, 1.15},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run("", func(t *testing.T) {
+			got := DataLifetimeMultiplier(tt.years)
+			if got != tt.want {
+				t.Errorf("DataLifetimeMultiplier(%d) = %v, want %v", tt.years, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestQRS_LifetimeMultiplier_ZeroYearsIsNeutral ensures years=0 (unknown/disabled)
+// produces exactly the same result as the plain CalculateQRS.
+func TestQRS_LifetimeMultiplier_ZeroYearsIsNeutral(t *testing.T) {
+	ff := []findings.UnifiedFinding{
+		{Algorithm: &findings.Algorithm{Name: "RSA-2048"}, QuantumRisk: findings.QRVulnerable, Severity: findings.SevCritical},
+		{Algorithm: &findings.Algorithm{Name: "AES-128"}, QuantumRisk: findings.QRWeakened, Severity: findings.SevLow},
+	}
+	base := CalculateQRS(ff)
+	withZero := CalculateQRSWithLifetime(ff, DataLifetimeMultiplier(0))
+	if base != withZero {
+		t.Errorf("years=0 should be identical to base: base=%+v, withLifetime=%+v", base, withZero)
+	}
+}
+
+// TestQRS_LifetimeMultiplier_OneYearIsShortLived verifies years=1 falls in the
+// short-lived tier (0.85) and produces a higher score than the base.
+func TestQRS_LifetimeMultiplier_OneYearIsShortLived(t *testing.T) {
+	ff := make([]findings.UnifiedFinding, 10)
+	for i := range ff {
+		ff[i] = findings.UnifiedFinding{
+			Algorithm:   &findings.Algorithm{Name: "RSA-2048"},
+			QuantumRisk: findings.QRVulnerable,
+			Severity:    findings.SevCritical,
+		}
+	}
+	base := CalculateQRS(ff) // 100 - 20 = 80
+	withOne := CalculateQRSWithLifetime(ff, DataLifetimeMultiplier(1))
+	if withOne.Score <= base.Score {
+		t.Errorf("years=1 (short-lived) score=%d should be > base score=%d", withOne.Score, base.Score)
+	}
+}
+
+// TestQRS_LifetimeMultiplier_100Years verifies very long retention still caps at 1.15.
+func TestQRS_LifetimeMultiplier_100Years(t *testing.T) {
+	ff := make([]findings.UnifiedFinding, 5)
+	for i := range ff {
+		ff[i] = findings.UnifiedFinding{
+			Algorithm:   &findings.Algorithm{Name: "RSA-2048"},
+			QuantumRisk: findings.QRVulnerable,
+			Severity:    findings.SevCritical,
+		}
+	}
+	// 100-year data has same multiplier as 30-year: 1.15
+	with100 := CalculateQRSWithLifetime(ff, DataLifetimeMultiplier(100))
+	with30 := CalculateQRSWithLifetime(ff, DataLifetimeMultiplier(30))
+	if with100 != with30 {
+		t.Errorf("years=100 and years=30 should produce identical scores (both → 1.15), got %d vs %d",
+			with100.Score, with30.Score)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 6. Grade thresholds — exact boundary values
+// ---------------------------------------------------------------------------
+
+// TestScoreToGrade_ExactBoundaries verifies the grade assigned at each boundary
+// and at the value just below it (boundary-1).
+func TestScoreToGrade_ExactBoundaries(t *testing.T) {
+	tests := []struct {
+		score int
+		grade string
+	}{
+		// A+ boundary
+		{95, "A+"},
+		{94, "A"},  // one below A+ threshold
+		// A boundary
+		{85, "A"},
+		{84, "B"},  // one below A threshold
+		// B boundary
+		{70, "B"},
+		{69, "C"},  // one below B threshold
+		// C boundary
+		{50, "C"},
+		{49, "D"},  // one below C threshold
+		// D boundary
+		{30, "D"},
+		{29, "F"},  // one below D threshold
+		// Extremes
+		{100, "A+"},
+		{0, "F"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run("", func(t *testing.T) {
+			got := scoreToGrade(tt.score)
+			if got != tt.grade {
+				t.Errorf("scoreToGrade(%d) = %q, want %q", tt.score, got, tt.grade)
+			}
+		})
+	}
+}
+
+// TestQRS_GradeBoundaryViaFindings verifies grade transitions by constructing
+// finding sets whose exact QRS score lands at the threshold values using
+// non-corroborated medium-severity findings (penalty = 1.0 each).
+//
+//   n medium-vulnerable → score = 100 - n
+//   n=5  → 95 → A+
+//   n=6  → 94 → A   (crosses 95 boundary)
+//   n=15 → 85 → A
+//   n=16 → 84 → B   (crosses 85 boundary)
+//   n=30 → 70 → B
+//   n=31 → 69 → C   (crosses 70 boundary)
+//   n=50 → 50 → C
+//   n=51 → 49 → D   (crosses 50 boundary)
+//   n=70 → 30 → D
+//   n=71 → 29 → F   (crosses 30 boundary)
+func TestQRS_GradeBoundaryViaFindings(t *testing.T) {
+	tests := []struct {
+		n         int
+		wantScore int
+		wantGrade string
+	}{
+		{5, 95, "A+"},
+		{6, 94, "A"},
+		{15, 85, "A"},
+		{16, 84, "B"},
+		{30, 70, "B"},
+		{31, 69, "C"},
+		{50, 50, "C"},
+		{51, 49, "D"},
+		{70, 30, "D"},
+		{71, 29, "F"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run("", func(t *testing.T) {
+			ff := make([]findings.UnifiedFinding, tt.n)
+			for i := range ff {
+				ff[i] = findings.UnifiedFinding{
+					Algorithm:   &findings.Algorithm{Name: "RSA-2048"},
+					QuantumRisk: findings.QRVulnerable,
+					Severity:    findings.SevMedium,
+				}
+			}
+			qrs := CalculateQRS(ff)
+			if qrs.Score != tt.wantScore {
+				t.Errorf("n=%d: Score = %d, want %d", tt.n, qrs.Score, tt.wantScore)
+			}
+			if qrs.Grade != tt.wantGrade {
+				t.Errorf("n=%d: Grade = %q, want %q (score=%d)", tt.n, qrs.Grade, tt.wantGrade, qrs.Score)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 7. HNDL — key-exchange vs signature
+// ---------------------------------------------------------------------------
+
+// TestHNDL_KeyExchangeImmediate_AllKnownFamilies checks every known key-exchange
+// family returns HNDLImmediate.
+func TestHNDL_KeyExchangeImmediate_AllKnownFamilies(t *testing.T) {
+	cases := []struct {
+		algName   string
+		primitive string
+	}{
+		{"ECDH", "key-agree"},
+		{"ECDHE", "key-agree"},
+		{"X25519", "key-exchange"},
+		{"X448", "key-exchange"},
+		{"DH", "key-agree"},
+		{"FFDH", "key-agree"},
+		{"RSA", "kem"},
+		{"RSAES-OAEP", "pke"},
+		{"RSAES-PKCS1", "pke"},
+		{"MQV", "key-agree"},
+		{"ECMQV", "key-agree"},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.algName, func(t *testing.T) {
+			got := ClassifyAlgorithm(c.algName, c.primitive, 0)
+			if got.HNDLRisk != HNDLImmediate {
+				t.Errorf("%q/%q HNDLRisk = %q, want %q",
+					c.algName, c.primitive, got.HNDLRisk, HNDLImmediate)
+			}
+		})
+	}
+}
+
+// TestHNDL_SignatureDeferred_AllKnownFamilies checks every known signature family
+// returns HNDLDeferred when given the "signature" primitive.
+func TestHNDL_SignatureDeferred_AllKnownFamilies(t *testing.T) {
+	cases := []struct {
+		algName string
+	}{
+		{"ECDSA"}, {"EdDSA"}, {"Ed25519"}, {"Ed448"},
+		{"RSA"}, {"DSA"}, {"KCDSA"}, {"EC-KCDSA"},
+		{"RSASSA-PKCS1"}, {"RSASSA-PSS"},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.algName, func(t *testing.T) {
+			got := ClassifyAlgorithm(c.algName, "signature", 0)
+			if got.HNDLRisk != HNDLDeferred {
+				t.Errorf("%q with 'signature' primitive HNDLRisk = %q, want %q",
+					c.algName, got.HNDLRisk, HNDLDeferred)
+			}
+		})
+	}
+}
+
+// TestHNDL_PQCSafeAlgorithmsHaveNoHNDL verifies all safe algorithms carry no HNDL tag.
+func TestHNDL_PQCSafeAlgorithmsHaveNoHNDL(t *testing.T) {
+	safeAlgs := []struct {
+		algName   string
+		primitive string
+	}{
+		{"ML-KEM-768", "kem"},
+		{"ML-DSA-65", "signature"},
+		{"SLH-DSA-SHA2-128f", "signature"},
+		{"SMAUG-T-128", "kem"},
+		{"HAETAE-3", "signature"},
+		{"AIMer-128f", "signature"},
+		{"NTRU+-576", "kem"},
+		{"HQC-128", "kem"},
+		{"XMSS", "signature"},
+		{"LMS", "signature"},
+	}
+
+	for _, alg := range safeAlgs {
+		alg := alg
+		t.Run(alg.algName, func(t *testing.T) {
+			got := ClassifyAlgorithm(alg.algName, alg.primitive, 0)
+			if got.HNDLRisk != "" {
+				t.Errorf("PQC-safe %q HNDLRisk = %q, want empty", alg.algName, got.HNDLRisk)
+			}
+			if got.Risk != RiskSafe {
+				t.Errorf("PQC-safe %q Risk = %q, want RiskSafe", alg.algName, got.Risk)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 8. LookupTargetForKeySize — unusual key sizes
+// ---------------------------------------------------------------------------
+
+// TestLookupTargetForKeySize_UnusualSizes checks that unusual RSA key sizes
+// (0, negative, 1023, 2049) fall into the expected tier without panicking.
+func TestLookupTargetForKeySize_UnusualSizes(t *testing.T) {
+	tests := []struct {
+		name    string
+		keySize int
+		wantAlg string
+	}{
+		// All below 3072 → ML-DSA-44
+		{"keySize=0", 0, "ML-DSA-44"},
+		{"keySize=-1", -1, "ML-DSA-44"},
+		{"keySize=1023", 1023, "ML-DSA-44"},
+		{"keySize=2049", 2049, "ML-DSA-44"},
+		// At/above 3072 → ML-DSA-65
+		{"keySize=3072", 3072, "ML-DSA-65"},
+		// At/above 4096 → ML-DSA-87
+		{"keySize=4096", 4096, "ML-DSA-87"},
+		{"keySize=8192", 8192, "ML-DSA-87"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("LookupTargetForKeySize panicked: keySize=%d: %v", tt.keySize, r)
+				}
+			}()
+			got := LookupTargetForKeySize("RSA", tt.keySize)
+			if got.Algorithm != tt.wantAlg {
+				t.Errorf("LookupTargetForKeySize(RSA, %d).Algorithm = %q, want %q",
+					tt.keySize, got.Algorithm, tt.wantAlg)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 9. CalculateQRSFull — combined lifetime + protocol + blast-radius
+// ---------------------------------------------------------------------------
+
+// TestCalculateQRSFull_NilImpactEqualsWithLifetime verifies that when impactResult
+// is nil, CalculateQRSFull produces the same result as CalculateQRSWithLifetime.
+func TestCalculateQRSFull_NilImpactEqualsWithLifetime(t *testing.T) {
+	ff := make([]findings.UnifiedFinding, 5)
+	for i := range ff {
+		ff[i] = findings.UnifiedFinding{
+			Algorithm:   &findings.Algorithm{Name: "RSA-2048"},
+			QuantumRisk: findings.QRVulnerable,
+			Severity:    findings.SevCritical,
+		}
+	}
+	mult := DataLifetimeMultiplier(20) // 1.15
+	want := CalculateQRSWithLifetime(ff, mult)
+	got := CalculateQRSFull(ff, nil, mult)
+	if got != want {
+		t.Errorf("nil impact: CalculateQRSFull=%+v, want=%+v (same as WithLifetime)", got, want)
+	}
+}
+
+// TestCalculateQRSFull_EmptyFindings verifies the base case for CalculateQRSFull.
+func TestCalculateQRSFull_EmptyFindings(t *testing.T) {
+	qrs := CalculateQRSFull(nil, nil, 1.0)
+	if qrs.Score != 100 {
+		t.Errorf("empty findings: Score = %d, want 100", qrs.Score)
+	}
+	if qrs.Grade != "A+" {
+		t.Errorf("empty findings: Grade = %q, want A+", qrs.Grade)
+	}
+}

--- a/pkg/suppress/edge_cases_test.go
+++ b/pkg/suppress/edge_cases_test.go
@@ -155,3 +155,208 @@ func TestIsSuppressed_IgnorePatternTakesPrecedence(t *testing.T) {
 		t.Errorf("expected 1 ignore suppression, got %d", stats.SuppressedByIgnore)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// NEW edge cases below (not duplicated from existing tests)
+// ---------------------------------------------------------------------------
+
+// TestScanContent_NoAlgorithmList_SuppressesAll verifies that an oqs:ignore
+// directive with no algorithm list (empty brackets omitted) suppresses any
+// algorithm on that line — i.e., Algorithms slice is nil/empty.
+func TestScanContent_NoAlgorithmList_SuppressesAllAlgorithms(t *testing.T) {
+	content := `// oqs:ignore
+rsa.GenerateKey(rand.Reader, 2048)
+`
+	s := &Scanner{suppressMap: make(map[string][]Suppression)}
+	sups := s.scanContent("main.go", content)
+	if len(sups) != 1 {
+		t.Fatalf("expected 1 suppression, got %d", len(sups))
+	}
+	if len(sups[0].Algorithms) != 0 {
+		t.Errorf("no algorithm list should produce empty Algorithms (suppress all), got %v", sups[0].Algorithms)
+	}
+}
+
+// TestIsSuppressed_NoAlgorithmList_SuppressesAnyAlgorithm verifies that an
+// empty Algorithms list in a suppression directive matches any algorithm string.
+func TestIsSuppressed_NoAlgorithmList_MatchesAny(t *testing.T) {
+	dir := t.TempDir()
+	content := `// oqs:ignore
+key, _ := rsa.GenerateKey(rand.Reader, 2048)
+`
+	fp := filepath.Join(dir, "main.go")
+	os.WriteFile(fp, []byte(content), 0644)
+
+	s, _ := NewScanner(dir)
+
+	// Any algorithm on line 2 should be suppressed
+	for _, alg := range []string{"RSA", "AES", "MD5", "ECDH"} {
+		if !s.IsSuppressed(fp, 2, alg) {
+			t.Errorf("algorithm %q should be suppressed by no-list directive", alg)
+		}
+	}
+}
+
+// TestScanContent_NarrowAlgorithmList_DoesNotSuppressOthers verifies that a
+// directive with a specific algorithm list only suppresses listed algorithms.
+func TestScanContent_NarrowAlgorithmList_Narrow(t *testing.T) {
+	content := `// oqs:ignore[RSA]
+key := genKey()
+md5 := doHash()
+`
+	s := &Scanner{suppressMap: make(map[string][]Suppression)}
+	sups := s.scanContent("main.go", content)
+	if len(sups) != 1 {
+		t.Fatalf("expected 1 suppression, got %d", len(sups))
+	}
+	if len(sups[0].Algorithms) != 1 || sups[0].Algorithms[0] != "RSA" {
+		t.Errorf("expected [RSA], got %v", sups[0].Algorithms)
+	}
+}
+
+// TestMatchesIgnorePattern_DoubleStarGlob verifies the ** recursive glob
+// expansion only matches files actually matching the suffix pattern.
+// Regression: earlier behavior used strings.HasPrefix with an empty prefix
+// extracted from "**/..." and thus matched every path.
+func TestMatchesIgnorePattern_DoubleStarGlob(t *testing.T) {
+	dir := t.TempDir()
+	ignoreContent := "**/*.test.go\n"
+	os.WriteFile(filepath.Join(dir, ".oqs-ignore"), []byte(ignoreContent), 0644)
+
+	s, _ := NewScanner(dir)
+
+	shouldMatch := []string{
+		filepath.Join(dir, "pkg/crypto/aes.test.go"),
+		filepath.Join(dir, "auth.test.go"),
+		filepath.Join(dir, "a/b/c/d/deep.test.go"),
+	}
+	for _, p := range shouldMatch {
+		if !s.MatchesIgnorePattern(p) {
+			t.Errorf("MatchesIgnorePattern(%q) = false, want true", p)
+		}
+	}
+
+	shouldNotMatch := []string{
+		filepath.Join(dir, "pkg/crypto/aes.go"),
+		filepath.Join(dir, "main.go"),
+		filepath.Join(dir, "notes.md"),
+	}
+	for _, p := range shouldNotMatch {
+		if s.MatchesIgnorePattern(p) {
+			t.Errorf("MatchesIgnorePattern(%q) = true, want false", p)
+		}
+	}
+}
+
+// TestMatchesIgnorePattern_DoubleStarMiddle verifies ** in the middle of a
+// pattern matches zero or more intermediate path segments.
+func TestMatchesIgnorePattern_DoubleStarMiddle(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".oqs-ignore"), []byte("vendor/**/cache/*.go\n"), 0644)
+	s, _ := NewScanner(dir)
+
+	shouldMatch := []string{
+		filepath.Join(dir, "vendor/cache/x.go"),
+		filepath.Join(dir, "vendor/a/cache/x.go"),
+		filepath.Join(dir, "vendor/a/b/c/cache/x.go"),
+	}
+	for _, p := range shouldMatch {
+		if !s.MatchesIgnorePattern(p) {
+			t.Errorf("MatchesIgnorePattern(%q) = false, want true", p)
+		}
+	}
+	if s.MatchesIgnorePattern(filepath.Join(dir, "vendor/a/b/other/x.go")) {
+		t.Error("non-cache path should not match")
+	}
+}
+
+// TestScanContent_HashStyleComment_WithAlgorithmList verifies Python/YAML-style
+// hash (#) comment suppression with an algorithm list.
+func TestScanContent_HashStyleComment_WithAlgorithmList(t *testing.T) {
+	content := `# oqs:ignore[AES-128]
+cipher = AES128.new(key)
+`
+	s := &Scanner{suppressMap: make(map[string][]Suppression)}
+	sups := s.scanContent("config.py", content)
+	if len(sups) != 1 {
+		t.Fatalf("expected 1 suppression, got %d", len(sups))
+	}
+	if len(sups[0].Algorithms) != 1 || sups[0].Algorithms[0] != "AES-128" {
+		t.Errorf("expected [AES-128], got %v", sups[0].Algorithms)
+	}
+}
+
+// TestScanContent_BlockComment_WithAlgorithmAndReason verifies C-style block
+// comment /* */ with both an algorithm list and a reason.
+func TestScanContent_BlockComment_WithAlgorithmAndReason(t *testing.T) {
+	content := `/* oqs:ignore[DES] — legacy HSM constraint */
+des_encrypt(data, key);
+`
+	s := &Scanner{suppressMap: make(map[string][]Suppression)}
+	sups := s.scanContent("legacy.c", content)
+	if len(sups) != 1 {
+		t.Fatalf("expected 1 suppression, got %d", len(sups))
+	}
+	if len(sups[0].Algorithms) != 1 || sups[0].Algorithms[0] != "DES" {
+		t.Errorf("expected [DES], got %v", sups[0].Algorithms)
+	}
+	if sups[0].Reason == "" {
+		t.Error("expected reason to be parsed from block comment")
+	}
+}
+
+// TestScanContent_XMLComment_WithAlgorithmList verifies HTML/XML comment
+// <!-- --> with an algorithm list parses correctly.
+func TestScanContent_XMLComment_WithAlgorithmList(t *testing.T) {
+	content := `<config>
+  <cipher>DES</cipher> <!-- oqs:ignore[DES] -->
+</config>
+`
+	s := &Scanner{suppressMap: make(map[string][]Suppression)}
+	sups := s.scanContent("config.xml", content)
+	if len(sups) != 1 {
+		t.Fatalf("expected 1 XML comment suppression with algorithm list, got %d", len(sups))
+	}
+	if len(sups[0].Algorithms) != 1 || sups[0].Algorithms[0] != "DES" {
+		t.Errorf("expected [DES] from XML comment, got %v", sups[0].Algorithms)
+	}
+}
+
+// TestScanContent_DirectiveOnLastLineNoNewline verifies a directive on the
+// very last line (no trailing newline) is still parsed.
+func TestScanContent_DirectiveAtEOF_NoNewline(t *testing.T) {
+	content := "cipher := aes128() // oqs:ignore[AES-128]"
+	s := &Scanner{suppressMap: make(map[string][]Suppression)}
+	sups := s.scanContent("main.go", content)
+	if len(sups) != 1 {
+		t.Fatalf("expected 1 suppression at EOF without newline, got %d", len(sups))
+	}
+	if len(sups[0].Algorithms) != 1 || sups[0].Algorithms[0] != "AES-128" {
+		t.Errorf("expected [AES-128], got %v", sups[0].Algorithms)
+	}
+}
+
+// TestIsSuppressed_BothLineAndFileMatch_CountsAsIgnore verifies that when a
+// finding matches BOTH the .oqs-ignore pattern AND an inline directive, the
+// suppression counter uses SuppressedByIgnore (pattern check runs first).
+func TestIsSuppressed_FileAndInlineMatch_IgnoreCountsFirst(t *testing.T) {
+	dir := t.TempDir()
+	ignoreContent := "testdata/**\n"
+	os.WriteFile(filepath.Join(dir, ".oqs-ignore"), []byte(ignoreContent), 0644)
+
+	testDir := filepath.Join(dir, "testdata")
+	os.MkdirAll(testDir, 0755)
+	fp := filepath.Join(testDir, "sample.go")
+	// File also has an inline directive
+	os.WriteFile(fp, []byte("// oqs:ignore\nrsa.GenerateKey()\n"), 0644)
+
+	s, _ := NewScanner(dir)
+	if !s.IsSuppressed(fp, 2, "RSA") {
+		t.Error("should be suppressed (both pattern and inline directive match)")
+	}
+	stats := s.Stats()
+	// Pattern takes precedence — should count as ignore, not inline
+	if stats.SuppressedByIgnore != 1 {
+		t.Errorf("expected 1 SuppressedByIgnore (pattern runs first), got %d", stats.SuppressedByIgnore)
+	}
+}

--- a/pkg/suppress/suppress.go
+++ b/pkg/suppress/suppress.go
@@ -216,17 +216,8 @@ func (s *Scanner) MatchesIgnorePattern(filePath string) bool {
 
 		// Handle ** recursive patterns
 		if strings.Contains(pattern, "**") {
-			prefix := strings.Split(pattern, "**")[0]
-			if strings.HasPrefix(relPath, prefix) {
+			if matchDoubleStar(pattern, relPath) {
 				return true
-			}
-			// Also check path components
-			parts := strings.Split(relPath, "/")
-			for i := range parts {
-				suffix := strings.Join(parts[i:], "/")
-				if strings.HasPrefix(suffix, prefix) {
-					return true
-				}
 			}
 			continue
 		}
@@ -252,6 +243,47 @@ func (s *Scanner) MatchesIgnorePattern(filePath string) bool {
 	}
 
 	return false
+}
+
+// matchDoubleStar reports whether path matches a glob pattern that may contain
+// "**" segments. "**" matches zero or more path segments; other segments are
+// matched with filepath.Match (so "*" matches any single-segment substring).
+// Both pattern and path use forward slashes.
+func matchDoubleStar(pattern, path string) bool {
+	return matchSegments(strings.Split(pattern, "/"), strings.Split(path, "/"))
+}
+
+func matchSegments(pat, path []string) bool {
+	for len(pat) > 0 {
+		if pat[0] == "**" {
+			// Collapse consecutive ** to one.
+			for len(pat) > 1 && pat[1] == "**" {
+				pat = pat[1:]
+			}
+			// ** at end matches any remaining path (including empty).
+			if len(pat) == 1 {
+				return true
+			}
+			// Try matching the rest of pattern against every suffix of path.
+			rest := pat[1:]
+			for i := 0; i <= len(path); i++ {
+				if matchSegments(rest, path[i:]) {
+					return true
+				}
+			}
+			return false
+		}
+		if len(path) == 0 {
+			return false
+		}
+		matched, err := filepath.Match(pat[0], path[0])
+		if err != nil || !matched {
+			return false
+		}
+		pat = pat[1:]
+		path = path[1:]
+	}
+	return len(path) == 0
 }
 
 // Stats returns suppression statistics.


### PR DESCRIPTION
## Summary

Fixes seven bugs uncovered by a parallel test-sweep across 11 packages. Each fix has a regression test in a newly added `*_test.go` file (~400 new test cases total).

### High-severity

- **`suppress`: `**` glob matcher was always-true.** Any `.oqs-ignore` pattern beginning with `**` silently suppressed every finding. Replaced the broken prefix check with a proper segment-based recursive matcher.
- **`orchestrator`: concurrent `Scan()` data race.** `normalizeFindings` mutated `UnifiedFinding.Algorithm.Name` in place on engine-owned slices; engines that cache results raced under `-race`. Added `UnifiedFinding.Clone()` and deep-copy at scan-pipeline merge points.
- **`tlsprobe`: multicast/broadcast not blocked by `--tls-strict`.** `224.0.0.0/4`, `255.255.255.255/32`, and `ff00::/8` were absent from `privateRanges`. A hostile DNS response could bypass the strict guard.

### Medium-severity

- **`output/sarif`: `sanitizeID` left XML-unsafe chars.** Rule IDs like `<SCRIPT>ALERT1<-SCRIPT>` violated SARIF 2.1.0 §3.49.3 and exposed HTML-renderers to injection. Now strips `< > " ' &`.
- **`quantum`: whitespace-padded names fell through to `RiskUnknown`.** AST/grep engines can surface tokens like `" RSA "`; the classifier now trims before lookup.
- **`migration`: extensionless config files emitted no snippet.** Debian/Ubuntu layouts like `/etc/nginx/sites-available/default` have no extension, so `langFromExt("")` returned early. Added path-prefix fallback.
- **`migration`: HAProxy signing snippet emitted nginx `ssl_certificate` directives.** HAProxy doesn't understand that syntax. Added a dedicated HAProxy case using `bind *:443 ssl crt`.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test -race -count=1 ./...` passes across all 45 packages
- [x] Each bug has a regression test that would fail on `main`
- [ ] CI green (GitHub Actions)