### PR TITLE
Sprint 0: Corrected HNDL scoring model (Mosca inequality + sector presets)

### DIFF
--- a/cmd/oqs-scanner/main.go
+++ b/cmd/oqs-scanner/main.go
@@ -442,7 +442,7 @@ Example with data lifetime adjustment for healthcare:
 			// Precedence: --data-lifetime-years (explicit) > --sector > default (10 years).
 			hndlShelfLife := dataLifetimeYears
 			if hndlShelfLife <= 0 && sector != "" {
-				hndlShelfLife = quantum.ShelfLifeForSector(sector)
+				hndlShelfLife = quantum.WarnOnUnknownSector(sector, os.Stderr)
 			}
 			if hndlShelfLife <= 0 {
 				hndlShelfLife = quantum.DefaultSectorShelfLifeYears

--- a/cmd/oqs-scanner/main.go
+++ b/cmd/oqs-scanner/main.go
@@ -363,6 +363,9 @@ Example with data lifetime adjustment for healthcare:
 			if dataLifetimeYears < 0 {
 				return fmt.Errorf("--data-lifetime-years must be a positive integer (got %d); set a value > 0 reflecting actual data retention (e.g. --data-lifetime-years 10), or omit the flag to use --sector preset or the 10-year default", dataLifetimeYears)
 			}
+			if cmd.Flags().Changed("data-lifetime-years") && dataLifetimeYears == 0 {
+				return fmt.Errorf("--data-lifetime-years 0 is not valid: no data has zero sensitivity in practice; set a positive value (e.g. --data-lifetime-years 10), or omit the flag to use --sector preset or the 10-year default")
+			}
 
 			absPath, err := filepath.Abs(targetPath)
 			if err != nil {
@@ -722,6 +725,9 @@ Example:
 			}
 			if dataLifetimeYears < 0 {
 				return fmt.Errorf("--data-lifetime-years must be a positive integer (got %d); set a value > 0 reflecting actual data retention (e.g. --data-lifetime-years 10), or omit the flag to use --sector preset or the 10-year default", dataLifetimeYears)
+			}
+			if cmd.Flags().Changed("data-lifetime-years") && dataLifetimeYears == 0 {
+				return fmt.Errorf("--data-lifetime-years 0 is not valid: no data has zero sensitivity in practice; set a positive value (e.g. --data-lifetime-years 10), or omit the flag to use --sector preset or the 10-year default")
 			}
 			if diffBase == "" {
 				return fmt.Errorf("--base is required (e.g. main, origin/main, a commit SHA)")

--- a/cmd/oqs-scanner/main.go
+++ b/cmd/oqs-scanner/main.go
@@ -341,11 +341,13 @@ func scanCmd() *cobra.Command {
 		complianceFlag    string
 		ciMode            string
 		webhookURL        string
-		dataLifetimeYears int
-		signCBOM          bool
-		tlsTargets        []string
-		tlsInsecure       bool
-		tlsStrict         bool
+		dataLifetimeYears    int
+		signCBOM             bool
+		tlsTargets           []string
+		tlsInsecure          bool
+		tlsStrict            bool
+		dataSensitivityYears int
+		sector               string
 	)
 
 	cmd := &cobra.Command{
@@ -429,6 +431,22 @@ Example with data lifetime adjustment for healthcare:
 			}
 			if !cmd.Flags().Changed("tls-strict") && cfg.TLS.Strict {
 				tlsStrict = true
+			}
+
+			// Resolve data sensitivity shelf-life for Mosca HNDL calculation.
+			// Precedence: --data-sensitivity-years > --sector > default (10 years).
+			hndlShelfLife := dataSensitivityYears
+			if hndlShelfLife <= 0 && sector != "" {
+				hndlShelfLife = quantum.ShelfLifeForSector(sector)
+			}
+			if hndlShelfLife <= 0 {
+				hndlShelfLife = quantum.DefaultSectorShelfLifeYears
+			}
+			if cmd.Flags().Changed("data-sensitivity-years") || sector != "" {
+				surplus := quantum.ComputeHNDLSurplus(hndlShelfLife, 0, 0)
+				level := quantum.HNDLLevelFromSurplus(surplus)
+				fmt.Fprintf(os.Stderr, "HNDL sensitivity: %d years (Mosca surplus: %+d, level: %s)\n",
+					hndlShelfLife, surplus, level)
 			}
 
 			orch := buildOrchestrator()
@@ -647,6 +665,19 @@ financial/banking=7, legal/contracts=10, web sessions/ephemeral=1.
 	cmd.Flags().StringSliceVar(&tlsTargets, "tls-targets", nil, "TLS endpoints to probe for quantum-vulnerable crypto (comma-separated host:port)")
 	cmd.Flags().BoolVar(&tlsInsecure, "tls-insecure", false, "Skip TLS certificate verification when probing (use for self-signed certs)")
 	cmd.Flags().BoolVar(&tlsStrict, "tls-strict", true, "Deny TLS probe connections to private/loopback IPs (use --tls-strict=false to allow)")
+
+	// HNDL Mosca inequality flags
+	cmd.Flags().IntVar(&dataSensitivityYears, "data-sensitivity-years", 0,
+		`Data shelf-life in years for the Mosca HNDL inequality calculation.
+Overrides --sector when both are set. Default: 10 years (or sector preset).
+Mosca inequality: surplus = (shelf_life + migration_lag) - time_to_CRQC
+  surplus > 2  → HNDL HIGH   (migrate now)
+  surplus 0..2 → HNDL MEDIUM (migration underway)
+  surplus < 0  → HNDL LOW    (data expires before CRQC)`)
+	cmd.Flags().StringVar(&sector, "sector", "",
+		`Industry sector for data sensitivity preset (case-insensitive).
+Presets (shelf-life): medical=30y, finance=7y, state=50y, infra=20y, code=5y, generic=10y.
+--data-sensitivity-years takes precedence if both flags are set.`)
 
 	return cmd
 }

--- a/cmd/oqs-scanner/main.go
+++ b/cmd/oqs-scanner/main.go
@@ -341,13 +341,12 @@ func scanCmd() *cobra.Command {
 		complianceFlag    string
 		ciMode            string
 		webhookURL        string
-		dataLifetimeYears    int
-		signCBOM             bool
-		tlsTargets           []string
-		tlsInsecure          bool
-		tlsStrict            bool
-		dataSensitivityYears int
-		sector               string
+		dataLifetimeYears int
+		signCBOM          bool
+		tlsTargets        []string
+		tlsInsecure       bool
+		tlsStrict         bool
+		sector            string
 	)
 
 	cmd := &cobra.Command{
@@ -362,7 +361,7 @@ Example with data lifetime adjustment for healthcare:
 				return fmt.Errorf("--path is required")
 			}
 			if dataLifetimeYears < 0 {
-				return fmt.Errorf("--data-lifetime-years must be >= 0 (got %d)", dataLifetimeYears)
+				return fmt.Errorf("--data-lifetime-years must be a positive integer (got %d); set a value > 0 reflecting actual data retention (e.g. --data-lifetime-years 10), or omit the flag to use --sector preset or the 10-year default", dataLifetimeYears)
 			}
 
 			absPath, err := filepath.Abs(targetPath)
@@ -433,16 +432,19 @@ Example with data lifetime adjustment for healthcare:
 				tlsStrict = true
 			}
 
-			// Resolve data sensitivity shelf-life for Mosca HNDL calculation.
-			// Precedence: --data-sensitivity-years > --sector > default (10 years).
-			hndlShelfLife := dataSensitivityYears
+			// Resolve HNDL shelf-life for Mosca inequality.
+			// --data-lifetime-years is the single source of truth for both QRS penalty
+			// multiplier and HNDL shelf life. --sector provides a preset when
+			// --data-lifetime-years is not explicitly set by the caller.
+			// Precedence: --data-lifetime-years (explicit) > --sector > default (10 years).
+			hndlShelfLife := dataLifetimeYears
 			if hndlShelfLife <= 0 && sector != "" {
 				hndlShelfLife = quantum.ShelfLifeForSector(sector)
 			}
 			if hndlShelfLife <= 0 {
 				hndlShelfLife = quantum.DefaultSectorShelfLifeYears
 			}
-			if cmd.Flags().Changed("data-sensitivity-years") || sector != "" {
+			if cmd.Flags().Changed("data-lifetime-years") || sector != "" {
 				surplus := quantum.ComputeHNDLSurplus(hndlShelfLife, 0, 0)
 				level := quantum.HNDLLevelFromSurplus(surplus)
 				fmt.Fprintf(os.Stderr, "HNDL sensitivity: %d years (Mosca surplus: %+d, level: %s)\n",
@@ -656,28 +658,23 @@ Example with data lifetime adjustment for healthcare:
 	cmd.Flags().StringVar(&webhookURL, "webhook-url", "", "POST scan results to this HTTPS URL on completion (JSON payload)")
 	cmd.Flags().BoolVar(&signCBOM, "sign-cbom", false, "Sign the CBOM output with an ephemeral Ed25519 key pair (only applies when --format cbom)")
 	cmd.Flags().IntVar(&dataLifetimeYears, "data-lifetime-years", 0,
-		`Expected data retention period in years. Adjusts HNDL urgency in QRS scoring.
-Industry guidelines: healthcare/medical=30, government/classified=25,
-financial/banking=7, legal/contracts=10, web sessions/ephemeral=1.
-0 = disabled (default). Values >10 amplify penalties, <5 reduce them.`)
+		`Expected data retention period in years. Used for both QRS penalty adjustment and
+the Mosca HNDL inequality calculation (surplus = shelf_life + migration_lag - time_to_CRQC).
+Industry guidelines: medical=30, state=50, infra=20, finance=7, code=5, generic=10.
+0 = disabled (default; HNDL uses --sector preset or 10y fallback for Mosca).
+Values >10 amplify QRS penalties, <5 reduce them. Must be > 0 if explicitly set.
+Overrides --sector when both are provided.`)
 
 	// TLS probe flags
 	cmd.Flags().StringSliceVar(&tlsTargets, "tls-targets", nil, "TLS endpoints to probe for quantum-vulnerable crypto (comma-separated host:port)")
 	cmd.Flags().BoolVar(&tlsInsecure, "tls-insecure", false, "Skip TLS certificate verification when probing (use for self-signed certs)")
 	cmd.Flags().BoolVar(&tlsStrict, "tls-strict", true, "Deny TLS probe connections to private/loopback IPs (use --tls-strict=false to allow)")
 
-	// HNDL Mosca inequality flags
-	cmd.Flags().IntVar(&dataSensitivityYears, "data-sensitivity-years", 0,
-		`Data shelf-life in years for the Mosca HNDL inequality calculation.
-Overrides --sector when both are set. Default: 10 years (or sector preset).
-Mosca inequality: surplus = (shelf_life + migration_lag) - time_to_CRQC
-  surplus > 2  → HNDL HIGH   (migrate now)
-  surplus 0..2 → HNDL MEDIUM (migration underway)
-  surplus < 0  → HNDL LOW    (data expires before CRQC)`)
+	// HNDL Mosca sector preset flag
 	cmd.Flags().StringVar(&sector, "sector", "",
-		`Industry sector for data sensitivity preset (case-insensitive).
-Presets (shelf-life): medical=30y, finance=7y, state=50y, infra=20y, code=5y, generic=10y.
---data-sensitivity-years takes precedence if both flags are set.`)
+		`Industry sector preset for Mosca HNDL shelf-life (case-insensitive).
+Presets: medical=30y, finance=7y, state=50y, infra=20y, code=5y, generic=10y.
+--data-lifetime-years takes precedence when both are set.`)
 
 	return cmd
 }
@@ -724,7 +721,7 @@ Example:
 				return fmt.Errorf("--path is required")
 			}
 			if dataLifetimeYears < 0 {
-				return fmt.Errorf("--data-lifetime-years must be >= 0 (got %d)", dataLifetimeYears)
+				return fmt.Errorf("--data-lifetime-years must be a positive integer (got %d); set a value > 0 reflecting actual data retention (e.g. --data-lifetime-years 10), or omit the flag to use --sector preset or the 10-year default", dataLifetimeYears)
 			}
 			if diffBase == "" {
 				return fmt.Errorf("--base is required (e.g. main, origin/main, a commit SHA)")

--- a/cmd/oqs-scanner/scan_fuzz_test.go
+++ b/cmd/oqs-scanner/scan_fuzz_test.go
@@ -1,0 +1,161 @@
+package main
+
+// scan_fuzz_test.go — fuzz tests for the two main CLI inputs that feed the
+// Mosca HNDL inequality: sector name and data-lifetime-years.
+//
+// Run in short mode (default in CI):
+//   go test ./cmd/oqs-scanner/ -run='^$' -fuzz=FuzzSector     -fuzztime=10s
+//   go test ./cmd/oqs-scanner/ -run='^$' -fuzz=FuzzDataLifetime -fuzztime=10s
+//
+// Run extended to improve corpus:
+//   go test ./cmd/oqs-scanner/ -run='^$' -fuzz=FuzzSector      -fuzztime=60s
+//   go test ./cmd/oqs-scanner/ -run='^$' -fuzz=FuzzDataLifetime -fuzztime=60s
+//
+// Invariants under fuzz:
+//   FuzzSector:       never panics; returns > 0 years; unknown sector writes a
+//                     WARNING containing valid sector names to the writer.
+//   FuzzDataLifetime: never panics; invalid values produce the same errors as
+//                     the CLI validation path; valid values produce a non-negative
+//                     Mosca surplus.
+
+import (
+	"bytes"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/quantum"
+)
+
+// FuzzSector verifies that WarnOnUnknownSector never panics for arbitrary string
+// input and that it consistently falls back to the generic default for unrecognised
+// sectors. The warning output for unknown sectors must list valid sector names.
+func FuzzSector(f *testing.F) {
+	// Seed corpus: known good sectors, edge cases, and common injection patterns.
+	f.Add("medical")
+	f.Add("finance")
+	f.Add("state")
+	f.Add("infra")
+	f.Add("code")
+	f.Add("generic")
+	f.Add("")
+	f.Add("MEDICAL")
+	f.Add("Medical")
+	f.Add("unicorn")
+	f.Add("aerospace")
+	f.Add("retail")
+	f.Add("../../../etc/passwd")
+	f.Add("'; DROP TABLE sectors; --")
+	f.Add(strings.Repeat("a", 1024))
+	f.Add("\x00\x01\xFF")
+	f.Add("медицина") // Cyrillic
+
+	f.Fuzz(func(t *testing.T, sector string) {
+		var buf bytes.Buffer
+
+		// Must not panic.
+		result := quantum.WarnOnUnknownSector(sector, &buf)
+
+		// Must always return a positive shelf-life.
+		if result <= 0 {
+			t.Errorf("WarnOnUnknownSector(%q) returned %d, want > 0", sector, result)
+		}
+
+		// For a known sector (case-insensitive), no warning must be written.
+		knownSectors := quantum.SectorShelfLife
+		isKnown := false
+		normalised := strings.ToLower(sector)
+		if _, ok := knownSectors[normalised]; ok {
+			isKnown = true
+		}
+
+		warning := buf.String()
+		if isKnown {
+			if warning != "" {
+				t.Errorf("WarnOnUnknownSector(%q): known sector wrote unexpected output %q", sector, warning)
+			}
+			if result != knownSectors[normalised] {
+				t.Errorf("WarnOnUnknownSector(%q) = %d, want %d", sector, result, knownSectors[normalised])
+			}
+		} else if sector != "" {
+			// Unknown, non-empty: must warn.
+			if !strings.Contains(warning, "WARNING") {
+				t.Errorf("WarnOnUnknownSector(%q): missing WARNING prefix, got %q", sector, warning)
+			}
+			// Warning must list valid sector names so user can correct typos.
+			for name := range knownSectors {
+				if !strings.Contains(warning, name) {
+					t.Errorf("WarnOnUnknownSector(%q): warning missing valid sector %q, got %q",
+						sector, name, warning)
+				}
+			}
+			// Fallback must be the default.
+			if result != quantum.DefaultSectorShelfLifeYears {
+				t.Errorf("WarnOnUnknownSector(%q) = %d, want default %d",
+					sector, result, quantum.DefaultSectorShelfLifeYears)
+			}
+		} else {
+			// Empty sector: no warning, default result.
+			if warning != "" {
+				t.Errorf("WarnOnUnknownSector(%q): empty sector wrote unexpected output %q", sector, warning)
+			}
+		}
+	})
+}
+
+// FuzzDataLifetime verifies that ComputeHNDLSurplus never panics for arbitrary
+// int64 inputs (truncated to int) and that the resulting surplus satisfies the
+// arithmetic identity: surplus = (shelfLife + lag) - crqc.
+//
+// This catches integer overflow, sign confusion, and off-by-one errors in the
+// Mosca formula that a fixed test table would not expose.
+func FuzzDataLifetime(f *testing.F) {
+	// Seed corpus: values at boundary conditions for the Mosca formula.
+	f.Add(int64(0))
+	f.Add(int64(1))
+	f.Add(int64(-1))
+	f.Add(int64(-5))
+	f.Add(int64(5))
+	f.Add(int64(10))
+	f.Add(int64(30))
+	f.Add(int64(50))
+	f.Add(int64(100))
+	f.Add(int64(math.MaxInt32 - 1))
+	f.Add(int64(math.MaxInt32))
+	f.Add(int64(math.MinInt32))
+	f.Add(int64(math.MaxInt64))
+	f.Add(int64(math.MinInt64))
+
+	f.Fuzz(func(t *testing.T, years int64) {
+		// Clamp to int range (ComputeHNDLSurplus takes int, not int64).
+		// Values outside [math.MinInt32, math.MaxInt32] are not valid CLI inputs
+		// and not what we're testing; skip them to avoid int overflow on 32-bit arches.
+		if years > math.MaxInt32 || years < math.MinInt32 {
+			return
+		}
+		shelfLife := int(years)
+
+		// Use explicit lag and crqc to make the arithmetic assertion deterministic.
+		const lag = 5
+		const crqc = 7
+
+		// Must not panic.
+		surplus := quantum.ComputeHNDLSurplus(shelfLife, lag, crqc)
+
+		// Arithmetic identity: surplus = (shelfLife + lag) - crqc.
+		want := (shelfLife + lag) - crqc
+		if surplus != want {
+			t.Errorf("ComputeHNDLSurplus(%d, %d, %d) = %d, want %d",
+				shelfLife, lag, crqc, surplus, want)
+		}
+
+		// Level mapping must never panic or return an unknown level.
+		level := quantum.HNDLLevelFromSurplus(surplus)
+		switch level {
+		case quantum.HNDLLevelLow, quantum.HNDLLevelMedium, quantum.HNDLLevelHigh:
+			// OK
+		default:
+			t.Errorf("HNDLLevelFromSurplus(%d) = %q: unexpected level", surplus, level)
+		}
+	})
+}

--- a/cmd/oqs-scanner/scan_s0_fixes_test.go
+++ b/cmd/oqs-scanner/scan_s0_fixes_test.go
@@ -1,0 +1,215 @@
+package main
+
+// scan_s0_fixes_test.go — regression bundle for Sprint 0 fix round F1-F4.
+//
+// Each test pin-points a specific fix and asserts the corrected behaviour:
+//
+//   F1: --data-sensitivity-years removed; passing it must produce an error.
+//   F2: --data-lifetime-years 0 is invalid (no data has zero sensitivity).
+//   F2: --data-lifetime-years -5 is invalid (negative retention makes no sense).
+//   F3: --sector unicorn warns to stderr, lists valid names, falls back to generic.
+//   F4: X25519-MLKEM-768 (hyphenated) is classified as PQ-safe / HNDL LOW.
+//
+// These tests must pass forever. Any future change that makes one of these
+// assertions fail has regressed a deliberate design decision from Sprint 0.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/quantum"
+)
+
+// TestS0F1_DataSensitivityYearsFlagRemoved verifies that --data-sensitivity-years
+// was removed (S0.F1). The old flag conflicted with --data-lifetime-years and was
+// silently ignored in some code paths. It is now gone.
+func TestS0F1_DataSensitivityYearsFlagRemoved(t *testing.T) {
+	cmd := scanCmd()
+
+	// The flag must not exist on the scan command.
+	f := cmd.Flags().Lookup("data-sensitivity-years")
+	if f != nil {
+		t.Errorf("--data-sensitivity-years still registered on scan command (S0.F1 regression): %+v", f)
+	}
+
+	// The flag must not exist on the diff command either (same flag set was shared).
+	diff := diffCmd()
+	f2 := diff.Flags().Lookup("data-sensitivity-years")
+	if f2 != nil {
+		t.Errorf("--data-sensitivity-years still registered on diff command (S0.F1 regression): %+v", f2)
+	}
+}
+
+// TestS0F1_DataLifetimeYearsFlagExists confirms that --data-lifetime-years is the
+// canonical replacement for the removed --data-sensitivity-years flag.
+func TestS0F1_DataLifetimeYearsFlagExists(t *testing.T) {
+	cmd := scanCmd()
+	f := cmd.Flags().Lookup("data-lifetime-years")
+	if f == nil {
+		t.Fatal("--data-lifetime-years missing from scan command (expected canonical HNDL flag)")
+	}
+	// Must be an int flag.
+	if f.Value.Type() != "int" {
+		t.Errorf("--data-lifetime-years type = %q, want \"int\"", f.Value.Type())
+	}
+}
+
+// TestS0F2_NegativeDataLifetimeRejected verifies that --data-lifetime-years with a
+// negative value is rejected before any scan execution (S0.F2). The error message
+// must include "positive integer" to guide the user.
+func TestS0F2_NegativeDataLifetimeRejected(t *testing.T) {
+	cases := []string{"-1", "-5", "-100"}
+	for _, v := range cases {
+		t.Run("lifetime_"+v, func(t *testing.T) {
+			root := rootCmd()
+			root.SetOut(new(bytes.Buffer))
+			root.SetErr(new(bytes.Buffer))
+			root.SetArgs([]string{"scan", "--path", ".", "--data-lifetime-years", v})
+			err := root.Execute()
+			if err == nil {
+				t.Errorf("--data-lifetime-years %s: expected error, got nil", v)
+				return
+			}
+			if !strings.Contains(err.Error(), "positive integer") {
+				t.Errorf("--data-lifetime-years %s: error %q should mention 'positive integer'", v, err.Error())
+			}
+		})
+	}
+}
+
+// TestS0F2_ZeroDataLifetimeExplicitlyRejected verifies that passing
+// --data-lifetime-years=0 explicitly is an error (S0.F2 decision: "no data has
+// zero sensitivity in practice"). The error message must explain why 0 is invalid.
+func TestS0F2_ZeroDataLifetimeExplicitlyRejected(t *testing.T) {
+	root := rootCmd()
+	root.SetOut(new(bytes.Buffer))
+	root.SetErr(new(bytes.Buffer))
+	root.SetArgs([]string{"scan", "--path", ".", "--data-lifetime-years", "0"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("--data-lifetime-years 0: expected error, got nil")
+	}
+	// The error must explain why 0 is invalid, not just say "invalid value".
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "not valid") && !strings.Contains(errMsg, "0") {
+		t.Errorf("--data-lifetime-years 0: error %q should indicate value is invalid", errMsg)
+	}
+	// Must suggest an alternative (e.g., "use --sector preset or the 10-year default").
+	if !strings.Contains(errMsg, "sector") && !strings.Contains(errMsg, "default") {
+		t.Errorf("--data-lifetime-years 0: error %q should suggest an alternative", errMsg)
+	}
+}
+
+// TestS0F2_OmittedDataLifetimeAccepted verifies that NOT passing --data-lifetime-years
+// (the default case) does not produce a validation error about the flag. This is the
+// most common use case and must not be accidentally broken.
+func TestS0F2_OmittedDataLifetimeAccepted(t *testing.T) {
+	cmd := scanCmd()
+	// The default value of data-lifetime-years must be 0 (disabled / not changed).
+	f := cmd.Flags().Lookup("data-lifetime-years")
+	if f == nil {
+		t.Fatal("--data-lifetime-years missing")
+	}
+	if f.DefValue != "0" {
+		t.Errorf("--data-lifetime-years default = %q, want \"0\" (omitted = use sector/default)", f.DefValue)
+	}
+}
+
+// TestS0F3_UnknownSectorWarnsWithValidNames verifies the sector warning path (S0.F3).
+// An unrecognised --sector value must:
+//   (a) write a WARNING to the writer
+//   (b) include all valid sector names in the warning
+//   (c) fall back to DefaultSectorShelfLifeYears (generic)
+func TestS0F3_UnknownSectorWarnsWithValidNames(t *testing.T) {
+	var buf bytes.Buffer
+	result := quantum.WarnOnUnknownSector("unicorn", &buf)
+
+	if result != quantum.DefaultSectorShelfLifeYears {
+		t.Errorf("WarnOnUnknownSector(\"unicorn\") = %d, want %d (generic fallback)",
+			result, quantum.DefaultSectorShelfLifeYears)
+	}
+
+	warning := buf.String()
+	if !strings.Contains(warning, "WARNING") {
+		t.Errorf("no WARNING prefix in output: %q", warning)
+	}
+	if !strings.Contains(warning, "unicorn") {
+		t.Errorf("warning should echo the unknown sector name, got: %q", warning)
+	}
+
+	// Every valid sector name must appear in the warning to help users fix typos.
+	for sector := range quantum.SectorShelfLife {
+		if !strings.Contains(warning, sector) {
+			t.Errorf("warning missing valid sector %q: %q", sector, warning)
+		}
+	}
+}
+
+// TestS0F3_KnownSectorsNoWarning verifies that known sector names (case-insensitive)
+// do not produce a warning. Accidentally warning on valid input would be noisy in CI.
+func TestS0F3_KnownSectorsNoWarning(t *testing.T) {
+	variants := map[string]string{
+		"lower":  "medical",
+		"upper":  "MEDICAL",
+		"mixed":  "Medical",
+		"finance": "finance",
+		"state":  "STATE",
+	}
+	for label, sector := range variants {
+		t.Run(label, func(t *testing.T) {
+			var buf bytes.Buffer
+			quantum.WarnOnUnknownSector(sector, &buf)
+			if buf.Len() != 0 {
+				t.Errorf("sector %q unexpectedly produced output: %q", sector, buf.String())
+			}
+		})
+	}
+}
+
+// TestS0F4_HyphenatedHybridKEMClassifiedAsPQSafe is the primary regression test
+// for S0.F4. Config-file parsers and some AST tokenisers emit "X25519-MLKEM-768"
+// (hyphens between components). Before F4, this was mis-classified as the classical
+// "X25519" key exchange (HNDLImmediate). After F4 it must be quantum-safe.
+func TestS0F4_HyphenatedHybridKEMClassifiedAsPQSafe(t *testing.T) {
+	forms := []struct {
+		name string
+		alg  string
+		prim string
+	}{
+		{"canonical", "X25519MLKEM768", "kem"},
+		{"hyphenated_kem", "X25519-MLKEM-768", "kem"},
+		{"hyphenated_kex", "X25519-MLKEM-768", "key-exchange"},
+		{"secp256r1_canonical", "SecP256r1MLKEM768", "kem"},
+		{"secp256r1_hyphenated", "SecP256r1-MLKEM-768", "kem"},
+	}
+	for _, tt := range forms {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			c := quantum.ClassifyAlgorithm(tt.alg, tt.prim, 0)
+
+			if c.Risk != quantum.RiskSafe {
+				t.Errorf("%q (%s): Risk = %q, want %q (S0.F4 regression: hyphenated form mis-classified as classical)",
+					tt.alg, tt.prim, c.Risk, quantum.RiskSafe)
+			}
+			if c.HNDLRisk != "" {
+				t.Errorf("%q (%s): HNDLRisk = %q, want \"\" (PQ-safe = no harvest risk = HNDL LOW)",
+					tt.alg, tt.prim, c.HNDLRisk)
+			}
+		})
+	}
+}
+
+// TestS0F4_BareX25519StillVulnerable ensures S0.F4's normalisation does NOT
+// accidentally make bare X25519 (classical key exchange) look PQ-safe. The
+// hyphen-stripping pass must only fire when the input actually contains hyphens.
+func TestS0F4_BareX25519StillVulnerable(t *testing.T) {
+	c := quantum.ClassifyAlgorithm("X25519", "key-exchange", 0)
+	if c.Risk != quantum.RiskVulnerable {
+		t.Errorf("X25519 (bare): Risk = %q, want %q (S0.F4 must not affect bare classical names)",
+			c.Risk, quantum.RiskVulnerable)
+	}
+	if c.HNDLRisk != quantum.HNDLImmediate {
+		t.Errorf("X25519 (bare): HNDLRisk = %q, want %q", c.HNDLRisk, quantum.HNDLImmediate)
+	}
+}

--- a/pkg/findings/unified.go
+++ b/pkg/findings/unified.go
@@ -95,7 +95,7 @@ type UnifiedFinding struct {
 	Severity       Severity     `json:"severity,omitempty"`
 	Recommendation string       `json:"recommendation,omitempty"`
 	DataFlowPath   []FlowStep   `json:"dataFlowPath,omitempty"`
-	HNDLRisk       string       `json:"hndlRisk,omitempty"`       // "immediate", "deferred", or "" (HNDL = Harvest Now, Decrypt Later)
+	HNDLRisk       string       `json:"hndlRisk,omitempty"`       // "immediate" (classical KEM), "deferred" (signature), or "" (PQC/symmetric/no risk). PFS/ECDHE does NOT lower this — see pkg/quantum classify.go.
 	Priority       string       `json:"priority,omitempty"`       // P1, P2, P3, P4
 	BlastRadius    int          `json:"blastRadius,omitempty"`    // 0-100, copied from impact analysis
 	TestFile        bool         `json:"testFile,omitempty"`        // true when finding is from a test file

--- a/pkg/output/hndl_format_test.go
+++ b/pkg/output/hndl_format_test.go
@@ -1,0 +1,304 @@
+package output
+
+// hndl_format_test.go — validates that all output formats (JSON, SARIF, CycloneDX CBOM)
+// correctly surface the HNDL risk and quantum risk fields for each finding type.
+//
+// Three findings are used throughout:
+//  1. RSA-2048 (kem)        — HNDLRisk = "immediate", QuantumRisk = quantum-vulnerable
+//  2. ECDHE-X25519 (kex)    — HNDLRisk = "immediate", QuantumRisk = quantum-vulnerable
+//  3. X25519MLKEM768 (kem)  — HNDLRisk = ""           QuantumRisk = quantum-safe
+//
+// Cross-check invariant: a finding with HNDLRisk != "" must have QuantumRisk
+// "quantum-vulnerable" (or similar non-safe); a finding with QuantumRisk
+// "quantum-safe" must have HNDLRisk == "".
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/findings"
+)
+
+// testFindings returns the 3 canonical findings used in format tests.
+func testFindings() []findings.UnifiedFinding {
+	return []findings.UnifiedFinding{
+		{
+			Location:    findings.Location{File: "/src/rsa.go", Line: 10},
+			Algorithm:   &findings.Algorithm{Name: "RSA-2048", Primitive: "kem"},
+			SourceEngine: "cipherscope",
+			QuantumRisk:  findings.QRVulnerable,
+			Severity:     findings.SevCritical,
+			HNDLRisk:     "immediate",
+			Confidence:   findings.ConfidenceHigh,
+			Reachable:    findings.ReachableYes,
+		},
+		{
+			Location:    findings.Location{File: "/src/tls.go", Line: 42},
+			Algorithm:   &findings.Algorithm{Name: "ECDHE-X25519", Primitive: "key-exchange"},
+			SourceEngine: "cipherscope",
+			QuantumRisk:  findings.QRVulnerable,
+			Severity:     findings.SevCritical,
+			HNDLRisk:     "immediate",
+			Confidence:   findings.ConfidenceHigh,
+			Reachable:    findings.ReachableYes,
+		},
+		{
+			Location:    findings.Location{File: "/src/hybrid.go", Line: 7},
+			Algorithm:   &findings.Algorithm{Name: "X25519MLKEM768", Primitive: "kem"},
+			SourceEngine: "cipherscope",
+			QuantumRisk:  findings.QRSafe,
+			Severity:     findings.SevInfo,
+			HNDLRisk:     "", // PQ-safe — no harvest risk
+			Confidence:   findings.ConfidenceHigh,
+			Reachable:    findings.ReachableYes,
+		},
+	}
+}
+
+// TestHNDLFormat_JSONSurfacesHNDLRisk verifies that the JSON output for each
+// finding includes the correct hndlRisk field (or omits it for PQ-safe findings).
+func TestHNDLFormat_JSONSurfacesHNDLRisk(t *testing.T) {
+	result := BuildResult("0.1.0", "/src", []string{"cipherscope"}, testFindings())
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, result); err != nil {
+		t.Fatalf("WriteJSON error: %v", err)
+	}
+
+	// Parse back to validate individual findings.
+	var parsed struct {
+		Findings []map[string]interface{} `json:"findings"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("JSON unmarshal error: %v", err)
+	}
+	if len(parsed.Findings) != 3 {
+		t.Fatalf("expected 3 findings, got %d", len(parsed.Findings))
+	}
+
+	cases := []struct {
+		algName      string
+		wantHNDLRisk string // "" means omitempty — key should be absent
+		wantQRisk    string
+	}{
+		{"RSA-2048", "immediate", "quantum-vulnerable"},
+		{"ECDHE-X25519", "immediate", "quantum-vulnerable"},
+		{"X25519MLKEM768", "", "quantum-safe"},
+	}
+
+	for _, tc := range cases {
+		// Find the parsed finding for this algorithm.
+		var finding map[string]interface{}
+		for _, f := range parsed.Findings {
+			alg, _ := f["algorithm"].(map[string]interface{})
+			if alg != nil && alg["name"] == tc.algName {
+				finding = f
+				break
+			}
+		}
+		if finding == nil {
+			t.Errorf("JSON: finding for %q not found", tc.algName)
+			continue
+		}
+
+		// Check hndlRisk field.
+		gotHNDL, hasHNDL := finding["hndlRisk"].(string)
+		if tc.wantHNDLRisk == "" {
+			if hasHNDL && gotHNDL != "" {
+				t.Errorf("JSON %q: hndlRisk = %q, want absent/empty (PQ-safe)", tc.algName, gotHNDL)
+			}
+		} else {
+			if gotHNDL != tc.wantHNDLRisk {
+				t.Errorf("JSON %q: hndlRisk = %q, want %q", tc.algName, gotHNDL, tc.wantHNDLRisk)
+			}
+		}
+
+		// Check quantumRisk field (consistency cross-check).
+		gotQRisk, _ := finding["quantumRisk"].(string)
+		if gotQRisk != tc.wantQRisk {
+			t.Errorf("JSON %q: quantumRisk = %q, want %q", tc.algName, gotQRisk, tc.wantQRisk)
+		}
+
+		// Cross-check invariant: immediate HNDL ↔ quantum-vulnerable.
+		if gotHNDL == "immediate" && gotQRisk != "quantum-vulnerable" {
+			t.Errorf("JSON %q: HNDLRisk=immediate but quantumRisk=%q (inconsistent)", tc.algName, gotQRisk)
+		}
+		if gotQRisk == "quantum-safe" && gotHNDL != "" {
+			t.Errorf("JSON %q: quantumRisk=quantum-safe but hndlRisk=%q (inconsistent)", tc.algName, gotHNDL)
+		}
+	}
+}
+
+// TestHNDLFormat_SARIFSurfacesHNDLRisk verifies that the SARIF output includes
+// hndlRisk in the result properties for vulnerable findings and omits it for safe ones.
+func TestHNDLFormat_SARIFSurfacesHNDLRisk(t *testing.T) {
+	result := BuildResult("0.1.0", "/src", []string{"cipherscope"}, testFindings())
+	var buf bytes.Buffer
+	if err := WriteSARIF(&buf, result); err != nil {
+		t.Fatalf("WriteSARIF error: %v", err)
+	}
+
+	// Parse SARIF as generic JSON.
+	var sarif map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &sarif); err != nil {
+		t.Fatalf("SARIF unmarshal error: %v", err)
+	}
+
+	runs, _ := sarif["runs"].([]interface{})
+	if len(runs) == 0 {
+		t.Fatal("SARIF: no runs")
+	}
+	sarifResults, _ := runs[0].(map[string]interface{})["results"].([]interface{})
+	if len(sarifResults) != 3 {
+		t.Fatalf("SARIF: expected 3 results, got %d", len(sarifResults))
+	}
+
+	// Build a map: algorithm name → SARIF result.
+	algToSarif := make(map[string]map[string]interface{})
+	for _, raw := range sarifResults {
+		res, _ := raw.(map[string]interface{})
+		msg, _ := res["message"].(map[string]interface{})
+		text, _ := msg["text"].(string)
+		// Message starts with "Cryptographic algorithm detected: <name>"
+		for _, alg := range []string{"RSA-2048", "ECDHE-X25519", "X25519MLKEM768"} {
+			if strings.Contains(text, alg) {
+				algToSarif[alg] = res
+			}
+		}
+	}
+
+	cases := []struct {
+		alg          string
+		wantHNDLRisk string
+		wantLevel    string
+	}{
+		{"RSA-2048", "immediate", "error"},      // SevCritical → SARIF error
+		{"ECDHE-X25519", "immediate", "error"},
+		{"X25519MLKEM768", "", "none"},           // SevInfo → SARIF none
+	}
+
+	for _, tc := range cases {
+		res := algToSarif[tc.alg]
+		if res == nil {
+			t.Errorf("SARIF: result for %q not found", tc.alg)
+			continue
+		}
+
+		// Check SARIF level.
+		level, _ := res["level"].(string)
+		if level != tc.wantLevel {
+			t.Errorf("SARIF %q: level = %q, want %q", tc.alg, level, tc.wantLevel)
+		}
+
+		// Check hndlRisk in properties.
+		props, _ := res["properties"].(map[string]interface{})
+		gotHNDL, _ := props["hndlRisk"].(string)
+		if tc.wantHNDLRisk == "" {
+			if gotHNDL != "" {
+				t.Errorf("SARIF %q: properties.hndlRisk = %q, want absent/empty", tc.alg, gotHNDL)
+			}
+		} else {
+			if gotHNDL != tc.wantHNDLRisk {
+				t.Errorf("SARIF %q: properties.hndlRisk = %q, want %q", tc.alg, gotHNDL, tc.wantHNDLRisk)
+			}
+		}
+
+		// Cross-check: immediate HNDL → quantumRisk must be quantum-vulnerable.
+		qr, _ := props["quantumRisk"].(string)
+		if gotHNDL == "immediate" && qr != "quantum-vulnerable" {
+			t.Errorf("SARIF %q: hndlRisk=immediate but quantumRisk=%q (inconsistent)", tc.alg, qr)
+		}
+	}
+}
+
+// TestHNDLFormat_CBOMSurfacesHNDLRisk verifies that the CycloneDX CBOM output
+// includes oqs:hndlRisk in the component properties for vulnerable algorithms
+// and omits it for PQ-safe ones.
+func TestHNDLFormat_CBOMSurfacesHNDLRisk(t *testing.T) {
+	result := BuildResult("0.1.0", "/src", []string{"cipherscope"}, testFindings())
+	var buf bytes.Buffer
+	if err := WriteCBOM(&buf, result); err != nil {
+		t.Fatalf("WriteCBOM error: %v", err)
+	}
+
+	// Parse CBOM as generic JSON.
+	var cbom map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &cbom); err != nil {
+		t.Fatalf("CBOM unmarshal error: %v", err)
+	}
+
+	components, _ := cbom["components"].([]interface{})
+	if len(components) == 0 {
+		t.Fatal("CBOM: no components")
+	}
+
+	// Index components by name.
+	compByName := make(map[string]map[string]interface{})
+	for _, raw := range components {
+		comp, _ := raw.(map[string]interface{})
+		name, _ := comp["name"].(string)
+		compByName[name] = comp
+	}
+
+	cases := []struct {
+		alg          string
+		wantHNDLRisk string // "" means property should be absent
+		wantPQVerdict string // oqs:policyVerdict
+	}{
+		{"RSA-2048", "immediate", "quantum-vulnerable"},
+		{"ECDHE-X25519", "immediate", "quantum-vulnerable"},
+		{"X25519MLKEM768", "", "quantum-safe"},
+	}
+
+	for _, tc := range cases {
+		comp := compByName[tc.alg]
+		if comp == nil {
+			names := make([]string, 0, len(compByName))
+			for k := range compByName {
+				names = append(names, k)
+			}
+			t.Errorf("CBOM: component %q not found (components: %v)", tc.alg, names)
+			continue
+		}
+
+		props, _ := comp["properties"].([]interface{})
+
+		// Find oqs:hndlRisk and oqs:policyVerdict in properties.
+		var hndlRisk, policyVerdict string
+		for _, p := range props {
+			prop, _ := p.(map[string]interface{})
+			name, _ := prop["name"].(string)
+			value, _ := prop["value"].(string)
+			switch name {
+			case "oqs:hndlRisk":
+				hndlRisk = value
+			case "oqs:policyVerdict":
+				policyVerdict = value
+			}
+		}
+
+		if tc.wantHNDLRisk == "" {
+			if hndlRisk != "" {
+				t.Errorf("CBOM %q: oqs:hndlRisk = %q, want absent (PQ-safe)", tc.alg, hndlRisk)
+			}
+		} else {
+			if hndlRisk != tc.wantHNDLRisk {
+				t.Errorf("CBOM %q: oqs:hndlRisk = %q, want %q", tc.alg, hndlRisk, tc.wantHNDLRisk)
+			}
+		}
+
+		if policyVerdict != tc.wantPQVerdict {
+			t.Errorf("CBOM %q: oqs:policyVerdict = %q, want %q", tc.alg, policyVerdict, tc.wantPQVerdict)
+		}
+
+		// Cross-check invariant.
+		if hndlRisk == "immediate" && policyVerdict != "quantum-vulnerable" {
+			t.Errorf("CBOM %q: hndlRisk=immediate but policyVerdict=%q (inconsistent)", tc.alg, policyVerdict)
+		}
+		if policyVerdict == "quantum-safe" && hndlRisk != "" {
+			t.Errorf("CBOM %q: policyVerdict=quantum-safe but hndlRisk=%q (inconsistent)", tc.alg, hndlRisk)
+		}
+	}
+}
+

--- a/pkg/quantum/backcompat_test.go
+++ b/pkg/quantum/backcompat_test.go
@@ -1,0 +1,204 @@
+package quantum
+
+// backcompat_test.go — backwards-compatibility golden snapshot tests.
+//
+// Classifies a fixed set of algorithm specimens and compares the result against a
+// golden JSON file. The snapshot ensures that future refactors do not silently
+// change the classification output.
+//
+// # Expected to CHANGE between model versions
+//   - HNDLRisk values (if HNDL model is revised)
+//   - Recommendation text (if wording is updated)
+//   - TargetAlgorithm / TargetStandard (as NIST standards evolve)
+//
+// # Expected to STAY STABLE
+//   - Risk field (quantum-vulnerable / quantum-safe / deprecated / etc.)
+//   - Severity field (critical / high / medium / low / info)
+//   - Algorithm names and which families they belong to
+//
+// To regenerate the golden file after an intentional change:
+//
+//	go test ./pkg/quantum/ -run TestBackcompat_ClassificationSnapshot -update
+//
+// Commit the updated golden file alongside the code change that caused it.
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var updateGolden = flag.Bool("update", false, "regenerate golden snapshot files")
+
+// goldenSpecimen is a single test specimen for the golden snapshot.
+type goldenSpecimen struct {
+	Algorithm string `json:"algorithm"`
+	Primitive string `json:"primitive"`
+	KeySize   int    `json:"keySize,omitempty"`
+}
+
+// goldenRecord captures the Classification fields we snapshot.
+// We snapshot only the fields expected to be stable; omit free-form text.
+type goldenRecord struct {
+	Specimen        goldenSpecimen `json:"specimen"`
+	Risk            Risk           `json:"risk"`
+	Severity        Severity       `json:"severity"`
+	HNDLRisk        string         `json:"hndlRisk"`
+	MigrationEffort string         `json:"migrationEffort,omitempty"` // effort set by ClassifyEffort
+}
+
+// goldenSnapshot is the top-level golden file structure.
+type goldenSnapshot struct {
+	// SchemaVersion lets us detect when the snapshot format itself changes.
+	SchemaVersion string         `json:"schemaVersion"`
+	Records       []goldenRecord `json:"records"`
+}
+
+// specimens is the fixed set of algorithm inputs. These cover:
+//   - Classical KEM/exchange (RSA, ECDH, ECDSA, X25519)
+//   - S0.F4 hybrid forms (canonical and hyphenated)
+//   - Pure PQ (ML-KEM, ML-DSA, SLH-DSA)
+//   - Korean K-PQC finalists (SMAUG-T, HAETAE)
+//   - Deprecated (MD5, DES)
+//   - Symmetric/hash (AES-256-GCM, SHA-256)
+var specimens = []goldenSpecimen{
+	{"RSA-2048", "signature", 2048},
+	{"RSA-2048", "kem", 2048},
+	{"ECDH", "key-exchange", 0},
+	{"ECDSA", "signature", 0},
+	{"X25519", "key-exchange", 0},
+	{"X25519MLKEM768", "kem", 0},         // canonical hybrid — S0.F4 regression guard
+	{"X25519-MLKEM-768", "kem", 0},       // hyphenated hybrid — S0.F4 regression guard
+	{"SecP256r1MLKEM768", "kem", 0},
+	{"ML-KEM-768", "kem", 0},
+	{"ML-KEM-512", "kem", 0},
+	{"ML-DSA-65", "signature", 0},
+	{"SLH-DSA-128s", "signature", 0},
+	{"SMAUG-T-128", "kem", 0},
+	{"HAETAE-3", "signature", 0},
+	{"AES-256-GCM", "symmetric", 256},
+	{"AES-128-CBC", "symmetric", 128},
+	{"SHA-256", "hash", 256},
+	{"MD5", "hash", 0},
+	{"DES", "symmetric", 56},
+}
+
+const (
+	goldenDir  = "testdata/s0-backcompat"
+	goldenFile = "testdata/s0-backcompat/golden.json"
+	schemaVer  = "1"
+)
+
+// buildSnapshot classifies all specimens and returns the golden snapshot struct.
+func buildSnapshot() goldenSnapshot {
+	records := make([]goldenRecord, len(specimens))
+	for i, s := range specimens {
+		c := ClassifyAlgorithm(s.Algorithm, s.Primitive, s.KeySize)
+		effort := ClassifyEffort(c, s.Primitive, false)
+		records[i] = goldenRecord{
+			Specimen:        s,
+			Risk:            c.Risk,
+			Severity:        c.Severity,
+			HNDLRisk:        c.HNDLRisk,
+			MigrationEffort: effort,
+		}
+	}
+	return goldenSnapshot{SchemaVersion: schemaVer, Records: records}
+}
+
+// TestBackcompat_ClassificationSnapshot is the golden snapshot test.
+// Pass -update to regenerate; otherwise it reads the existing golden file and
+// compares field-by-field.
+func TestBackcompat_ClassificationSnapshot(t *testing.T) {
+	current := buildSnapshot()
+
+	if *updateGolden {
+		data, err := json.MarshalIndent(current, "", "  ")
+		if err != nil {
+			t.Fatalf("marshal snapshot: %v", err)
+		}
+		if err := os.MkdirAll(goldenDir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", goldenDir, err)
+		}
+		if err := os.WriteFile(goldenFile, append(data, '\n'), 0644); err != nil {
+			t.Fatalf("write golden file: %v", err)
+		}
+		t.Logf("golden file updated: %s (%d records)", goldenFile, len(current.Records))
+		return
+	}
+
+	data, err := os.ReadFile(filepath.Join(".", goldenFile))
+	if err != nil {
+		t.Fatalf("read golden file %q: %v\n\nRun with -update to generate it.", goldenFile, err)
+	}
+
+	var golden goldenSnapshot
+	if err := json.Unmarshal(data, &golden); err != nil {
+		t.Fatalf("unmarshal golden file: %v", err)
+	}
+
+	if len(golden.Records) != len(current.Records) {
+		t.Fatalf("record count mismatch: golden=%d current=%d (was a specimen added/removed?)",
+			len(golden.Records), len(current.Records))
+	}
+
+	for i, cur := range current.Records {
+		gold := golden.Records[i]
+		spec := cur.Specimen
+
+		// STABLE fields: these must not change without an intentional update.
+		if cur.Risk != gold.Risk {
+			t.Errorf("[%d] %s(%s): Risk changed: %q → %q (STABLE field — update golden if intentional)",
+				i, spec.Algorithm, spec.Primitive, gold.Risk, cur.Risk)
+		}
+		if cur.Severity != gold.Severity {
+			t.Errorf("[%d] %s(%s): Severity changed: %q → %q (STABLE field)",
+				i, spec.Algorithm, spec.Primitive, gold.Severity, cur.Severity)
+		}
+		if cur.MigrationEffort != gold.MigrationEffort {
+			t.Errorf("[%d] %s(%s): MigrationEffort changed: %q → %q (STABLE field)",
+				i, spec.Algorithm, spec.Primitive, gold.MigrationEffort, cur.MigrationEffort)
+		}
+
+		// HNDL risk: labelled separately because it is expected to evolve with the HNDL model.
+		if cur.HNDLRisk != gold.HNDLRisk {
+			t.Errorf("[%d] %s(%s): HNDLRisk changed: %q → %q (HNDL model field — update golden if HNDL model changed)",
+				i, spec.Algorithm, spec.Primitive, gold.HNDLRisk, cur.HNDLRisk)
+		}
+	}
+}
+
+// TestBackcompat_StableFieldsInvariant verifies the invariants that must hold
+// for stable fields regardless of what the golden file says — if these fail,
+// the classifier has a bug, not just an evolution.
+func TestBackcompat_StableFieldsInvariant(t *testing.T) {
+	for _, s := range specimens {
+		s := s
+		name := s.Algorithm + "(" + s.Primitive + ")"
+		t.Run(name, func(t *testing.T) {
+			c := ClassifyAlgorithm(s.Algorithm, s.Primitive, s.KeySize)
+
+			// RiskSafe algorithms must never have a non-empty HNDLRisk.
+			if c.Risk == RiskSafe && c.HNDLRisk != "" {
+				t.Errorf("%s: Risk=safe but HNDLRisk=%q (PQ-safe algorithms have no HNDL risk)", name, c.HNDLRisk)
+			}
+
+			// RiskDeprecated algorithms must never have an HNDLRisk (classically broken ≠ HNDL risk).
+			if c.Risk == RiskDeprecated && c.HNDLRisk != "" {
+				t.Errorf("%s: Risk=deprecated but HNDLRisk=%q (deprecated algos are classically broken, not HNDL)", name, c.HNDLRisk)
+			}
+
+			// Classical KEMs (immediate) must be RiskVulnerable.
+			if c.HNDLRisk == HNDLImmediate && c.Risk != RiskVulnerable {
+				t.Errorf("%s: HNDLRisk=immediate but Risk=%q (should be RiskVulnerable)", name, c.Risk)
+			}
+
+			// Deferred signatures must be RiskVulnerable.
+			if c.HNDLRisk == HNDLDeferred && c.Risk != RiskVulnerable {
+				t.Errorf("%s: HNDLRisk=deferred but Risk=%q (should be RiskVulnerable)", name, c.Risk)
+			}
+		})
+	}
+}

--- a/pkg/quantum/classify.go
+++ b/pkg/quantum/classify.go
@@ -438,6 +438,30 @@ func extractBaseName(name string) string {
 			return prefix
 		}
 	}
+
+	// Hyphenated hybrid KEM normalization: config files and AST tokenisers sometimes
+	// produce "X25519-MLKEM-768" instead of "X25519MLKEM768". Strip HYPHENS ONLY
+	// from the input and retry the PQC prefix match.
+	//
+	// Underscores are intentionally NOT stripped: underscore-separated identifiers
+	// (ML_KEM_768, SLH_DSA_SHA2_128s) are typically variable/constant names in
+	// source code, not algorithm names, and should continue to be classified by
+	// their first segment ("ML" → unknown). Stripping underscores would silently
+	// misclassify those identifiers as PQC-safe.
+	//
+	// This pass fires ONLY when the input contained hyphens (strippedHyphens != upper)
+	// so that bare classical names like "X25519" are never re-matched against their
+	// hybrid superset, and must run BEFORE the quantumVulnerableFamilies check.
+	strippedHyphens := strings.ReplaceAll(upper, "-", "")
+	if strippedHyphens != upper {
+		for _, prefix := range pqcSafeFamiliesSorted {
+			strippedKey := strings.ReplaceAll(strings.ToUpper(prefix), "-", "")
+			if strings.HasPrefix(strippedHyphens, strippedKey) {
+				return prefix
+			}
+		}
+	}
+
 	for _, alg := range deprecatedAlgorithmsSorted {
 		if strings.EqualFold(name, alg) {
 			return alg

--- a/pkg/quantum/classify.go
+++ b/pkg/quantum/classify.go
@@ -40,12 +40,27 @@ type Classification struct {
 }
 
 // HNDL risk levels for Harvest Now, Decrypt Later attacks.
+//
+// PFS (ECDHE) does NOT lower HNDL risk when the KEM is classical. The ephemeral
+// ECDH public key is captured in the recorded handshake and is Shor-breakable;
+// PFS protects against long-term key compromise, not quantum decryption of the
+// ephemeral exchange itself. Only a PQ-KEM session (ML-KEM, X25519MLKEM768, etc.)
+// is HNDL-resistant. See: Mosca, IEEE S&P 2018; Blanco-Romero et al., arXiv:2603.01091 (2026).
 const (
-	HNDLImmediate = "immediate" // Key exchange — data encrypted now can be decrypted when quantum computers arrive (2030 deadline)
-	HNDLDeferred  = "deferred"  // Signatures — only future signatures at risk, not past data (2035 deadline)
+	HNDLImmediate = "immediate" // Classical key exchange — recorded data can be decrypted when CRQC arrives (CNSA 2.0: 2030)
+	HNDLDeferred  = "deferred"  // Signatures — only future signatures at risk, not past data (CNSA 2.0: 2035)
 )
 
-// pqcSafeFamilies are NIST post-quantum standard families and K-PQC Round 4 finalists.
+// pqcSafeFamilies are NIST post-quantum standard families, K-PQC Round 4 finalists,
+// and IETF-standardized hybrid KEMs that pair a classical primitive with ML-KEM.
+// Hybrid KEMs must be listed here with their full name so that extractBaseName
+// (longest-prefix-first) returns the full hybrid name rather than the classical
+// component prefix (e.g. "X25519"), which would incorrectly flag them as vulnerable.
+//
+// HNDL safety of hybrids: even though the classical component (X25519, P-256, etc.)
+// is Shor-breakable, the ML-KEM component provides an independent PQ-secure shared
+// secret. An attacker with a CRQC can break X25519 but still cannot break ML-KEM,
+// so the session key remains confidential. HNDL risk is therefore LOW.
 var pqcSafeFamilies = map[string]bool{
 	"ML-KEM":  true, // FIPS 203
 	"ML-DSA":  true, // FIPS 204
@@ -58,6 +73,12 @@ var pqcSafeFamilies = map[string]bool{
 	"HAETAE":  true, // Signature, lattice-based
 	"AIMer":   true, // Signature, AES-based MPC-in-the-head
 	"NTRU+":   true, // KEM, NTRU variant
+	// Hybrid KEMs: classical + ML-KEM (IETF draft-ietf-tls-hybrid-design-16)
+	// TLS codepoint classification is handled in Sprint 1 (S1.3); name-based
+	// classification is added here so source/config findings are correct too.
+	"X25519MLKEM768":    true, // 0x11EC — production dominant (>50% Cloudflare, Oct 2025)
+	"SecP256r1MLKEM768": true, // 0x11EB
+	"SecP384r1MLKEM1024": true, // 0x11ED
 }
 
 // kpqcEliminatedCandidates are K-PQC candidates eliminated in earlier rounds.

--- a/pkg/quantum/classify_hndl_test.go
+++ b/pkg/quantum/classify_hndl_test.go
@@ -121,6 +121,43 @@ func TestClassifyHNDL_MoscaHighForLongLivedDataWithClassicalKEM(t *testing.T) {
 	}
 }
 
+// TestClassifyHNDL_HyphenatedHybridKEM verifies that hyphenated forms of hybrid KEMs
+// (as produced by config-file parsers and some AST tokenisers) are classified as
+// PQ-safe, not as their classical component. Without normalisation, "X25519-MLKEM-768"
+// would be mis-identified as "X25519" (quantum-vulnerable) because extractBaseName
+// would match the "X25519" prefix in quantumVulnerableFamilies.
+func TestClassifyHNDL_HyphenatedHybridKEM(t *testing.T) {
+	// Note: underscore-separated forms (X25519_MLKEM_768, ML_KEM_768) are intentionally
+	// NOT tested here. Underscores indicate variable/constant names in source code, not
+	// algorithm names, so those forms remain quantum-vulnerable (see TestClassifyPQCCasing).
+	cases := []struct {
+		name string
+		alg  string
+		prim string
+	}{
+		// Canonical (no hyphens) — already tested in TestClassifyHNDL_PQKEMHasNoHNDLRisk;
+		// repeated here alongside hyphenated variants to make the comparison explicit.
+		{"X25519MLKEM768 canonical", "X25519MLKEM768", "kem"},
+		{"SecP256r1MLKEM768 canonical", "SecP256r1MLKEM768", "kem"},
+		// Hyphenated forms — S0.F4 fix.
+		{"X25519-MLKEM-768 hyphenated kem", "X25519-MLKEM-768", "kem"},
+		{"X25519-MLKEM-768 hyphenated key-exchange", "X25519-MLKEM-768", "key-exchange"},
+		{"SecP256r1-MLKEM-768 hyphenated", "SecP256r1-MLKEM-768", "kem"},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			c := ClassifyAlgorithm(tt.alg, tt.prim, 0)
+			if c.HNDLRisk != "" {
+				t.Errorf("%q: expected empty HNDLRisk (PQ-safe), got %q", tt.alg, c.HNDLRisk)
+			}
+			if c.Risk != RiskSafe {
+				t.Errorf("%q: expected RiskSafe, got %s (extractBaseName matched classical component)", tt.alg, c.Risk)
+			}
+		})
+	}
+}
+
 // TestClassifyHNDL_EdgeCases covers boundary inputs for the HNDL classifier.
 func TestClassifyHNDL_EdgeCases(t *testing.T) {
 	t.Run("zero shelf life is not negative surplus panic", func(t *testing.T) {

--- a/pkg/quantum/classify_hndl_test.go
+++ b/pkg/quantum/classify_hndl_test.go
@@ -1,0 +1,160 @@
+package quantum
+
+// classify_hndl_test.go — regression tests proving:
+//   1. Classical KEMs are HNDL-immediate regardless of PFS (TLS 1.3 / ephemeral).
+//   2. PQ KEMs (ML-KEM, hybrid X25519MLKEM768) carry no HNDL risk (empty HNDLRisk = LOW).
+//
+// Academic basis: Mosca, IEEE S&P 2018; Blanco-Romero et al., arXiv:2603.01091 (2026).
+
+import "testing"
+
+// TestClassifyHNDL_ClassicalKEMWithPFSIsStillImmediate is the key regression test
+// for S0.1. PFS (ephemeral ECDH) does NOT protect against HNDL because the entire
+// TLS handshake — including the ephemeral public key — is captured by the adversary.
+// A quantum computer can run Shor's algorithm on that key to recover the session secret.
+//
+// This test proves the old "PFS lowers HNDL risk" assumption is absent from the
+// classifier. It must pass forever; any future change that makes ECDHE/X25519 return
+// anything other than HNDLImmediate is a regression.
+func TestClassifyHNDL_ClassicalKEMWithPFSIsStillImmediate(t *testing.T) {
+	// These algorithms are all classical KEMs used in PFS-capable cipher suites
+	// (TLS 1.3 always PFS; ECDHE suites in TLS 1.2 are PFS). The presence of PFS
+	// is irrelevant — the ephemeral public key is Shor-breakable.
+	pfsKEMs := []struct {
+		name      string
+		algorithm string
+		primitive string
+	}{
+		{"ECDHE (TLS 1.2 PFS)", "ECDHE", "key-exchange"},
+		{"ECDHE key-agree", "ECDHE", "key-agree"},
+		{"X25519 (TLS 1.3 default)", "X25519", "key-exchange"},
+		{"X25519 key-agree", "X25519", "key-agree"},
+		{"X448", "X448", "key-exchange"},
+		{"ECDH", "ECDH", "key-exchange"},
+		{"DH", "DH", "key-exchange"},
+		{"FFDH", "FFDH", "key-agree"},
+	}
+
+	for _, tt := range pfsKEMs {
+		t.Run(tt.name, func(t *testing.T) {
+			c := ClassifyAlgorithm(tt.algorithm, tt.primitive, 0)
+			if c.HNDLRisk != HNDLImmediate {
+				t.Errorf(
+					"classical KEM %q (%s) with PFS must still be HNDLImmediate — "+
+						"PFS does NOT protect against quantum decryption of captured handshakes. "+
+						"Got HNDLRisk=%q",
+					tt.algorithm, tt.primitive, c.HNDLRisk,
+				)
+			}
+			if c.Risk != RiskVulnerable {
+				t.Errorf("classical KEM %q should be RiskVulnerable, got %s", tt.algorithm, c.Risk)
+			}
+		})
+	}
+}
+
+// TestClassifyHNDL_PQKEMHasNoHNDLRisk verifies that PQ-resistant KEMs have an
+// empty HNDLRisk field (= no harvest risk = LOW in the Mosca framework).
+//
+// ML-KEM-768 (pure PQ KEM) and X25519MLKEM768 (hybrid) both provide PQ security:
+// even if a CRQC breaks the X25519 component of the hybrid, the independent
+// ML-KEM shared secret remains confidential.
+func TestClassifyHNDL_PQKEMHasNoHNDLRisk(t *testing.T) {
+	pqKEMs := []struct {
+		algorithm string
+		primitive string
+	}{
+		{"ML-KEM-768", "kem"},
+		{"ML-KEM-512", "kem"},
+		{"ML-KEM-1024", "kem"},
+		{"X25519MLKEM768", "kem"},    // hybrid — 0x11EC, production dominant
+		{"SecP256r1MLKEM768", "kem"}, // hybrid — 0x11EB
+	}
+
+	for _, tt := range pqKEMs {
+		t.Run(tt.algorithm, func(t *testing.T) {
+			c := ClassifyAlgorithm(tt.algorithm, tt.primitive, 0)
+			if c.HNDLRisk != "" {
+				t.Errorf(
+					"PQ KEM %q should have empty HNDLRisk (no harvest risk, maps to HNDL LOW), got %q",
+					tt.algorithm, c.HNDLRisk,
+				)
+			}
+			if c.Risk != RiskSafe {
+				t.Errorf("PQ KEM %q should be RiskSafe, got %s", tt.algorithm, c.Risk)
+			}
+		})
+	}
+}
+
+// TestClassifyHNDL_PQKEMEmptyRiskMapsToMoscaLow verifies that an empty HNDLRisk
+// from a PQ KEM corresponds to HNDLLevelLow in the Mosca framework via
+// ComputeHNDLSurplus with shelfLife=0 (no data to harvest = no risk).
+func TestClassifyHNDL_PQKEMEmptyRiskMapsToMoscaLow(t *testing.T) {
+	// When the KEM is PQ-resistant, there is no harvest risk regardless of data
+	// sensitivity. We model this as shelfLife=0 (data has no harvest value to a
+	// quantum adversary) which always maps to MEDIUM or LOW depending on lag/crqc.
+	// With explicit crqc > lag (e.g. crqc=10, lag=5): surplus = (0+5)-10 = -5 → LOW.
+	surplus := ComputeHNDLSurplus(0, 5, 10)
+	level := HNDLLevelFromSurplus(surplus)
+	if level != HNDLLevelLow {
+		t.Errorf("PQ KEM (shelfLife=0, lag=5, crqc=10): surplus=%d, level=%s, want HNDLLevelLow",
+			surplus, level)
+	}
+}
+
+// TestClassifyHNDL_MoscaHighForLongLivedDataWithClassicalKEM verifies that long-lived
+// data protected by a classical KEM scores HIGH on the Mosca inequality under default
+// parameters. This is the canonical "migrate now" case for financial/medical orgs.
+func TestClassifyHNDL_MoscaHighForLongLivedDataWithClassicalKEM(t *testing.T) {
+	// ECDHE = HNDLImmediate (classical KEM). With a 10-year data shelf life and
+	// default parameters (lag=5, crqc=5 in 2026), surplus = 10 → HIGH.
+	c := ClassifyAlgorithm("ECDHE", "key-exchange", 0)
+	if c.HNDLRisk != HNDLImmediate {
+		t.Fatalf("ECDHE should be HNDLImmediate, got %q", c.HNDLRisk)
+	}
+	// Mosca scoring: long-lived data protected by this KEM is HIGH urgency.
+	surplus := ComputeHNDLSurplus(10, 5, 5)
+	level := HNDLLevelFromSurplus(surplus)
+	if level != HNDLLevelHigh {
+		t.Errorf("10y shelf, lag=5, crqc=5: surplus=%d, level=%s, want HNDLLevelHigh", surplus, level)
+	}
+}
+
+// TestClassifyHNDL_EdgeCases covers boundary inputs for the HNDL classifier.
+func TestClassifyHNDL_EdgeCases(t *testing.T) {
+	t.Run("zero shelf life is not negative surplus panic", func(t *testing.T) {
+		// 0 shelf life: surplus = (0 + 5) - 5 = 0 → MEDIUM
+		surplus := ComputeHNDLSurplus(0, 5, 5)
+		if surplus != 0 {
+			t.Errorf("shelfLife=0: surplus=%d, want 0", surplus)
+		}
+		if HNDLLevelFromSurplus(surplus) != HNDLLevelMedium {
+			t.Errorf("surplus=0 should be MEDIUM")
+		}
+	})
+
+	t.Run("negative shelf life returns negative surplus", func(t *testing.T) {
+		surplus := ComputeHNDLSurplus(-1, 5, 5)
+		if surplus != -1 {
+			t.Errorf("shelfLife=-1: surplus=%d, want -1", surplus)
+		}
+		if HNDLLevelFromSurplus(surplus) != HNDLLevelLow {
+			t.Errorf("surplus=-1 should be LOW")
+		}
+	})
+
+	t.Run("empty sector returns default shelf life", func(t *testing.T) {
+		years := ShelfLifeForSector("")
+		if years != DefaultSectorShelfLifeYears {
+			t.Errorf("empty sector should return %d, got %d", DefaultSectorShelfLifeYears, years)
+		}
+	})
+
+	t.Run("unknown sector returns default shelf life", func(t *testing.T) {
+		years := ShelfLifeForSector("unknown-sector-xyz")
+		if years != DefaultSectorShelfLifeYears {
+			t.Errorf("unknown sector should return %d, got %d", DefaultSectorShelfLifeYears, years)
+		}
+	})
+}

--- a/pkg/quantum/classify_race_test.go
+++ b/pkg/quantum/classify_race_test.go
@@ -1,0 +1,228 @@
+package quantum
+
+// classify_race_test.go — concurrency stress tests for ClassifyAlgorithm.
+//
+// Runs 1000 goroutines simultaneously calling ClassifyAlgorithm with diverse
+// (sector, timeToCRQC, algorithm) inputs. Goals:
+//
+//  1. No data races — verified by -race flag.
+//  2. No panics — any goroutine panic propagates to the test runner.
+//  3. Determinism — same input always produces the same output; results are
+//     verified against a single-threaded reference run.
+//
+// Run with:
+//   go test -race -count=50 ./pkg/quantum/ -run TestClassifyAlgorithm_ConcurrentStress
+//
+// -count=50 re-runs 50 times to flush out races that manifest rarely.
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// classifyInput describes a single ClassifyAlgorithm call.
+type classifyInput struct {
+	algorithm string
+	primitive string
+	keySize   int
+}
+
+// classifyResult is the subset of Classification fields we compare for determinism.
+type classifyResult struct {
+	risk        Risk
+	hndlRisk    string
+	severity    Severity
+}
+
+func toResult(c Classification) classifyResult {
+	return classifyResult{
+		risk:     c.Risk,
+		hndlRisk: c.HNDLRisk,
+		severity: c.Severity,
+	}
+}
+
+// buildStressInputs generates 1000 diverse inputs by cycling through sectors,
+// timeToCRQC values, and algorithm names. This ensures goroutines do not all
+// hit the same code path, maximising coverage of internal state.
+func buildStressInputs() []classifyInput {
+	algorithms := []struct{ name, prim string }{
+		{"RSA-2048", "signature"},
+		{"ECDH", "key-exchange"},
+		{"ECDHE", "key-agree"},
+		{"X25519", "key-exchange"},
+		{"X25519MLKEM768", "kem"},
+		{"X25519-MLKEM-768", "kem"},
+		{"SecP256r1MLKEM768", "kem"},
+		{"ML-KEM-768", "kem"},
+		{"ML-KEM-512", "kem"},
+		{"ML-DSA-65", "signature"},
+		{"SLH-DSA-128s", "signature"},
+		{"AES-256-GCM", "symmetric"},
+		{"AES-128-CBC", "symmetric"},
+		{"ChaCha20-Poly1305", "ae"},
+		{"SHA-256", "hash"},
+		{"SHA-512", "hash"},
+		{"MD5", "hash"},
+		{"DES", "symmetric"},
+		{"ECDSA", "signature"},
+		{"Kyber768", "kem"},
+		{"X25519Kyber768Draft00", "kem"},
+		{"unknown-algo-fallback", "kem"},
+		{"SMAUG-T-128", "kem"},
+		{"HAETAE-3", "signature"},
+		{"GCKSign", "signature"},
+	}
+	keySizes := []int{0, 128, 256}
+
+	inputs := make([]classifyInput, 0, 1000)
+	for i := 0; i < 1000; i++ {
+		alg := algorithms[i%len(algorithms)]
+		ks := keySizes[i%len(keySizes)]
+		inputs = append(inputs, classifyInput{
+			algorithm: alg.name,
+			primitive: alg.prim,
+			keySize:   ks,
+		})
+	}
+	return inputs
+}
+
+// TestClassifyAlgorithm_ConcurrentStress launches 1000 goroutines, each calling
+// ClassifyAlgorithm once. Verifies no races (-race flag) and that results match
+// a single-threaded reference run (determinism).
+func TestClassifyAlgorithm_ConcurrentStress(t *testing.T) {
+	inputs := buildStressInputs()
+
+	// Build single-threaded reference results first.
+	reference := make([]classifyResult, len(inputs))
+	for i, inp := range inputs {
+		reference[i] = toResult(ClassifyAlgorithm(inp.algorithm, inp.primitive, inp.keySize))
+	}
+
+	// Run all 1000 goroutines in parallel.
+	results := make([]classifyResult, len(inputs))
+	var wg sync.WaitGroup
+	wg.Add(len(inputs))
+	for i, inp := range inputs {
+		go func(idx int, in classifyInput) {
+			defer wg.Done()
+			results[idx] = toResult(ClassifyAlgorithm(in.algorithm, in.primitive, in.keySize))
+		}(i, inp)
+	}
+	wg.Wait()
+
+	// Verify determinism: each concurrent result must match the reference.
+	failures := 0
+	for i, got := range results {
+		want := reference[i]
+		if got != want {
+			t.Errorf("input[%d] %q(%s,ks=%d): concurrent=%+v reference=%+v",
+				i, inputs[i].algorithm, inputs[i].primitive, inputs[i].keySize, got, want)
+			failures++
+			if failures > 10 {
+				t.Fatal("too many failures, stopping")
+			}
+		}
+	}
+}
+
+// TestClassifyAlgorithm_ConcurrentMoscaStress runs 200 goroutines each computing
+// a full Mosca surplus + level for a random (sector, crqc) combination, verifying
+// no shared-state corruption between the three pure functions.
+func TestClassifyAlgorithm_ConcurrentMoscaStress(t *testing.T) {
+	type moscaInput struct {
+		sector string
+		crqc   int
+	}
+	sectors := []string{"medical", "finance", "state", "infra", "code", "generic"}
+	crqcVals := []int{1, 3, 5, 10, 30, 50}
+
+	// Build 200 inputs cycling over combinations.
+	inputs := make([]moscaInput, 200)
+	for i := range inputs {
+		inputs[i] = moscaInput{
+			sector: sectors[i%len(sectors)],
+			crqc:   crqcVals[i%len(crqcVals)],
+		}
+	}
+
+	// Reference: single-threaded.
+	type moscaResult struct {
+		shelfLife int
+		surplus   int
+		level     HNDLLevel
+	}
+	ref := make([]moscaResult, len(inputs))
+	for i, inp := range inputs {
+		sl := ShelfLifeForSector(inp.sector)
+		s := ComputeHNDLSurplus(sl, DefaultMigrationLagYears, inp.crqc)
+		ref[i] = moscaResult{shelfLife: sl, surplus: s, level: HNDLLevelFromSurplus(s)}
+	}
+
+	// Parallel.
+	results := make([]moscaResult, len(inputs))
+	var wg sync.WaitGroup
+	wg.Add(len(inputs))
+	for i, inp := range inputs {
+		go func(idx int, in moscaInput) {
+			defer wg.Done()
+			sl := ShelfLifeForSector(in.sector)
+			s := ComputeHNDLSurplus(sl, DefaultMigrationLagYears, in.crqc)
+			results[idx] = moscaResult{shelfLife: sl, surplus: s, level: HNDLLevelFromSurplus(s)}
+		}(i, inp)
+	}
+	wg.Wait()
+
+	for i, got := range results {
+		want := ref[i]
+		if got != want {
+			t.Errorf("input[%d] sector=%s crqc=%d: concurrent=%+v reference=%+v",
+				i, inputs[i].sector, inputs[i].crqc, got, want)
+		}
+	}
+}
+
+// TestClassifyAlgorithm_ConcurrentExtractBaseName stresses extractBaseName
+// with the S0.F4 hyphenated hybrid KEM names — these triggered the bug that
+// F4 fixed, and are the most likely to expose races in string processing.
+func TestClassifyAlgorithm_ConcurrentExtractBaseName(t *testing.T) {
+	hybridNames := []struct{ name, prim string }{
+		{"X25519-MLKEM-768", "kem"},
+		{"X25519MLKEM768", "kem"},
+		{"SecP256r1-MLKEM-768", "kem"},
+		{"SecP256r1MLKEM768", "kem"},
+		{"X25519", "key-exchange"}, // classical — must NOT be mis-classified as PQ-safe
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan string, len(hybridNames)*100)
+
+	for rep := 0; rep < 100; rep++ {
+		for _, h := range hybridNames {
+			wg.Add(1)
+			go func(name, prim string) {
+				defer wg.Done()
+				c := ClassifyAlgorithm(name, prim, 0)
+				if name == "X25519" {
+					// Bare X25519 is classical — must remain HNDLImmediate.
+					if c.HNDLRisk != HNDLImmediate {
+						errCh <- fmt.Sprintf("X25519 HNDLRisk = %q, want %q (concurrent mis-classification)", c.HNDLRisk, HNDLImmediate)
+					}
+				} else {
+					// Hybrid and pure PQ — must be RiskSafe with empty HNDLRisk.
+					if c.Risk != RiskSafe || c.HNDLRisk != "" {
+						errCh <- fmt.Sprintf("%q: Risk=%s HNDLRisk=%q, want RiskSafe+\"\" (concurrent mis-classification)", name, c.Risk, c.HNDLRisk)
+					}
+				}
+			}(h.name, h.prim)
+		}
+	}
+	wg.Wait()
+	close(errCh)
+
+	for msg := range errCh {
+		t.Error(msg)
+	}
+}

--- a/pkg/quantum/hndl.go
+++ b/pkg/quantum/hndl.go
@@ -36,12 +36,17 @@ const (
 	HNDLLevelLow HNDLLevel = "low"
 )
 
+// nowFn is the time source for defaultTimeToCRQC. Replaceable in tests to simulate
+// specific years (e.g. 2031 to verify the post-CRQC clamp, 2026 for the reference year).
+// Production code must never override this; use t.Cleanup to restore in tests.
+var nowFn = time.Now
+
 // defaultTimeToCRQC returns the estimated remaining years until a cryptographically
 // relevant quantum computer (CRQC) arrives, based on Mosca's 50% probability estimate
 // of 2031 (from 2022 reference). Returns 0 if the estimate has already elapsed.
 func defaultTimeToCRQC() int {
 	crqcYear := moscaReferenceYear + moscaCRQCWindow
-	remaining := crqcYear - time.Now().Year()
+	remaining := crqcYear - nowFn().Year()
 	if remaining < 0 {
 		return 0
 	}

--- a/pkg/quantum/hndl.go
+++ b/pkg/quantum/hndl.go
@@ -1,0 +1,94 @@
+package quantum
+
+import "time"
+
+// Mosca inequality constants.
+// The Mosca inequality states: if (data shelf life + migration lag) > time to CRQC,
+// the organisation is at risk. See: Mosca, IEEE S&P 2018.
+const (
+	// moscaReferenceYear is the base year of Mosca's 50% CRQC probability estimate.
+	moscaReferenceYear = 2022
+	// moscaCRQCWindow is the number of years from moscaReferenceYear to the 50%
+	// probability CRQC threshold (2031). Adjusted for the current year at runtime.
+	moscaCRQCWindow = 9
+
+	// DefaultMigrationLagYears is the typical enterprise PQC migration lag. Derived
+	// from NIST IR 8547 timeline: organisations targeting the 2030 CNSA 2.0 deadline
+	// typically begin large-scale migration 4–6 years before the cutoff.
+	DefaultMigrationLagYears = 5
+)
+
+// HNDLLevel classifies the urgency of a Harvest Now, Decrypt Later threat using
+// the Mosca inequality. Values are ordered: High > Medium > Low.
+type HNDLLevel string
+
+const (
+	// HNDLLevelHigh means the Mosca surplus is > 2 years: data lifetime + migration
+	// lag exceeds the CRQC horizon by a comfortable margin. Immediate action required.
+	HNDLLevelHigh HNDLLevel = "high"
+
+	// HNDLLevelMedium means surplus is in [0, 2]: at or near the CRQC threshold.
+	// Migration should be underway; further delay risks missing the window.
+	HNDLLevelMedium HNDLLevel = "medium"
+
+	// HNDLLevelLow means surplus is negative: data will be retired before the CRQC
+	// horizon, or the KEM is already quantum-resistant. No harvest risk.
+	HNDLLevelLow HNDLLevel = "low"
+)
+
+// defaultTimeToCRQC returns the estimated remaining years until a cryptographically
+// relevant quantum computer (CRQC) arrives, based on Mosca's 50% probability estimate
+// of 2031 (from 2022 reference). Returns 0 if the estimate has already elapsed.
+func defaultTimeToCRQC() int {
+	crqcYear := moscaReferenceYear + moscaCRQCWindow
+	remaining := crqcYear - time.Now().Year()
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+// ComputeHNDLSurplus implements the Mosca inequality:
+//
+//	surplus = (dataShelfLifeYears + migrationLagYears) - timeToCRQCYears
+//
+// Interpretation:
+//
+//	surplus > 2  → HNDL HIGH:   data lifetime + migration lag significantly exceeds CRQC horizon
+//	surplus 0..2 → HNDL MEDIUM: at or near the threshold; migration should be underway
+//	surplus < 0  → HNDL LOW:    data expires before CRQC, or KEM is PQ-resistant; no harvest risk
+//
+// Caller conventions:
+//   - Pass migrationLagYears <= 0 to use DefaultMigrationLagYears (5 years).
+//   - Pass timeToCRQCYears <= 0 to use the dynamic default derived from Mosca's
+//     50%-probability 2031 estimate, adjusted for the current year.
+//   - dataShelfLifeYears should reflect the actual retention period; 0 means
+//     "no retention" (surplus will be negative or zero, mapping to LOW/MEDIUM).
+//
+// Academic basis: Mosca, IEEE S&P 2018; Blanco-Romero et al., arXiv:2603.01091 (2026).
+func ComputeHNDLSurplus(dataShelfLifeYears, migrationLagYears, timeToCRQCYears int) int {
+	lag := migrationLagYears
+	if lag <= 0 {
+		lag = DefaultMigrationLagYears
+	}
+	crqc := timeToCRQCYears
+	if crqc <= 0 {
+		crqc = defaultTimeToCRQC()
+	}
+	return (dataShelfLifeYears + lag) - crqc
+}
+
+// HNDLLevelFromSurplus maps a Mosca surplus value to a HNDLLevel.
+//
+//	surplus > 2  → HNDLLevelHigh
+//	surplus 0..2 → HNDLLevelMedium
+//	surplus < 0  → HNDLLevelLow
+func HNDLLevelFromSurplus(surplus int) HNDLLevel {
+	if surplus > 2 {
+		return HNDLLevelHigh
+	}
+	if surplus >= 0 {
+		return HNDLLevelMedium
+	}
+	return HNDLLevelLow
+}

--- a/pkg/quantum/hndl_property_test.go
+++ b/pkg/quantum/hndl_property_test.go
@@ -1,0 +1,152 @@
+package quantum
+
+// hndl_property_test.go — property-based and invariant tests for the Mosca HNDL model.
+//
+// These tests catch latent bugs that table-driven golden tests miss by verifying
+// mathematical properties that must hold across arbitrary inputs:
+//
+//   - Monotonicity: surplus is non-decreasing in shelfLife, non-increasing in crqc
+//   - Idempotence: HNDLLevelFromSurplus produces the same result on repeated calls
+//   - Level ordering: a higher surplus never maps to a lower-urgency level
+//   - Boundary stability: the exact breakpoints (-1, 0, 1, 2, 3) behave as documented
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// TestHNDLSurplus_ShelfLifeMonotonicity verifies that for fixed lag and crqc,
+// incrementing shelfLife by 1 never decreases the surplus.
+// Surplus = (shelfLife + lag) - crqc, so it is strictly increasing in shelfLife.
+func TestHNDLSurplus_ShelfLifeMonotonicity(t *testing.T) {
+	lag := 5
+	crqc := 7
+	prev := ComputeHNDLSurplus(0, lag, crqc)
+	for shelfLife := 1; shelfLife <= 100; shelfLife++ {
+		curr := ComputeHNDLSurplus(shelfLife, lag, crqc)
+		if curr < prev {
+			t.Errorf("monotonicity violated: shelfLife=%d surplus=%d < prev=%d (lag=%d, crqc=%d)",
+				shelfLife, curr, prev, lag, crqc)
+		}
+		prev = curr
+	}
+}
+
+// TestHNDLSurplus_CRQCMonotonicity verifies that for fixed shelfLife and lag,
+// incrementing crqc by 1 never increases the surplus.
+// Surplus = (shelfLife + lag) - crqc, so it is strictly decreasing in crqc.
+func TestHNDLSurplus_CRQCMonotonicity(t *testing.T) {
+	shelfLife := 15
+	lag := 5
+	prev := ComputeHNDLSurplus(shelfLife, lag, 1)
+	for crqc := 2; crqc <= 100; crqc++ {
+		curr := ComputeHNDLSurplus(shelfLife, lag, crqc)
+		if curr > prev {
+			t.Errorf("monotonicity violated: crqc=%d surplus=%d > prev=%d (shelfLife=%d, lag=%d)",
+				crqc, curr, prev, shelfLife, lag)
+		}
+		prev = curr
+	}
+}
+
+// TestHNDLLevelFromSurplus_Idempotent verifies that HNDLLevelFromSurplus produces
+// the same result when called twice with the same input — golden for any future refactor
+// that might introduce side effects or non-deterministic state.
+func TestHNDLLevelFromSurplus_Idempotent(t *testing.T) {
+	for surplus := -20; surplus <= 20; surplus++ {
+		a := HNDLLevelFromSurplus(surplus)
+		b := HNDLLevelFromSurplus(surplus)
+		if a != b {
+			t.Errorf("HNDLLevelFromSurplus(%d) not idempotent: first=%q second=%q", surplus, a, b)
+		}
+	}
+}
+
+// TestHNDLLevelFromSurplus_BoundaryStability asserts the exact documented breakpoints:
+//
+//	surplus < 0  → HNDLLevelLow
+//	surplus 0..2 → HNDLLevelMedium
+//	surplus > 2  → HNDLLevelHigh
+//
+// These are the canonical boundaries from the Mosca inequality. If they shift,
+// this test is the canary.
+func TestHNDLLevelFromSurplus_BoundaryStability(t *testing.T) {
+	tests := []struct {
+		surplus int
+		want    HNDLLevel
+	}{
+		{-1000000, HNDLLevelLow},
+		{-100, HNDLLevelLow},
+		{-2, HNDLLevelLow},
+		{-1, HNDLLevelLow},   // just below MEDIUM threshold
+		{0, HNDLLevelMedium}, // lower MEDIUM boundary (inclusive)
+		{1, HNDLLevelMedium},
+		{2, HNDLLevelMedium}, // upper MEDIUM boundary (inclusive)
+		{3, HNDLLevelHigh},   // just above MEDIUM → HIGH
+		{4, HNDLLevelHigh},
+		{100, HNDLLevelHigh},
+		{1000000, HNDLLevelHigh},
+	}
+	for _, tt := range tests {
+		got := HNDLLevelFromSurplus(tt.surplus)
+		if got != tt.want {
+			t.Errorf("HNDLLevelFromSurplus(%d) = %q, want %q", tt.surplus, got, tt.want)
+		}
+	}
+}
+
+// TestHNDLSurplus_RandomShelfLifeMonotonicity runs 100 random (lag, crqc) pairs
+// and verifies monotone non-decreasing in shelfLife for each. This guards against
+// off-by-one errors that deterministic table tests might not trigger.
+func TestHNDLSurplus_RandomShelfLifeMonotonicity(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		lag := rng.Intn(20) + 1  // 1..20
+		crqc := rng.Intn(20) + 1 // 1..20
+		prev := ComputeHNDLSurplus(0, lag, crqc)
+		for shelfLife := 1; shelfLife <= 50; shelfLife++ {
+			curr := ComputeHNDLSurplus(shelfLife, lag, crqc)
+			if curr < prev {
+				t.Errorf("iteration %d: shelfLife=%d surplus=%d < prev=%d (lag=%d, crqc=%d)",
+					i, shelfLife, curr, prev, lag, crqc)
+			}
+			prev = curr
+		}
+	}
+}
+
+// TestHNDLLevelFromSurplus_LevelOrderConsistency verifies that urgency is non-decreasing:
+// a higher surplus must never map to a lower-urgency level than a lower surplus.
+// Urgency ordering: Low=0, Medium=1, High=2.
+func TestHNDLLevelFromSurplus_LevelOrderConsistency(t *testing.T) {
+	urgency := map[HNDLLevel]int{
+		HNDLLevelLow:    0,
+		HNDLLevelMedium: 1,
+		HNDLLevelHigh:   2,
+	}
+	prev := urgency[HNDLLevelFromSurplus(-50)]
+	for surplus := -49; surplus <= 50; surplus++ {
+		level := HNDLLevelFromSurplus(surplus)
+		curr := urgency[level]
+		if curr < prev {
+			t.Errorf("level ordering violated at surplus=%d: level %q (urgency %d) < previous urgency %d",
+				surplus, level, curr, prev)
+		}
+		prev = curr
+	}
+}
+
+// TestComputeHNDLSurplus_Linearity verifies the linear structure of the Mosca formula:
+// surplus(n+1) - surplus(n) == 1 when only shelfLife changes by 1.
+func TestComputeHNDLSurplus_Linearity(t *testing.T) {
+	lag := 5
+	crqc := 8
+	for shelfLife := 0; shelfLife < 50; shelfLife++ {
+		a := ComputeHNDLSurplus(shelfLife, lag, crqc)
+		b := ComputeHNDLSurplus(shelfLife+1, lag, crqc)
+		if b-a != 1 {
+			t.Errorf("linearity violated at shelfLife=%d: delta=%d (want 1), surplus(%d)=%d, surplus(%d)=%d",
+				shelfLife, b-a, shelfLife, a, shelfLife+1, b)
+		}
+	}
+}

--- a/pkg/quantum/hndl_test.go
+++ b/pkg/quantum/hndl_test.go
@@ -1,6 +1,7 @@
 package quantum
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -175,4 +176,110 @@ func TestHNDL_RecommendationContainsHNDLTerminology(t *testing.T) {
 
 func containsIgnoreCase(s, substr string) bool {
 	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
+}
+
+// ─── Mosca inequality: ComputeHNDLSurplus ──────────────────────────────────
+
+func TestComputeHNDLSurplus_ExplicitValues(t *testing.T) {
+	tests := []struct {
+		name         string
+		shelfLife    int
+		migLag       int
+		timeToCRQC   int
+		wantSurplus  int
+	}{
+		// surplus = (shelf + lag) - crqc
+		{"zero shelf, explicit lag+crqc", 0, 5, 5, 0},
+		{"standard 10y shelf", 10, 5, 5, 10},
+		{"medical 30y shelf", 30, 5, 5, 30},
+		{"finance 7y shelf", 7, 5, 5, 7},
+		{"state 50y shelf", 50, 5, 5, 50},
+		{"code 5y shelf, crqc=10", 5, 5, 10, 0},
+		{"code 5y shelf, crqc=15", 5, 5, 15, -5},
+		{"negative surplus (data expires before CRQC)", 1, 3, 10, -6},
+		{"negative shelf treated as-is", -1, 5, 5, -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ComputeHNDLSurplus(tt.shelfLife, tt.migLag, tt.timeToCRQC)
+			if got != tt.wantSurplus {
+				t.Errorf("ComputeHNDLSurplus(%d, %d, %d) = %d, want %d",
+					tt.shelfLife, tt.migLag, tt.timeToCRQC, got, tt.wantSurplus)
+			}
+		})
+	}
+}
+
+func TestComputeHNDLSurplus_DefaultMigrationLag(t *testing.T) {
+	// Passing migrationLagYears=0 should use DefaultMigrationLagYears (5).
+	explicit := ComputeHNDLSurplus(10, DefaultMigrationLagYears, 5)
+	defaulted := ComputeHNDLSurplus(10, 0, 5)
+	if explicit != defaulted {
+		t.Errorf("migLag=0 should use default (%d): explicit=%d, defaulted=%d",
+			DefaultMigrationLagYears, explicit, defaulted)
+	}
+}
+
+func TestComputeHNDLSurplus_DefaultTimeToCRQC(t *testing.T) {
+	// Passing timeToCRQCYears=0 should use the dynamic default (≥ 0).
+	// We can't pin the exact value across years, but the result must be
+	// arithmetically consistent with a non-negative CRQC window.
+	surplus := ComputeHNDLSurplus(10, 5, 0)
+	// timeToCRQC is always ≥ 0, so surplus ≤ (10 + 5) = 15.
+	if surplus > 15 {
+		t.Errorf("ComputeHNDLSurplus(10, 5, 0) = %d, want ≤ 15 (CRQC must be ≥ 0)", surplus)
+	}
+	// With shelf=10 and default lag=5, surplus should always map to HIGH for any
+	// year ≤ 2031 (surplus = 15 - crqc ≥ 15 - 5 = 10 when crqc≥0 today) or remain
+	// elevated when CRQC arrives (surplus = 15 - 0 = 15 in year 2031+).
+	level := HNDLLevelFromSurplus(surplus)
+	if level != HNDLLevelHigh {
+		t.Errorf("10y shelf with defaults should be HNDLLevelHigh, got %s (surplus=%d)", level, surplus)
+	}
+}
+
+func TestComputeHNDLSurplus_EdgeCases(t *testing.T) {
+	// Zero shelf life with explicit values — near-zero surplus.
+	s := ComputeHNDLSurplus(0, 5, 5)
+	if s != 0 {
+		t.Errorf("ComputeHNDLSurplus(0, 5, 5) = %d, want 0", s)
+	}
+
+	// Zero shelf, zero lag (→default 5), zero crqc (→dynamic ≥ 0): surplus = 5 - crqc.
+	// We just verify it doesn't panic and returns an int.
+	_ = ComputeHNDLSurplus(0, 0, 0)
+
+	// Negative shelf is passed through unchanged.
+	s = ComputeHNDLSurplus(-5, 5, 5)
+	if s != -5 {
+		t.Errorf("ComputeHNDLSurplus(-5, 5, 5) = %d, want -5", s)
+	}
+}
+
+// ─── HNDLLevelFromSurplus ─────────────────────────────────────────────────
+
+func TestHNDLLevelFromSurplus(t *testing.T) {
+	tests := []struct {
+		surplus int
+		want    HNDLLevel
+	}{
+		{-10, HNDLLevelLow},
+		{-1, HNDLLevelLow},
+		{0, HNDLLevelMedium},
+		{1, HNDLLevelMedium},
+		{2, HNDLLevelMedium},
+		{3, HNDLLevelHigh},
+		{10, HNDLLevelHigh},
+		{50, HNDLLevelHigh},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("surplus_%+d", tt.surplus), func(t *testing.T) {
+			got := HNDLLevelFromSurplus(tt.surplus)
+			if got != tt.want {
+				t.Errorf("HNDLLevelFromSurplus(%d) = %q, want %q", tt.surplus, got, tt.want)
+			}
+		})
+	}
 }

--- a/pkg/quantum/hndl_time_test.go
+++ b/pkg/quantum/hndl_time_test.go
@@ -1,0 +1,153 @@
+package quantum
+
+// hndl_time_test.go — time-travel tests for defaultTimeToCRQC.
+//
+// Addresses the code-reviewer's "silent clamp after 2031" concern:
+//   - At year 2031: crqcYear (2031) - 2031 = 0, return 0 (threshold year, not clamped).
+//   - At year 2032+: crqcYear - year = negative → clamped to 0.
+//
+// We override the package-level nowFn variable (added alongside this test) to inject
+// a fake clock. This is the cleanest approach: no build tags, no go:linkname, no
+// interface wrapping. The variable is documented as test-only in hndl.go.
+//
+// Academic basis: Mosca, IEEE S&P 2018. crqcYear = moscaReferenceYear(2022) + moscaCRQCWindow(9) = 2031.
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// fakeNow returns a time.Time whose Year() == year.
+func fakeNow(year int) func() time.Time {
+	return func() time.Time {
+		return time.Date(year, time.January, 1, 0, 0, 0, 0, time.UTC)
+	}
+}
+
+// withFakeYear overrides nowFn for the duration of the test and restores it on cleanup.
+func withFakeYear(t *testing.T, year int) {
+	t.Helper()
+	old := nowFn
+	nowFn = fakeNow(year)
+	t.Cleanup(func() { nowFn = old })
+}
+
+// TestDefaultTimeToCRQC_SpecificYears verifies the function at landmark years.
+//
+//	crqcYear = 2022 + 9 = 2031
+//	remaining = crqcYear - nowFn().Year()
+//	clamped to 0 when negative.
+func TestDefaultTimeToCRQC_SpecificYears(t *testing.T) {
+	tests := []struct {
+		year int
+		want int
+		note string
+	}{
+		{2026, 5, "reference year of test suite (5y to CRQC)"},
+		{2030, 1, "one year before CRQC horizon"},
+		{2031, 0, "threshold year: 2031-2031=0, not clamped"},
+		{2032, 0, "first post-threshold year: -1 clamped to 0"},
+		{2033, 0, "second post-threshold year: -2 clamped to 0"},
+		{2050, 0, "well past threshold: -19 clamped to 0"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(fmt.Sprintf("year_%d", tt.year), func(t *testing.T) {
+			withFakeYear(t, tt.year)
+			got := defaultTimeToCRQC()
+			if got != tt.want {
+				t.Errorf("year=%d defaultTimeToCRQC()=%d, want %d (%s)",
+					tt.year, got, tt.want, tt.note)
+			}
+		})
+	}
+}
+
+// TestDefaultTimeToCRQC_ClampIsNonNegative verifies the clamp guarantee: the function
+// never returns a negative value, even decades past the CRQC threshold.
+func TestDefaultTimeToCRQC_ClampIsNonNegative(t *testing.T) {
+	for year := 2026; year <= 2100; year++ {
+		withFakeYear(t, year)
+		got := defaultTimeToCRQC()
+		if got < 0 {
+			t.Errorf("year=%d defaultTimeToCRQC()=%d, want >= 0 (post-threshold clamp violated)", year, got)
+		}
+	}
+}
+
+// TestDefaultTimeToCRQC_HNDLLevelTransitionsAcrossThreshold verifies that
+// HNDL urgency for long-lived data correctly transitions across the CRQC threshold.
+//
+//   shelfLife=10, lag=5: surplus = (10+5) - crqc = 15 - crqc
+//     crqc=12: surplus=3  → HIGH   (crqcYear - fakeYear = 12, i.e. year=2019)
+//     crqc=15: surplus=0  → MEDIUM (crqcYear - fakeYear = 15, i.e. year=2016)
+//     crqc=16: surplus=-1 → LOW    (crqcYear - fakeYear = 16, i.e. year=2015)
+//
+// Post-2031: crqc is clamped to 0; surplus = (10+5)-0 = 15 → HIGH — the urgency
+// is maximum once the CRQC has arrived, not zero.
+func TestDefaultTimeToCRQC_HNDLLevelTransitionsAcrossThreshold(t *testing.T) {
+	tests := []struct {
+		fakeYear  int
+		wantCRQC  int
+		shelfLife int
+		lag       int
+		wantLevel HNDLLevel
+		note      string
+	}{
+		// Pre-threshold: crqc > 0, Mosca surplus varies
+		{2019, 12, 10, 5, HNDLLevelHigh, "crqc=12 → surplus=3 → HIGH"},
+		{2016, 15, 10, 5, HNDLLevelMedium, "crqc=15 → surplus=0 → MEDIUM"},
+		{2015, 16, 10, 5, HNDLLevelLow, "crqc=16 → surplus=-1 → LOW"},
+		// Post-threshold: crqc clamped to 0 → surplus = shelfLife+lag = 15 → HIGH
+		{2032, 0, 10, 5, HNDLLevelHigh, "post-2031: crqc=0 → surplus=15 → HIGH"},
+		{2050, 0, 10, 5, HNDLLevelHigh, "year 2050: crqc=0 → surplus=15 → HIGH"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(fmt.Sprintf("year%d", tt.fakeYear), func(t *testing.T) {
+			withFakeYear(t, tt.fakeYear)
+			gotCRQC := defaultTimeToCRQC()
+			if gotCRQC != tt.wantCRQC {
+				t.Fatalf("year=%d: defaultTimeToCRQC()=%d, want %d", tt.fakeYear, gotCRQC, tt.wantCRQC)
+			}
+			surplus := ComputeHNDLSurplus(tt.shelfLife, tt.lag, gotCRQC)
+			level := HNDLLevelFromSurplus(surplus)
+			if level != tt.wantLevel {
+				t.Errorf("year=%d shelfLife=%d lag=%d crqc=%d: surplus=%d level=%s, want %s (%s)",
+					tt.fakeYear, tt.shelfLife, tt.lag, gotCRQC, surplus, level, tt.wantLevel, tt.note)
+			}
+		})
+	}
+}
+
+// TestComputeHNDLSurplus_WithDefaultCRQC_AtKeyYears verifies ComputeHNDLSurplus
+// end-to-end (crqc=0 → uses nowFn) at specific clock years with medical shelf life.
+//
+//   medical shelfLife=30, lag=5(default): surplus = 35 - crqc
+func TestComputeHNDLSurplus_WithDefaultCRQC_AtKeyYears(t *testing.T) {
+	tests := []struct {
+		year      int
+		wantLevel HNDLLevel
+	}{
+		{2026, HNDLLevelHigh},   // crqc=5, surplus=30 → HIGH
+		{2031, HNDLLevelHigh},   // crqc=0, surplus=35 → HIGH
+		{2100, HNDLLevelHigh},   // crqc=0, surplus=35 → HIGH (CRQC has arrived)
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(fmt.Sprintf("medical_year%d", tt.year), func(t *testing.T) {
+			withFakeYear(t, tt.year)
+			// shelfLife=30 (medical), migLag=0 (→default 5), crqc=0 (→nowFn)
+			surplus := ComputeHNDLSurplus(30, 0, 0)
+			level := HNDLLevelFromSurplus(surplus)
+			if level != tt.wantLevel {
+				t.Errorf("year=%d medical(30y): surplus=%d level=%s, want %s",
+					tt.year, surplus, level, tt.wantLevel)
+			}
+		})
+	}
+}
+

--- a/pkg/quantum/matrix_test.go
+++ b/pkg/quantum/matrix_test.go
@@ -1,0 +1,277 @@
+package quantum
+
+// matrix_test.go — exhaustive sector × timeToCRQC × KEM classification matrix.
+//
+// 6 sectors × 8 year values × 10 KEM algorithms = 480 sub-tests.
+// Each cell asserts:
+//  (a) Classical KEMs (RSA, ECDHE, Kyber768, draft, unknown) → HNDLImmediate + Mosca HNDL level
+//  (b) Classical signatures (ECDSA) → HNDLDeferred + RiskVulnerable
+//  (c) Hybrid PQ KEMs (X25519MLKEM768, hyphenated, SecP256r1MLKEM768) → RiskSafe, no HNDL
+//  (d) Pure PQ KEM (ML-KEM-768) → RiskSafe, no HNDL
+//
+// The Mosca HNDL level for classical KEMs is computed as:
+//   surplus = (sectorShelfLife + DefaultMigrationLagYears) - timeToCRQC
+//   level   = HNDLLevelFromSurplus(surplus)
+//
+// Year 0: rejected at the CLI boundary. The classifier itself accepts it (timeToCRQC=0
+// triggers the dynamic default); for matrix rows we pass timeToCRQC=1 to test the
+// minimum-positive boundary without hitting the dynamic default path.
+
+import (
+	"fmt"
+	"testing"
+)
+
+// kemSpec describes a single KEM specimen in the matrix.
+type kemSpec struct {
+	algorithm string
+	primitive string
+	// expected classification fields
+	wantRisk     Risk
+	wantHNDLRisk string // "immediate", "deferred", or "" for PQ-safe
+}
+
+// kemSpecs are the 10 KEM algorithm specimens for the matrix.
+var kemSpecs = []kemSpec{
+	// (a) Classical KEMs → HNDLImmediate
+	{
+		algorithm:    "RSA-2048",
+		primitive:    "kem",
+		wantRisk:     RiskVulnerable,
+		wantHNDLRisk: HNDLImmediate,
+	},
+	{
+		algorithm:    "ECDHE-X25519",
+		primitive:    "key-exchange",
+		wantRisk:     RiskVulnerable,
+		wantHNDLRisk: HNDLImmediate,
+	},
+	{
+		// Kyber768 is the pre-standardisation name. Not in pqcSafeFamilies;
+		// falls through to "unrecognized kem" path → HNDLImmediate.
+		algorithm:    "Kyber768",
+		primitive:    "kem",
+		wantRisk:     RiskVulnerable,
+		wantHNDLRisk: HNDLImmediate,
+	},
+	{
+		// X25519Kyber768Draft00: deprecated IETF draft hybrid. extractBaseName
+		// matches "X25519" prefix in quantumVulnerableFamilies → treated as
+		// classical X25519 key exchange → HNDLImmediate.
+		algorithm:    "X25519Kyber768Draft00",
+		primitive:    "kem",
+		wantRisk:     RiskVulnerable,
+		wantHNDLRisk: HNDLImmediate,
+	},
+	{
+		// Unrecognized KEM with opaque name → conservative: HNDLImmediate.
+		algorithm:    "unknown-algo-fallback",
+		primitive:    "kem",
+		wantRisk:     RiskVulnerable,
+		wantHNDLRisk: HNDLImmediate,
+	},
+	// (b) Classical signature → HNDLDeferred (future authenticity risk, not data harvesting)
+	{
+		algorithm:    "ECDSA-P256",
+		primitive:    "signature",
+		wantRisk:     RiskVulnerable,
+		wantHNDLRisk: HNDLDeferred,
+	},
+	// (c) Hybrid PQ KEMs → RiskSafe, no HNDL
+	{
+		algorithm:    "X25519MLKEM768",
+		primitive:    "kem",
+		wantRisk:     RiskSafe,
+		wantHNDLRisk: "",
+	},
+	{
+		// S0.F4: hyphenated form must be normalised to X25519MLKEM768, not X25519.
+		algorithm:    "X25519-MLKEM-768",
+		primitive:    "kem",
+		wantRisk:     RiskSafe,
+		wantHNDLRisk: "",
+	},
+	{
+		algorithm:    "SecP256r1MLKEM768",
+		primitive:    "kem",
+		wantRisk:     RiskSafe,
+		wantHNDLRisk: "",
+	},
+	// (d) Pure PQ KEM → RiskSafe, no HNDL
+	{
+		algorithm:    "ML-KEM-768",
+		primitive:    "kem",
+		wantRisk:     RiskSafe,
+		wantHNDLRisk: "",
+	},
+}
+
+// sectorRow describes one row in the sector dimension of the matrix.
+type sectorRow struct {
+	sector    string
+	shelfLife int // expected ShelfLifeForSector(sector)
+}
+
+var sectorRows = []sectorRow{
+	{"medical", 30},
+	{"finance", 7},
+	{"state", 50},
+	{"infra", 20},
+	{"code", 5},
+	{"generic", 10},
+}
+
+// yearRow describes one row in the timeToCRQC dimension of the matrix.
+// computeYear is the value passed to ComputeHNDLSurplus: 0 is the CLI boundary
+// (rejected before reaching the classifier), so we use 1 there.
+type yearRow struct {
+	label       string
+	computeYear int
+}
+
+var yearRows = []yearRow{
+	{"0_cliBoundary_use1", 1}, // year=0 rejected at CLI; use 1 for the minimum-positive boundary
+	{"1", 1},
+	{"3", 3},
+	{"5", 5},
+	{"10", 10},
+	{"30", 30},
+	{"50", 50},
+	{"100", 100},
+}
+
+// expectedMoscaLevel computes the expected HNDL level for a classical KEM at a given
+// (sector, timeToCRQC) cell.
+func expectedMoscaLevel(shelfLife, timeToCRQC int) HNDLLevel {
+	surplus := ComputeHNDLSurplus(shelfLife, DefaultMigrationLagYears, timeToCRQC)
+	return HNDLLevelFromSurplus(surplus)
+}
+
+// TestMatrix_SectorYearKEM is the 480-case cross-product test.
+// Sub-test names are: sector/year/algorithm — readable in go test -v output.
+func TestMatrix_SectorYearKEM(t *testing.T) {
+	for _, sector := range sectorRows {
+		// Verify the sector shelf-life constant is what we expect.
+		gotShelf := ShelfLifeForSector(sector.sector)
+		if gotShelf != sector.shelfLife {
+			t.Errorf("ShelfLifeForSector(%q) = %d, want %d (matrix spec mismatch)", sector.sector, gotShelf, sector.shelfLife)
+		}
+
+		for _, yr := range yearRows {
+			for _, kem := range kemSpecs {
+				name := fmt.Sprintf("%s/year%s/%s", sector.sector, yr.label, kem.algorithm)
+				t.Run(name, func(t *testing.T) {
+					c := ClassifyAlgorithm(kem.algorithm, kem.primitive, 0)
+
+					// Risk field must match expected.
+					if c.Risk != kem.wantRisk {
+						t.Errorf("Risk = %q, want %q", c.Risk, kem.wantRisk)
+					}
+
+					// HNDL risk field must match expected.
+					if c.HNDLRisk != kem.wantHNDLRisk {
+						t.Errorf("HNDLRisk = %q, want %q", c.HNDLRisk, kem.wantHNDLRisk)
+					}
+
+					// For immediate classical KEMs: verify Mosca HNDL level for this cell.
+					if kem.wantHNDLRisk == HNDLImmediate {
+						wantLevel := expectedMoscaLevel(sector.shelfLife, yr.computeYear)
+						gotSurplus := ComputeHNDLSurplus(sector.shelfLife, DefaultMigrationLagYears, yr.computeYear)
+						gotLevel := HNDLLevelFromSurplus(gotSurplus)
+						if gotLevel != wantLevel {
+							t.Errorf("Mosca level mismatch: sector=%s(shelf=%d) year=%d: surplus=%d level=%s, want %s",
+								sector.sector, sector.shelfLife, yr.computeYear, gotSurplus, gotLevel, wantLevel)
+						}
+					}
+
+					// For PQ-safe: double-check HNDLLevel is LOW regardless of sector/year.
+					if kem.wantHNDLRisk == "" && kem.wantRisk == RiskSafe {
+						// shelfLife=0 models "no harvest risk" — surplus always negative or near-zero.
+						// The algorithm itself is PQ-safe; HNDL level is LOW by definition.
+						safeSurplus := ComputeHNDLSurplus(0, DefaultMigrationLagYears, yr.computeYear)
+						safeLevel := HNDLLevelFromSurplus(safeSurplus)
+						// With timeToCRQC >= 1 and shelfLife=0: surplus = (0+5)-year = 5-year.
+						// For year >= 6: surplus < 0 → LOW. For year < 6: surplus >= 0 → MEDIUM/HIGH.
+						// We only assert that the *algorithm* itself has no HNDL risk (HNDLRisk="").
+						// The safeSurplus here shows what the Mosca math says for shelfLife=0,
+						// but for a PQ-safe KEM, the caller should treat it as LOW regardless.
+						_ = safeLevel // documented above; behaviour verified via HNDLRisk==""
+					}
+				})
+			}
+		}
+	}
+}
+
+// TestMatrix_ImmediateKEM_MoscaLevelSample spot-checks a handful of specific
+// (sector, year, KEM) cells to give readable failure messages for the most
+// important combinations.
+func TestMatrix_ImmediateKEM_MoscaLevelSample(t *testing.T) {
+	type cell struct {
+		sector    string
+		shelfLife int
+		years     int
+		kem       string
+		prim      string
+		wantLevel HNDLLevel
+	}
+	cells := []cell{
+		// Medical (30y) + 1y crqc: 30+5-1=34 → HIGH — most urgent case
+		{"medical", 30, 1, "RSA-2048", "kem", HNDLLevelHigh},
+		// Finance (7y) + 10y crqc: 7+5-10=2 → MEDIUM — near the wire
+		{"finance", 7, 10, "RSA-2048", "kem", HNDLLevelMedium},
+		// Code (5y) + 10y crqc: 5+5-10=0 → MEDIUM — exactly on threshold
+		{"code", 5, 10, "ECDHE-X25519", "key-exchange", HNDLLevelMedium},
+		// State (50y) + 100y crqc: 50+5-100=-45 → LOW — quantum era ends first
+		{"state", 50, 100, "RSA-2048", "kem", HNDLLevelLow},
+		// Infra (20y) + 30y crqc: 20+5-30=-5 → LOW
+		{"infra", 20, 30, "X25519Kyber768Draft00", "kem", HNDLLevelLow},
+		// Generic (10y) + 3y crqc: 10+5-3=12 → HIGH
+		{"generic", 10, 3, "unknown-algo-fallback", "kem", HNDLLevelHigh},
+	}
+	for _, tc := range cells {
+		tc := tc
+		name := fmt.Sprintf("%s_%dy_%s", tc.sector, tc.years, tc.kem)
+		t.Run(name, func(t *testing.T) {
+			c := ClassifyAlgorithm(tc.kem, tc.prim, 0)
+			if c.HNDLRisk != HNDLImmediate {
+				t.Fatalf("expected HNDLImmediate for %q, got %q", tc.kem, c.HNDLRisk)
+			}
+			surplus := ComputeHNDLSurplus(tc.shelfLife, DefaultMigrationLagYears, tc.years)
+			level := HNDLLevelFromSurplus(surplus)
+			if level != tc.wantLevel {
+				t.Errorf("sector=%s shelf=%d years=%d: surplus=%d level=%s, want %s",
+					tc.sector, tc.shelfLife, tc.years, surplus, level, tc.wantLevel)
+			}
+		})
+	}
+}
+
+// TestMatrix_PQSafeAlgorithms_AlwaysLowHNDLRisk verifies that PQ-safe algorithms
+// have empty HNDLRisk across all sectors and years — they are not affected by the
+// Mosca inequality because the ML-KEM component provides independent PQ security.
+func TestMatrix_PQSafeAlgorithms_AlwaysLowHNDLRisk(t *testing.T) {
+	pqSafe := []struct{ alg, prim string }{
+		{"ML-KEM-768", "kem"},
+		{"X25519MLKEM768", "kem"},
+		{"X25519-MLKEM-768", "kem"},
+		{"SecP256r1MLKEM768", "kem"},
+	}
+	for _, alg := range pqSafe {
+		for _, sector := range sectorRows {
+			for _, yr := range yearRows {
+				name := fmt.Sprintf("%s/%s/year%s", alg.alg, sector.sector, yr.label)
+				t.Run(name, func(t *testing.T) {
+					c := ClassifyAlgorithm(alg.alg, alg.prim, 0)
+					if c.HNDLRisk != "" {
+						t.Errorf("%q: HNDLRisk = %q, want \"\" (PQ-safe — no harvest risk regardless of sector/year)",
+							alg.alg, c.HNDLRisk)
+					}
+					if c.Risk != RiskSafe {
+						t.Errorf("%q: Risk = %q, want %q", alg.alg, c.Risk, RiskSafe)
+					}
+				})
+			}
+		}
+	}
+}

--- a/pkg/quantum/sectors.go
+++ b/pkg/quantum/sectors.go
@@ -1,6 +1,11 @@
 package quantum
 
-import "strings"
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
 
 // SectorShelfLife maps industry sector names to their typical data shelf-life in years.
 // Used as the default for --data-lifetime-years when --sector is specified.
@@ -33,7 +38,8 @@ const DefaultSectorShelfLifeYears = 10
 
 // ShelfLifeForSector returns the data shelf-life for the given sector name.
 // Matching is case-insensitive. Returns DefaultSectorShelfLifeYears for an
-// empty or unrecognized sector.
+// empty or unrecognized sector. See WarnOnUnknownSector for a version that
+// emits a diagnostic when the sector name is not recognized.
 func ShelfLifeForSector(sector string) int {
 	if sector == "" {
 		return DefaultSectorShelfLifeYears
@@ -41,5 +47,29 @@ func ShelfLifeForSector(sector string) int {
 	if years, ok := SectorShelfLife[strings.ToLower(sector)]; ok {
 		return years
 	}
+	return DefaultSectorShelfLifeYears
+}
+
+// WarnOnUnknownSector is like ShelfLifeForSector but writes a warning to w when
+// the sector is non-empty and not a recognized preset. The warning lists all valid
+// sector names so the user can correct a typo without consulting the docs.
+//
+// Call this from CLI commands instead of ShelfLifeForSector when user input is
+// involved so that silently falling back to the default is visible in the output.
+func WarnOnUnknownSector(sector string, w io.Writer) int {
+	if sector == "" {
+		return DefaultSectorShelfLifeYears
+	}
+	if years, ok := SectorShelfLife[strings.ToLower(sector)]; ok {
+		return years
+	}
+	// Build a sorted list of valid names for the warning message.
+	valid := make([]string, 0, len(SectorShelfLife))
+	for s := range SectorShelfLife {
+		valid = append(valid, s)
+	}
+	sort.Strings(valid)
+	fmt.Fprintf(w, "WARNING: unknown --sector %q; valid values: %s. Falling back to \"generic\" (%d years).\n",
+		sector, strings.Join(valid, ", "), DefaultSectorShelfLifeYears)
 	return DefaultSectorShelfLifeYears
 }

--- a/pkg/quantum/sectors.go
+++ b/pkg/quantum/sectors.go
@@ -3,7 +3,7 @@ package quantum
 import "strings"
 
 // SectorShelfLife maps industry sector names to their typical data shelf-life in years.
-// Used as the default for --data-sensitivity-years when --sector is specified.
+// Used as the default for --data-lifetime-years when --sector is specified.
 //
 // Values are conservative upper bounds sourced from industry retention requirements:
 //   - medical: HIPAA requires records for 6 years; state laws can require 30+ years for
@@ -27,7 +27,7 @@ var SectorShelfLife = map[string]int{
 	"generic": 10,
 }
 
-// DefaultSectorShelfLifeYears is returned when no --sector or --data-sensitivity-years
+// DefaultSectorShelfLifeYears is returned when no --sector or --data-lifetime-years
 // is provided. 10 years covers the most common legal hold periods.
 const DefaultSectorShelfLifeYears = 10
 

--- a/pkg/quantum/sectors.go
+++ b/pkg/quantum/sectors.go
@@ -1,0 +1,45 @@
+package quantum
+
+import "strings"
+
+// SectorShelfLife maps industry sector names to their typical data shelf-life in years.
+// Used as the default for --data-sensitivity-years when --sector is specified.
+//
+// Values are conservative upper bounds sourced from industry retention requirements:
+//   - medical: HIPAA requires records for 6 years; state laws can require 30+ years for
+//     specific categories (lifetime records, minors, etc.).
+//   - finance: SEC Rule 17a-4 requires broker-dealer records for 7 years; bank exam
+//     data often retained for the same period.
+//   - state: Classified government data may be sensitive for decades; 50 years covers
+//     diplomatic cables, defence contracts, and long-term strategic material.
+//   - infra: Critical infrastructure operational data (SCADA logs, grid telemetry)
+//     retained for 20 years under NERC CIP and similar regimes.
+//   - code: Source code and build artefacts are typically rotated within one major
+//     release cycle (~5 years for most commercial software).
+//   - generic: General enterprise data without a specific classification; 10 years
+//     is a common legal hold period across jurisdictions.
+var SectorShelfLife = map[string]int{
+	"medical": 30,
+	"finance": 7,
+	"state":   50,
+	"infra":   20,
+	"code":    5,
+	"generic": 10,
+}
+
+// DefaultSectorShelfLifeYears is returned when no --sector or --data-sensitivity-years
+// is provided. 10 years covers the most common legal hold periods.
+const DefaultSectorShelfLifeYears = 10
+
+// ShelfLifeForSector returns the data shelf-life for the given sector name.
+// Matching is case-insensitive. Returns DefaultSectorShelfLifeYears for an
+// empty or unrecognized sector.
+func ShelfLifeForSector(sector string) int {
+	if sector == "" {
+		return DefaultSectorShelfLifeYears
+	}
+	if years, ok := SectorShelfLife[strings.ToLower(sector)]; ok {
+		return years
+	}
+	return DefaultSectorShelfLifeYears
+}

--- a/pkg/quantum/sectors_test.go
+++ b/pkg/quantum/sectors_test.go
@@ -1,0 +1,83 @@
+package quantum
+
+import "testing"
+
+func TestShelfLifeForSector_AllPresets(t *testing.T) {
+	tests := []struct {
+		sector    string
+		wantYears int
+	}{
+		{"medical", 30},
+		{"finance", 7},
+		{"state", 50},
+		{"infra", 20},
+		{"code", 5},
+		{"generic", 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.sector, func(t *testing.T) {
+			got := ShelfLifeForSector(tt.sector)
+			if got != tt.wantYears {
+				t.Errorf("ShelfLifeForSector(%q) = %d, want %d", tt.sector, got, tt.wantYears)
+			}
+		})
+	}
+}
+
+func TestShelfLifeForSector_CaseInsensitive(t *testing.T) {
+	variants := []string{"MEDICAL", "Medical", "mEdIcAl", "MEDICAL"}
+	for _, v := range variants {
+		t.Run(v, func(t *testing.T) {
+			got := ShelfLifeForSector(v)
+			if got != 30 {
+				t.Errorf("ShelfLifeForSector(%q) = %d, want 30 (case-insensitive)", v, got)
+			}
+		})
+	}
+}
+
+func TestShelfLifeForSector_UnknownFallsBackToDefault(t *testing.T) {
+	unknowns := []string{"aerospace", "retail", "gaming", "xyz123"}
+	for _, u := range unknowns {
+		t.Run(u, func(t *testing.T) {
+			got := ShelfLifeForSector(u)
+			if got != DefaultSectorShelfLifeYears {
+				t.Errorf("ShelfLifeForSector(%q) = %d, want DefaultSectorShelfLifeYears (%d)",
+					u, got, DefaultSectorShelfLifeYears)
+			}
+		})
+	}
+}
+
+func TestShelfLifeForSector_EmptyStringFallsBackToDefault(t *testing.T) {
+	got := ShelfLifeForSector("")
+	if got != DefaultSectorShelfLifeYears {
+		t.Errorf("ShelfLifeForSector(\"\") = %d, want %d", got, DefaultSectorShelfLifeYears)
+	}
+}
+
+func TestSectorShelfLife_AllPresetsConsistentWithMap(t *testing.T) {
+	// Verify the SectorShelfLife map contains exactly the documented presets.
+	expected := map[string]int{
+		"medical": 30,
+		"finance": 7,
+		"state":   50,
+		"infra":   20,
+		"code":    5,
+		"generic": 10,
+	}
+	if len(SectorShelfLife) != len(expected) {
+		t.Errorf("SectorShelfLife has %d entries, want %d", len(SectorShelfLife), len(expected))
+	}
+	for sector, years := range expected {
+		got, ok := SectorShelfLife[sector]
+		if !ok {
+			t.Errorf("SectorShelfLife missing %q", sector)
+			continue
+		}
+		if got != years {
+			t.Errorf("SectorShelfLife[%q] = %d, want %d", sector, got, years)
+		}
+	}
+}

--- a/pkg/quantum/sectors_test.go
+++ b/pkg/quantum/sectors_test.go
@@ -1,6 +1,8 @@
 package quantum
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestShelfLifeForSector_AllPresets(t *testing.T) {
 	tests := []struct {

--- a/pkg/quantum/sectors_test.go
+++ b/pkg/quantum/sectors_test.go
@@ -1,6 +1,8 @@
 package quantum
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -81,5 +83,64 @@ func TestSectorShelfLife_AllPresetsConsistentWithMap(t *testing.T) {
 		if got != years {
 			t.Errorf("SectorShelfLife[%q] = %d, want %d", sector, got, years)
 		}
+	}
+}
+
+// ─── WarnOnUnknownSector ─────────────────────────────────────────────────────
+
+func TestWarnOnUnknownSector_KnownSectorNoWarning(t *testing.T) {
+	var buf bytes.Buffer
+	for sector, want := range SectorShelfLife {
+		buf.Reset()
+		got := WarnOnUnknownSector(sector, &buf)
+		if got != want {
+			t.Errorf("WarnOnUnknownSector(%q) = %d, want %d", sector, got, want)
+		}
+		if buf.Len() != 0 {
+			t.Errorf("WarnOnUnknownSector(%q) wrote unexpected output: %q", sector, buf.String())
+		}
+	}
+}
+
+func TestWarnOnUnknownSector_UnknownSectorWarnsAndFallsBack(t *testing.T) {
+	var buf bytes.Buffer
+	got := WarnOnUnknownSector("unicorn", &buf)
+	if got != DefaultSectorShelfLifeYears {
+		t.Errorf("WarnOnUnknownSector(\"unicorn\") = %d, want %d", got, DefaultSectorShelfLifeYears)
+	}
+	warning := buf.String()
+	if !strings.Contains(warning, "WARNING") {
+		t.Errorf("expected WARNING prefix in output, got: %q", warning)
+	}
+	if !strings.Contains(warning, "unicorn") {
+		t.Errorf("warning should echo the unknown sector name, got: %q", warning)
+	}
+	// Warning must list all valid sector names.
+	for sector := range SectorShelfLife {
+		if !strings.Contains(warning, sector) {
+			t.Errorf("warning should list valid sector %q, got: %q", sector, warning)
+		}
+	}
+}
+
+func TestWarnOnUnknownSector_EmptyNoWarning(t *testing.T) {
+	var buf bytes.Buffer
+	got := WarnOnUnknownSector("", &buf)
+	if got != DefaultSectorShelfLifeYears {
+		t.Errorf("WarnOnUnknownSector(\"\") = %d, want %d", got, DefaultSectorShelfLifeYears)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("WarnOnUnknownSector(\"\") should not write output, got: %q", buf.String())
+	}
+}
+
+func TestWarnOnUnknownSector_CaseInsensitiveNoWarning(t *testing.T) {
+	var buf bytes.Buffer
+	got := WarnOnUnknownSector("MEDICAL", &buf)
+	if got != 30 {
+		t.Errorf("WarnOnUnknownSector(\"MEDICAL\") = %d, want 30", got)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("case-insensitive match should not warn, got: %q", buf.String())
 	}
 }

--- a/pkg/quantum/testdata/s0-backcompat/golden.json
+++ b/pkg/quantum/testdata/s0-backcompat/golden.json
@@ -1,0 +1,190 @@
+{
+  "schemaVersion": "1",
+  "records": [
+    {
+      "specimen": {
+        "algorithm": "RSA-2048",
+        "primitive": "signature",
+        "keySize": 2048
+      },
+      "risk": "quantum-vulnerable",
+      "severity": "high",
+      "hndlRisk": "deferred",
+      "migrationEffort": "moderate"
+    },
+    {
+      "specimen": {
+        "algorithm": "RSA-2048",
+        "primitive": "kem",
+        "keySize": 2048
+      },
+      "risk": "quantum-vulnerable",
+      "severity": "critical",
+      "hndlRisk": "immediate",
+      "migrationEffort": "complex"
+    },
+    {
+      "specimen": {
+        "algorithm": "ECDH",
+        "primitive": "key-exchange"
+      },
+      "risk": "quantum-vulnerable",
+      "severity": "critical",
+      "hndlRisk": "immediate",
+      "migrationEffort": "complex"
+    },
+    {
+      "specimen": {
+        "algorithm": "ECDSA",
+        "primitive": "signature"
+      },
+      "risk": "quantum-vulnerable",
+      "severity": "high",
+      "hndlRisk": "deferred",
+      "migrationEffort": "moderate"
+    },
+    {
+      "specimen": {
+        "algorithm": "X25519",
+        "primitive": "key-exchange"
+      },
+      "risk": "quantum-vulnerable",
+      "severity": "critical",
+      "hndlRisk": "immediate",
+      "migrationEffort": "complex"
+    },
+    {
+      "specimen": {
+        "algorithm": "X25519MLKEM768",
+        "primitive": "kem"
+      },
+      "risk": "quantum-safe",
+      "severity": "info",
+      "hndlRisk": ""
+    },
+    {
+      "specimen": {
+        "algorithm": "X25519-MLKEM-768",
+        "primitive": "kem"
+      },
+      "risk": "quantum-safe",
+      "severity": "info",
+      "hndlRisk": ""
+    },
+    {
+      "specimen": {
+        "algorithm": "SecP256r1MLKEM768",
+        "primitive": "kem"
+      },
+      "risk": "quantum-safe",
+      "severity": "info",
+      "hndlRisk": ""
+    },
+    {
+      "specimen": {
+        "algorithm": "ML-KEM-768",
+        "primitive": "kem"
+      },
+      "risk": "quantum-safe",
+      "severity": "info",
+      "hndlRisk": ""
+    },
+    {
+      "specimen": {
+        "algorithm": "ML-KEM-512",
+        "primitive": "kem"
+      },
+      "risk": "quantum-safe",
+      "severity": "info",
+      "hndlRisk": ""
+    },
+    {
+      "specimen": {
+        "algorithm": "ML-DSA-65",
+        "primitive": "signature"
+      },
+      "risk": "quantum-safe",
+      "severity": "info",
+      "hndlRisk": ""
+    },
+    {
+      "specimen": {
+        "algorithm": "SLH-DSA-128s",
+        "primitive": "signature"
+      },
+      "risk": "quantum-safe",
+      "severity": "info",
+      "hndlRisk": ""
+    },
+    {
+      "specimen": {
+        "algorithm": "SMAUG-T-128",
+        "primitive": "kem"
+      },
+      "risk": "quantum-safe",
+      "severity": "info",
+      "hndlRisk": ""
+    },
+    {
+      "specimen": {
+        "algorithm": "HAETAE-3",
+        "primitive": "signature"
+      },
+      "risk": "quantum-safe",
+      "severity": "info",
+      "hndlRisk": ""
+    },
+    {
+      "specimen": {
+        "algorithm": "AES-256-GCM",
+        "primitive": "symmetric",
+        "keySize": 256
+      },
+      "risk": "quantum-resistant",
+      "severity": "info",
+      "hndlRisk": ""
+    },
+    {
+      "specimen": {
+        "algorithm": "AES-128-CBC",
+        "primitive": "symmetric",
+        "keySize": 128
+      },
+      "risk": "quantum-weakened",
+      "severity": "low",
+      "hndlRisk": "",
+      "migrationEffort": "moderate"
+    },
+    {
+      "specimen": {
+        "algorithm": "SHA-256",
+        "primitive": "hash",
+        "keySize": 256
+      },
+      "risk": "quantum-resistant",
+      "severity": "info",
+      "hndlRisk": ""
+    },
+    {
+      "specimen": {
+        "algorithm": "MD5",
+        "primitive": "hash"
+      },
+      "risk": "deprecated",
+      "severity": "critical",
+      "hndlRisk": "",
+      "migrationEffort": "simple"
+    },
+    {
+      "specimen": {
+        "algorithm": "DES",
+        "primitive": "symmetric",
+        "keySize": 56
+      },
+      "risk": "deprecated",
+      "severity": "critical",
+      "hndlRisk": "",
+      "migrationEffort": "simple"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes three technical errors in OQS Scanner's Harvest-Now-Decrypt-Later (HNDL) risk model before any downstream PQC UI ships on top of it.

- **Drops PFS-as-HNDL-safe assumption** — classical ECDH captured in the handshake is itself Shor-breakable; PFS does not protect against quantum factoring of the ephemeral exchange. HNDL risk now depends solely on whether the KEM is quantum-resistant.
- **Introduces Mosca-inequality HNDL computation** — `surplus = (data_shelf_life + migration_lag) - time_to_CRQC` with `time_to_CRQC` dynamically resolved against Mosca's 2031 projection.
- **Adds sector presets** — `--sector {medical|finance|state|infra|code|generic}` for shelf-life defaults (30/7/50/20/5/10 years). `--data-lifetime-years` takes precedence and now feeds both QRS and HNDL.
- **Normalizes hyphenated hybrid KEM names** — `X25519-MLKEM-768` classified as PQ-safe alongside `X25519MLKEM768`.

## Test plan

- [x] `go test -race -count=1 ./...` — 44 packages green, 0 failures
- [x] `go test -race -count=5 ./pkg/quantum/...` — no flakiness
- [x] `go vet ./...` — clean
- [x] Fuzz: `FuzzSector` + `FuzzDataLifetime` 10s each — ~1.4M execs, no panics
- [x] Backwards-compat golden snapshot stable (`pkg/quantum/testdata/s0-backcompat/golden.json`)
- [x] CLI: `--data-sensitivity-years` removed, `--data-lifetime-years -5`/`0` rejected, unknown `--sector` warns
- [x] +789 new tests across 8 categories (property / time-travel / matrix / concurrency / fuzz / output-format / backcompat / fix-round regression)

Academic grounding: Mosca (*IEEE S&P* 2018); Gidney & Ekerå (*Quantum* 2021); Blanco-Romero et al. (arXiv:2603.01091, 2026); NIST IR 8547 (draft, 2024).