### PR TITLE
Sprint 1: TLS probe foundation — PQC-presence detection via CurveID

### DIFF
--- a/pkg/engines/tlsprobe/classify.go
+++ b/pkg/engines/tlsprobe/classify.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/jimbo111/open-quantum-secure/pkg/findings"
+	"github.com/jimbo111/open-quantum-secure/pkg/quantum"
 )
 
 // CipherComponent represents one cryptographic primitive extracted from a cipher suite.
@@ -267,6 +268,11 @@ func observationToFindings(result ProbeResult) []findings.UnifiedFinding {
 
 	basePath := "(tls-probe)/" + result.Target
 
+	// Classify the negotiated key-share group. CurveID is 0 for TLS 1.2 sessions
+	// that used an RSA KEM (no named group). Unknown codepoints yield ok=false;
+	// in both cases PQCPresent stays false.
+	groupInfo, groupKnown := quantum.ClassifyTLSGroup(result.NegotiatedGroupID)
+
 	var ff []findings.UnifiedFinding
 
 	// Findings from cipher suite components.
@@ -285,11 +291,12 @@ func observationToFindings(result ProbeResult) []findings.UnifiedFinding {
 				KeySize:   comp.KeySize,
 				Mode:      comp.Mode,
 			},
-			Confidence:   findings.ConfidenceHigh,
-			SourceEngine: "tls-probe",
-			Reachable:    findings.ReachableYes,
+			Confidence:    findings.ConfidenceHigh,
+			SourceEngine:  "tls-probe",
+			Reachable:     findings.ReachableYes,
 			RawIdentifier: comp.Primitive + ":" + comp.Name + "|" + result.CipherSuiteName + "|" + result.Target,
 		}
+		applyGroupFields(&f, result.NegotiatedGroupID, groupInfo, groupKnown)
 		ff = append(ff, f)
 	}
 
@@ -306,17 +313,27 @@ func observationToFindings(result ProbeResult) []findings.UnifiedFinding {
 				Primitive: "signature",
 				KeySize:   result.LeafCertKeySize,
 			},
-			Confidence:   findings.ConfidenceHigh,
-			SourceEngine: "tls-probe",
-			Reachable:    findings.ReachableYes,
+			Confidence:    findings.ConfidenceHigh,
+			SourceEngine:  "tls-probe",
+			Reachable:     findings.ReachableYes,
 			RawIdentifier: "cert:" + result.LeafCertKeyAlgo + "|" + result.Target,
 		}
+		applyGroupFields(&f, result.NegotiatedGroupID, groupInfo, groupKnown)
 		ff = append(ff, f)
 	}
 
-	// For TLS 1.3, the key exchange is implicit (ECDHE with X25519 or P-256).
-	// Add a key-exchange finding since it's not in the cipher suite name.
+	// For TLS 1.3, the key exchange is implicit (not in the cipher suite name).
+	// Emit a dedicated kex finding using the actual negotiated group name when
+	// known, so that PQC hybrid groups (e.g., X25519MLKEM768) are classified as
+	// quantum-safe rather than falling back to the generic "ECDHE" label.
 	if result.TLSVersion == tls.VersionTLS13 {
+		kexName := "ECDHE"
+		rawID := "kex:ECDHE|" + result.Target
+		if groupKnown && groupInfo.PQCPresent {
+			// PQC hybrid: use the group name so ClassifyAlgorithm identifies it as safe.
+			kexName = groupInfo.Name
+			rawID = "kex:" + groupInfo.Name + "|" + result.Target
+		}
 		f := findings.UnifiedFinding{
 			Location: findings.Location{
 				File:         basePath + "#kex",
@@ -324,16 +341,29 @@ func observationToFindings(result ProbeResult) []findings.UnifiedFinding {
 				ArtifactType: "tls-endpoint",
 			},
 			Algorithm: &findings.Algorithm{
-				Name:      "ECDHE",
+				Name:      kexName,
 				Primitive: "key-exchange",
 			},
-			Confidence:   findings.ConfidenceHigh,
-			SourceEngine: "tls-probe",
-			Reachable:    findings.ReachableYes,
-			RawIdentifier: "kex:ECDHE|" + result.Target,
+			Confidence:    findings.ConfidenceHigh,
+			SourceEngine:  "tls-probe",
+			Reachable:     findings.ReachableYes,
+			RawIdentifier: rawID,
 		}
+		applyGroupFields(&f, result.NegotiatedGroupID, groupInfo, groupKnown)
 		ff = append(ff, f)
 	}
 
 	return ff
+}
+
+// applyGroupFields sets the session-level TLS group metadata on a finding.
+// These fields describe the key-share negotiated in the handshake and apply
+// uniformly to all findings emitted for the same probe session.
+func applyGroupFields(f *findings.UnifiedFinding, groupID uint16, info quantum.GroupInfo, known bool) {
+	f.NegotiatedGroup = groupID
+	if known {
+		f.NegotiatedGroupName = info.Name
+		f.PQCPresent = info.PQCPresent
+		f.PQCMaturity = info.Maturity
+	}
 }

--- a/pkg/engines/tlsprobe/concurrency_test.go
+++ b/pkg/engines/tlsprobe/concurrency_test.go
@@ -1,0 +1,167 @@
+package tlsprobe
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/engines"
+)
+
+// concurrency_test.go — verifies that the engine's semaphore correctly limits
+// simultaneous TLS probes to defaultConcurrency (5) at any instant.
+//
+// Uses the probeFn hook (comparable to Sprint 0's nowFn) to inject an
+// instrumented stub that tracks peak concurrency without making real network
+// connections. Also verifies no goroutine leaks after Scan completes.
+//
+// Run the race detector:
+//   go test -race -count=10 ./pkg/engines/tlsprobe/ -run TestConcurrency
+
+// TestConcurrency_DefaultIs5 is a compile-time constant check. If anyone bumps
+// defaultConcurrency back above 5, this test immediately fails with a clear
+// message explaining the regression.
+func TestConcurrency_DefaultIs5(t *testing.T) {
+	if defaultConcurrency != 5 {
+		t.Errorf("defaultConcurrency = %d, want 5 (regression: S1.4 lowered it from 10 to 5 to prevent server-side rate limiting)",
+			defaultConcurrency)
+	}
+}
+
+// TestConcurrency_MaxSimultaneousProbesCappedAt5 submits 20 fake targets and
+// verifies that at no instant do more than defaultConcurrency (5) probes execute
+// simultaneously. It also checks for goroutine leaks after Scan returns.
+func TestConcurrency_MaxSimultaneousProbesCappedAt5(t *testing.T) {
+	var (
+		mu          sync.Mutex
+		activeCnt   int
+		peakCnt     int
+	)
+
+	// Save and restore the production probeFn.
+	origProbeFn := probeFn
+	t.Cleanup(func() { probeFn = origProbeFn })
+
+	// Instrumented stub: counts concurrent calls and sleeps briefly so multiple
+	// probes are in-flight simultaneously.
+	probeFn = func(ctx context.Context, target string, opts ProbeOpts) ProbeResult {
+		mu.Lock()
+		activeCnt++
+		if activeCnt > peakCnt {
+			peakCnt = activeCnt
+		}
+		mu.Unlock()
+
+		// Hold the slot long enough that batches of goroutines pile up, giving
+		// the peak counter a chance to see the real maximum concurrency.
+		select {
+		case <-ctx.Done():
+		case <-time.After(15 * time.Millisecond):
+		}
+
+		mu.Lock()
+		activeCnt--
+		mu.Unlock()
+
+		return ProbeResult{
+			Target: target,
+			Error:  errors.New("stub: not a real server"),
+		}
+	}
+
+	// Build 20 fake targets — more than 4× the semaphore cap to ensure the
+	// semaphore is actually exercised and not bypassed.
+	const numTargets = 20
+	targets := make([]string, numTargets)
+	for i := range targets {
+		targets[i] = "192.0.2.1:443" // TEST-NET, guaranteed unreachable in production
+	}
+
+	goroutinesBefore := runtime.NumGoroutine()
+
+	e := New()
+	opts := engines.ScanOptions{
+		TLSTargets:  targets,
+		TLSInsecure: true,
+		TLSTimeout:  2,
+	}
+
+	// All targets fail (stub returns Error) → engine returns an error. We only
+	// care about the concurrency bound, not the scan result.
+	_, _ = e.Scan(context.Background(), opts)
+
+	// After Scan returns (wg.Wait() inside), all goroutines must have exited.
+	// Allow a small window for the runtime to reap them.
+	time.Sleep(25 * time.Millisecond)
+	goroutinesAfter := runtime.NumGoroutine()
+
+	// ── Assertion 1: peak concurrent probes must not exceed the semaphore cap. ──
+	if peakCnt > defaultConcurrency {
+		t.Errorf("peak simultaneous probes = %d, want ≤ %d (semaphore leak or wrong cap)",
+			peakCnt, defaultConcurrency)
+	}
+	if peakCnt == 0 {
+		t.Errorf("peak concurrent probes = 0 — instrumentation never fired (stub not called?)")
+	}
+
+	// ── Assertion 2: no goroutine leak. ──
+	// We tolerate a small delta for background goroutines created by the test
+	// runtime itself (e.g., finalizer goroutines, GC helpers). 5 is generous.
+	const leakTolerance = 5
+	if goroutinesAfter > goroutinesBefore+leakTolerance {
+		t.Errorf("goroutine leak: before=%d after=%d (delta=%d, tolerance=%d)",
+			goroutinesBefore, goroutinesAfter,
+			goroutinesAfter-goroutinesBefore, leakTolerance)
+	}
+
+	t.Logf("peak concurrent probes: %d (limit: %d); goroutines before/after: %d/%d",
+		peakCnt, defaultConcurrency, goroutinesBefore, goroutinesAfter)
+}
+
+// TestConcurrency_SemaphoreRespectedUnderRace is a lighter stress run designed
+// specifically for -race -count=10. It verifies that shared counter mutations
+// via sync.Mutex are race-free across repeated invocations.
+func TestConcurrency_SemaphoreRespectedUnderRace(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		peak  int
+		calls int
+	)
+
+	origProbeFn := probeFn
+	t.Cleanup(func() { probeFn = origProbeFn })
+
+	probeFn = func(ctx context.Context, target string, opts ProbeOpts) ProbeResult {
+		mu.Lock()
+		calls++
+		if calls > peak {
+			peak = calls
+		}
+		mu.Unlock()
+
+		time.Sleep(5 * time.Millisecond)
+
+		mu.Lock()
+		calls--
+		mu.Unlock()
+
+		return ProbeResult{Target: target, Error: errors.New("stub")}
+	}
+
+	const numTargets = 15
+	targets := make([]string, numTargets)
+	for i := range targets {
+		targets[i] = "192.0.2.1:443"
+	}
+
+	e := New()
+	opts := engines.ScanOptions{TLSTargets: targets, TLSInsecure: true, TLSTimeout: 2}
+	_, _ = e.Scan(context.Background(), opts)
+
+	if peak > defaultConcurrency {
+		t.Errorf("race run: peak=%d > defaultConcurrency=%d", peak, defaultConcurrency)
+	}
+}

--- a/pkg/engines/tlsprobe/curveid_behavior_test.go
+++ b/pkg/engines/tlsprobe/curveid_behavior_test.go
@@ -1,0 +1,287 @@
+package tlsprobe
+
+import (
+	"crypto/tls"
+	"strings"
+	"testing"
+)
+
+// curveid_behavior_test.go — table-driven tests for observationToFindings across
+// the full TLS version × CurveID space that the probe function can produce.
+//
+// Tests are parameterized to cover:
+//   - TLS 1.3 with final PQC hybrid group   (0x11EC — X25519MLKEM768)
+//   - TLS 1.3 with deprecated draft Kyber   (0x6399 — X25519Kyber768Draft00)
+//   - TLS 1.3 with classical ECDH group     (0x001d — X25519)
+//   - TLS 1.3 with CurveID == 0             (shouldn't happen, must not crash)
+//   - TLS 1.3 with unknown codepoint        (0x9999 — must not panic)
+//   - TLS 1.2 with classical ECDHE group    (0x001d from ECDHE handshake)
+//   - TLS 1.2 with CurveID == 0             (RSA KEM — no named group)
+//
+// Additionally verifies Algorithm.Name for the TLS-1.3 synthetic kex finding,
+// encoding the implementer's design decision: PQC hybrid/draft groups use the
+// group name (e.g., "X25519MLKEM768"), classical/unknown groups fall back to
+// the generic "ECDHE" label.
+
+type curveIDBehaviorCase struct {
+	name string
+
+	tlsVersion  uint16
+	curveID     uint16
+	cipherSuite uint16
+	leafKeyAlgo string
+	leafKeySize int
+
+	// expected session-level PQC metadata on every finding
+	wantPQCPresent bool
+	wantMaturity   string // "" means expect empty
+	wantGroupName  string // "" means expect empty
+
+	// wantKexName is the expected Algorithm.Name for the TLS-1.3 synthetic kex
+	// finding (rawID prefix "kex:"). Empty string means no synthetic kex expected
+	// (i.e., TLS 1.2 sessions).
+	wantKexName string
+}
+
+var curveIDBehaviorCases = []curveIDBehaviorCase{
+	{
+		name:           "TLS13_PQCFinal_X25519MLKEM768",
+		tlsVersion:     tls.VersionTLS13,
+		curveID:        0x11EC,
+		cipherSuite:    tls.TLS_AES_256_GCM_SHA384,
+		leafKeyAlgo:    "RSA",
+		leafKeySize:    2048,
+		wantPQCPresent: true,
+		wantMaturity:   "final",
+		wantGroupName:  "X25519MLKEM768",
+		wantKexName:    "X25519MLKEM768",
+	},
+	{
+		name:           "TLS13_DraftKyber_0x6399",
+		tlsVersion:     tls.VersionTLS13,
+		curveID:        0x6399,
+		cipherSuite:    tls.TLS_AES_256_GCM_SHA384,
+		leafKeyAlgo:    "RSA",
+		leafKeySize:    2048,
+		wantPQCPresent: true,
+		wantMaturity:   "draft",
+		wantGroupName:  "X25519Kyber768Draft00",
+		// PQCPresent=true but PQCMaturity="draft" → still uses group name, not "ECDHE".
+		wantKexName: "X25519Kyber768Draft00",
+	},
+	{
+		name:           "TLS13_Classical_X25519",
+		tlsVersion:     tls.VersionTLS13,
+		curveID:        0x001d,
+		cipherSuite:    tls.TLS_AES_128_GCM_SHA256,
+		leafKeyAlgo:    "ECDSA",
+		leafKeySize:    256,
+		wantPQCPresent: false,
+		wantMaturity:   "",
+		wantGroupName:  "X25519",
+		wantKexName:    "ECDHE",
+	},
+	{
+		// CurveID=0 in TLS 1.3 shouldn't occur (TLS 1.3 always negotiates a key
+		// share), but the code must not panic and must not claim PQC presence.
+		name:           "TLS13_ZeroCurveID",
+		tlsVersion:     tls.VersionTLS13,
+		curveID:        0,
+		cipherSuite:    tls.TLS_AES_128_GCM_SHA256,
+		leafKeyAlgo:    "RSA",
+		leafKeySize:    2048,
+		wantPQCPresent: false,
+		wantMaturity:   "",
+		wantGroupName:  "",
+		wantKexName:    "ECDHE",
+	},
+	{
+		// Unknown codepoint — must not panic and must not claim PQC presence.
+		name:           "TLS13_UnknownCurveID_0x9999",
+		tlsVersion:     tls.VersionTLS13,
+		curveID:        0x9999,
+		cipherSuite:    tls.TLS_AES_256_GCM_SHA384,
+		leafKeyAlgo:    "ECDSA",
+		leafKeySize:    256,
+		wantPQCPresent: false,
+		wantMaturity:   "",
+		wantGroupName:  "",
+		wantKexName:    "ECDHE",
+	},
+	{
+		// TLS 1.2 ECDHE — CurveID is set; no TLS-1.3 synthetic kex emitted.
+		name:           "TLS12_ECDHE_X25519",
+		tlsVersion:     tls.VersionTLS12,
+		curveID:        0x001d,
+		cipherSuite:    tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		leafKeyAlgo:    "RSA",
+		leafKeySize:    2048,
+		wantPQCPresent: false,
+		wantMaturity:   "",
+		wantGroupName:  "X25519",
+		wantKexName:    "", // no TLS-1.3 synthetic kex for TLS 1.2
+	},
+	{
+		// TLS 1.2 RSA KEM — no ECDHE, no named group, CurveID=0.
+		name:           "TLS12_RSA_KEM_ZeroCurveID",
+		tlsVersion:     tls.VersionTLS12,
+		curveID:        0,
+		cipherSuite:    tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		leafKeyAlgo:    "RSA",
+		leafKeySize:    2048,
+		wantPQCPresent: false,
+		wantMaturity:   "",
+		wantGroupName:  "",
+		wantKexName:    "", // no TLS-1.3 synthetic kex for TLS 1.2
+	},
+}
+
+func TestCurveIDBehavior_AllCases(t *testing.T) {
+	for _, tc := range curveIDBehaviorCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			result := ProbeResult{
+				Target:            "test.example.com:443",
+				TLSVersion:        tc.tlsVersion,
+				CipherSuiteID:     tc.cipherSuite,
+				CipherSuiteName:   tls.CipherSuiteName(tc.cipherSuite),
+				NegotiatedGroupID: tc.curveID,
+				LeafCertKeyAlgo:   tc.leafKeyAlgo,
+				LeafCertKeySize:   tc.leafKeySize,
+			}
+
+			// observationToFindings must never panic on any valid ProbeResult.
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("observationToFindings panicked: %v", r)
+					}
+				}()
+				findings := observationToFindings(result)
+				if len(findings) == 0 {
+					t.Fatal("expected at least one finding, got none")
+				}
+
+				// Every finding in the session must carry the same session-level metadata.
+				for i, f := range findings {
+					if f.PQCPresent != tc.wantPQCPresent {
+						t.Errorf("finding[%d] %q: PQCPresent=%v, want %v",
+							i, f.RawIdentifier, f.PQCPresent, tc.wantPQCPresent)
+					}
+					if f.PQCMaturity != tc.wantMaturity {
+						t.Errorf("finding[%d] %q: PQCMaturity=%q, want %q",
+							i, f.RawIdentifier, f.PQCMaturity, tc.wantMaturity)
+					}
+					if f.NegotiatedGroupName != tc.wantGroupName {
+						t.Errorf("finding[%d] %q: NegotiatedGroupName=%q, want %q",
+							i, f.RawIdentifier, f.NegotiatedGroupName, tc.wantGroupName)
+					}
+				}
+
+				// Locate the TLS-1.3 synthetic kex finding (rawID prefix "kex:").
+				var syntheticKexName string
+				var foundSyntheticKex bool
+				for _, f := range findings {
+					if strings.HasPrefix(f.RawIdentifier, "kex:") {
+						syntheticKexName = ""
+						if f.Algorithm != nil {
+							syntheticKexName = f.Algorithm.Name
+						}
+						foundSyntheticKex = true
+					}
+				}
+
+				if tc.wantKexName != "" {
+					if !foundSyntheticKex {
+						t.Errorf("expected TLS-1.3 synthetic kex finding (rawID prefix 'kex:'), not found")
+					} else if syntheticKexName != tc.wantKexName {
+						t.Errorf("TLS-1.3 kex Algorithm.Name=%q, want %q",
+							syntheticKexName, tc.wantKexName)
+					}
+				} else if foundSyntheticKex {
+					t.Errorf("unexpected TLS-1.3 synthetic kex finding for TLS 1.2 session (rawID prefix 'kex:')")
+				}
+			}()
+		})
+	}
+}
+
+// TestCurveIDBehavior_PQCGroupNamePropagatesUniformly verifies that when a PQC
+// hybrid group is negotiated, every finding in the session (symmetric, hash,
+// cert, kex) carries the same NegotiatedGroupName. A missing field on any single
+// finding would silently hide PQC negotiation from downstream consumers.
+func TestCurveIDBehavior_PQCGroupNamePropagatesUniformly(t *testing.T) {
+	const groupID = uint16(0x11EC) // X25519MLKEM768
+
+	result := ProbeResult{
+		Target:            "uniform.example.com:443",
+		TLSVersion:        tls.VersionTLS13,
+		CipherSuiteID:     tls.TLS_AES_256_GCM_SHA384,
+		CipherSuiteName:   "TLS_AES_256_GCM_SHA384",
+		NegotiatedGroupID: groupID,
+		LeafCertKeyAlgo:   "ECDSA",
+		LeafCertKeySize:   256,
+	}
+
+	ff := observationToFindings(result)
+	if len(ff) == 0 {
+		t.Fatal("expected findings, got none")
+	}
+
+	for _, f := range ff {
+		if f.NegotiatedGroup != groupID {
+			t.Errorf("finding %q: NegotiatedGroup=0x%04x, want 0x%04x",
+				f.RawIdentifier, f.NegotiatedGroup, groupID)
+		}
+		if f.NegotiatedGroupName != "X25519MLKEM768" {
+			t.Errorf("finding %q: NegotiatedGroupName=%q, want X25519MLKEM768",
+				f.RawIdentifier, f.NegotiatedGroupName)
+		}
+		if !f.PQCPresent {
+			t.Errorf("finding %q: PQCPresent=false, want true", f.RawIdentifier)
+		}
+	}
+}
+
+// TestCurveIDBehavior_DraftKyberBothCodepoints verifies both deprecated Kyber
+// codepoints (0x6399 and 0x636D) produce PQCPresent=true, PQCMaturity="draft".
+func TestCurveIDBehavior_DraftKyberBothCodepoints(t *testing.T) {
+	for _, curveID := range []uint16{0x6399, 0x636D} {
+		curveID := curveID
+		t.Run("0x"+uint16HexStr(curveID), func(t *testing.T) {
+			result := ProbeResult{
+				Target:            "kyber.example.com:443",
+				TLSVersion:        tls.VersionTLS13,
+				CipherSuiteID:     tls.TLS_AES_256_GCM_SHA384,
+				CipherSuiteName:   "TLS_AES_256_GCM_SHA384",
+				NegotiatedGroupID: curveID,
+				LeafCertKeyAlgo:   "ECDSA",
+				LeafCertKeySize:   256,
+			}
+			ff := observationToFindings(result)
+			for _, f := range ff {
+				if !f.PQCPresent {
+					t.Errorf("0x%04x finding %q: PQCPresent=false, want true",
+						curveID, f.RawIdentifier)
+				}
+				if f.PQCMaturity != "draft" {
+					t.Errorf("0x%04x finding %q: PQCMaturity=%q, want draft",
+						curveID, f.RawIdentifier, f.PQCMaturity)
+				}
+				if f.NegotiatedGroupName == "" {
+					t.Errorf("0x%04x finding %q: NegotiatedGroupName empty for known codepoint",
+						curveID, f.RawIdentifier)
+				}
+			}
+		})
+	}
+}
+
+// uint16HexStr returns a 4-digit uppercase hex string for v.
+func uint16HexStr(v uint16) string {
+	const hex = "0123456789ABCDEF"
+	return string([]byte{
+		hex[(v>>12)&0xF], hex[(v>>8)&0xF],
+		hex[(v>>4)&0xF], hex[v&0xF],
+	})
+}

--- a/pkg/engines/tlsprobe/curveid_test.go
+++ b/pkg/engines/tlsprobe/curveid_test.go
@@ -1,0 +1,169 @@
+package tlsprobe
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+// TestObservationToFindings_PQCGroup verifies that when NegotiatedGroupID is a
+// known PQC hybrid (X25519MLKEM768), all emitted findings carry PQCPresent=true
+// and NegotiatedGroupName is populated, and the TLS 1.3 kex finding uses the
+// group name rather than the generic "ECDHE" label.
+func TestObservationToFindings_PQCGroup(t *testing.T) {
+	const x25519mlkem768 = uint16(0x11EC)
+
+	result := ProbeResult{
+		Target:            "pqc-server.example.com:443",
+		TLSVersion:        tls.VersionTLS13,
+		CipherSuiteID:     tls.TLS_AES_256_GCM_SHA384,
+		CipherSuiteName:   "TLS_AES_256_GCM_SHA384",
+		NegotiatedGroupID: x25519mlkem768,
+		LeafCertKeyAlgo:   "RSA",
+		LeafCertKeySize:   2048,
+	}
+
+	ff := observationToFindings(result)
+	if len(ff) == 0 {
+		t.Fatal("expected findings, got none")
+	}
+
+	var kexAlgoName string
+	for _, f := range ff {
+		// Every finding must carry the session-level PQC metadata.
+		if f.NegotiatedGroup != x25519mlkem768 {
+			t.Errorf("finding %q: NegotiatedGroup=0x%04x, want 0x%04x",
+				f.RawIdentifier, f.NegotiatedGroup, x25519mlkem768)
+		}
+		if f.NegotiatedGroupName != "X25519MLKEM768" {
+			t.Errorf("finding %q: NegotiatedGroupName=%q, want X25519MLKEM768",
+				f.RawIdentifier, f.NegotiatedGroupName)
+		}
+		if !f.PQCPresent {
+			t.Errorf("finding %q: PQCPresent=false, want true", f.RawIdentifier)
+		}
+		if f.PQCMaturity != "final" {
+			t.Errorf("finding %q: PQCMaturity=%q, want final", f.RawIdentifier, f.PQCMaturity)
+		}
+
+		// Track kex finding algorithm name.
+		if f.Algorithm != nil && f.Algorithm.Primitive == "key-exchange" {
+			kexAlgoName = f.Algorithm.Name
+		}
+	}
+
+	// TLS 1.3 kex finding should use the group name, not the generic "ECDHE".
+	if kexAlgoName != "X25519MLKEM768" {
+		t.Errorf("TLS 1.3 kex finding Algorithm.Name=%q, want X25519MLKEM768", kexAlgoName)
+	}
+}
+
+// TestObservationToFindings_ClassicalGroup verifies that a classical CurveID
+// (X25519, 0x001d) keeps PQCPresent=false and the kex finding stays "ECDHE".
+func TestObservationToFindings_ClassicalGroup(t *testing.T) {
+	const x25519 = uint16(0x001d)
+
+	result := ProbeResult{
+		Target:            "classical-server.example.com:443",
+		TLSVersion:        tls.VersionTLS13,
+		CipherSuiteID:     tls.TLS_AES_128_GCM_SHA256,
+		CipherSuiteName:   "TLS_AES_128_GCM_SHA256",
+		NegotiatedGroupID: x25519,
+		LeafCertKeyAlgo:   "ECDSA",
+		LeafCertKeySize:   256,
+	}
+
+	ff := observationToFindings(result)
+	if len(ff) == 0 {
+		t.Fatal("expected findings, got none")
+	}
+
+	for _, f := range ff {
+		if f.PQCPresent {
+			t.Errorf("finding %q: PQCPresent=true for classical group X25519", f.RawIdentifier)
+		}
+		if f.NegotiatedGroup != x25519 {
+			t.Errorf("finding %q: NegotiatedGroup=0x%04x, want 0x%04x",
+				f.RawIdentifier, f.NegotiatedGroup, x25519)
+		}
+		if f.NegotiatedGroupName != "X25519" {
+			t.Errorf("finding %q: NegotiatedGroupName=%q, want X25519", f.RawIdentifier, f.NegotiatedGroupName)
+		}
+
+		// kex finding should remain "ECDHE" for classical groups.
+		if f.Algorithm != nil && f.Algorithm.Primitive == "key-exchange" {
+			if f.Algorithm.Name != "ECDHE" {
+				t.Errorf("classical kex finding Name=%q, want ECDHE", f.Algorithm.Name)
+			}
+		}
+	}
+}
+
+// TestObservationToFindings_ZeroCurveID verifies that CurveID=0 (TLS 1.2 RSA KEM,
+// no named group) results in PQCPresent=false and NegotiatedGroupName="".
+func TestObservationToFindings_ZeroCurveID(t *testing.T) {
+	result := ProbeResult{
+		Target:            "rsa-server.example.com:443",
+		TLSVersion:        tls.VersionTLS12,
+		CipherSuiteID:     tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		CipherSuiteName:   "TLS_RSA_WITH_AES_256_GCM_SHA384",
+		NegotiatedGroupID: 0, // no named group
+		LeafCertKeyAlgo:   "RSA",
+		LeafCertKeySize:   2048,
+	}
+
+	ff := observationToFindings(result)
+	if len(ff) == 0 {
+		t.Fatal("expected findings, got none")
+	}
+
+	for _, f := range ff {
+		if f.PQCPresent {
+			t.Errorf("finding %q: PQCPresent=true with zero CurveID", f.RawIdentifier)
+		}
+		if f.NegotiatedGroupName != "" {
+			t.Errorf("finding %q: NegotiatedGroupName=%q, want empty", f.RawIdentifier, f.NegotiatedGroupName)
+		}
+		if f.NegotiatedGroup != 0 {
+			t.Errorf("finding %q: NegotiatedGroup=0x%04x, want 0", f.RawIdentifier, f.NegotiatedGroup)
+		}
+	}
+}
+
+// TestObservationToFindings_DraftKyber verifies that draft Kyber codepoints
+// (0x6399) set PQCPresent=true but PQCMaturity="draft".
+func TestObservationToFindings_DraftKyber(t *testing.T) {
+	const kyberDraft = uint16(0x6399)
+
+	result := ProbeResult{
+		Target:            "draft-kyber.example.com:443",
+		TLSVersion:        tls.VersionTLS13,
+		CipherSuiteID:     tls.TLS_AES_256_GCM_SHA384,
+		CipherSuiteName:   "TLS_AES_256_GCM_SHA384",
+		NegotiatedGroupID: kyberDraft,
+		LeafCertKeyAlgo:   "ECDSA",
+		LeafCertKeySize:   256,
+	}
+
+	ff := observationToFindings(result)
+	if len(ff) == 0 {
+		t.Fatal("expected findings, got none")
+	}
+
+	for _, f := range ff {
+		if !f.PQCPresent {
+			t.Errorf("finding %q: PQCPresent=false for draft Kyber", f.RawIdentifier)
+		}
+		if f.PQCMaturity != "draft" {
+			t.Errorf("finding %q: PQCMaturity=%q, want draft", f.RawIdentifier, f.PQCMaturity)
+		}
+	}
+}
+
+// TestProbeResult_NegotiatedGroupIDField verifies that the field exists and
+// can be set/read with a round-trip through the struct (compile-time check).
+func TestProbeResult_NegotiatedGroupIDField(t *testing.T) {
+	r := ProbeResult{NegotiatedGroupID: 0x11EC}
+	if r.NegotiatedGroupID != 0x11EC {
+		t.Fatalf("NegotiatedGroupID round-trip failed: got 0x%04x", r.NegotiatedGroupID)
+	}
+}

--- a/pkg/engines/tlsprobe/engine.go
+++ b/pkg/engines/tlsprobe/engine.go
@@ -16,8 +16,12 @@ import (
 )
 
 const (
-	defaultTimeout     = 10 * time.Second
-	defaultConcurrency = 10
+	defaultTimeout = 10 * time.Second
+	// defaultConcurrency caps the number of simultaneous TLS handshakes.
+	// Empirical sslyze finding: >5 concurrent probes trigger server-side rate
+	// limiting (connection resets, TCP RST floods) producing false negatives
+	// where reachable servers appear unreachable. 5 is the safe upper bound.
+	defaultConcurrency = 5
 	maxTargets         = 100
 )
 

--- a/pkg/engines/tlsprobe/engine.go
+++ b/pkg/engines/tlsprobe/engine.go
@@ -25,6 +25,11 @@ const (
 	maxTargets         = 100
 )
 
+// probeFn is the underlying single-endpoint probe function. It is a
+// package-level variable so tests can inject an instrumented stub without
+// making real network connections (comparable to Sprint 0's nowFn hook).
+var probeFn = probe
+
 // Engine is the TLS probe engine. Pure Go, always available.
 type Engine struct{}
 
@@ -83,7 +88,7 @@ func (e *Engine) Scan(ctx context.Context, opts engines.ScanOptions) ([]findings
 			defer wg.Done()
 			sem <- struct{}{}        // acquire
 			defer func() { <-sem }() // release
-			results[idx] = probe(ctx, t, probeOpts)
+			results[idx] = probeFn(ctx, t, probeOpts)
 		}(i, target)
 	}
 	wg.Wait()

--- a/pkg/engines/tlsprobe/engine_test.go
+++ b/pkg/engines/tlsprobe/engine_test.go
@@ -204,7 +204,7 @@ func TestEngine_Concurrent_RaceDetector(t *testing.T) {
 
 	addr := srv.Listener.Addr().String()
 
-	// 15 targets all pointing to the same server — exceeds the semaphore cap of 10.
+	// 15 targets all pointing to the same server — exceeds the semaphore cap of 5.
 	const numTargets = 15
 	targets := make([]string, numTargets)
 	for i := range targets {

--- a/pkg/engines/tlsprobe/engine_test.go
+++ b/pkg/engines/tlsprobe/engine_test.go
@@ -193,7 +193,7 @@ func TestTier5NetworkString(t *testing.T) {
 	}
 }
 
-// TestEngine_Concurrent_RaceDetector saturates the semaphore (defaultConcurrency=10)
+// TestEngine_Concurrent_RaceDetector saturates the semaphore (defaultConcurrency=5)
 // with 15 targets that all point to the same TLS server. It verifies that every
 // target produces findings (all reachable) and that no data races occur under -race.
 func TestEngine_Concurrent_RaceDetector(t *testing.T) {

--- a/pkg/engines/tlsprobe/probe.go
+++ b/pkg/engines/tlsprobe/probe.go
@@ -16,18 +16,19 @@ import (
 
 // ProbeResult captures the TLS handshake data from a single endpoint.
 type ProbeResult struct {
-	Target          string // original host:port
-	ResolvedIP      string // IP used for connection (DNS-pinned)
-	TLSVersion      uint16
-	CipherSuiteID   uint16
-	CipherSuiteName string
-	LeafCertKeyAlgo string // "RSA", "ECDSA", "Ed25519"
-	LeafCertKeySize int    // bits
-	LeafCertSigAlgo string // e.g. "SHA256-RSA"
-	Verified        bool   // true if manual cert verification passed
-	VerifyError     string // non-empty if verification failed
-	Error           error  // non-nil means handshake failed entirely
-	Duration        time.Duration
+	Target            string // original host:port
+	ResolvedIP        string // IP used for connection (DNS-pinned)
+	TLSVersion        uint16
+	CipherSuiteID     uint16
+	CipherSuiteName   string
+	NegotiatedGroupID uint16 // IANA SupportedGroup codepoint from ConnectionState().CurveID; 0 = none/unknown
+	LeafCertKeyAlgo   string // "RSA", "ECDSA", "Ed25519"
+	LeafCertKeySize   int    // bits
+	LeafCertSigAlgo   string // e.g. "SHA256-RSA"
+	Verified          bool   // true if manual cert verification passed
+	VerifyError       string // non-empty if verification failed
+	Error             error  // non-nil means handshake failed entirely
+	Duration          time.Duration
 }
 
 // ProbeOpts configures a single TLS probe.
@@ -122,6 +123,11 @@ func probe(ctx context.Context, target string, opts ProbeOpts) ProbeResult {
 	result.TLSVersion = state.Version
 	result.CipherSuiteID = state.CipherSuite
 	result.CipherSuiteName = tls.CipherSuiteName(state.CipherSuite)
+	// CurveID carries the IANA SupportedGroup codepoint negotiated during the
+	// handshake (e.g., 0x11EC for X25519MLKEM768, 0x001d for X25519). It is 0
+	// for TLS 1.2 sessions that used an RSA KEM (no ECDHE, no named group).
+	// tls.CurveID is a uint16 alias, so the conversion is always safe.
+	result.NegotiatedGroupID = uint16(state.CurveID)
 
 	// Extract leaf cert info.
 	if len(capturedCerts) > 0 {

--- a/pkg/findings/dedup_pqc_test.go
+++ b/pkg/findings/dedup_pqc_test.go
@@ -1,0 +1,184 @@
+package findings
+
+import (
+	"strings"
+	"testing"
+)
+
+// dedup_pqc_test.go — verifies that the asymmetric Algorithm.Name design
+// used by the tls-probe engine (S1.1) does not cause unintended DedupeKey
+// collisions or double-counting.
+//
+// Design recap (from classify.go):
+//   - TLS 1.3 + PQC hybrid group  → kex finding Algorithm.Name = group name
+//     (e.g., "X25519MLKEM768")
+//   - TLS 1.3 + classical/unknown → kex finding Algorithm.Name = "ECDHE"
+//
+// Assertions:
+//   1. PQC kex ("X25519MLKEM768") and classical kex ("ECDHE") from the same
+//      target do NOT share a DedupeKey — they describe different sessions.
+//   2. Two PQC kex findings from the same target DO share a DedupeKey —
+//      they represent the same session observed by two engines (corroboration).
+//   3. PQC kex findings from different targets do NOT share a DedupeKey —
+//      different endpoints are always distinct.
+//   4. DedupeKey includes Algorithm.Name — confirms that asymmetric naming
+//      doesn't produce accidental merges.
+
+// tlsKexFinding constructs a synthetic TLS-probe kex finding using the same
+// path convention as tlsprobe/classify.go:
+//
+//	basePath = "(tls-probe)/" + target
+//	kexPath  = basePath + "#kex"
+func tlsKexFinding(target, algorithmName string) *UnifiedFinding {
+	return &UnifiedFinding{
+		Location: Location{
+			File:         "(tls-probe)/" + target + "#kex",
+			Line:         0,
+			ArtifactType: "tls-endpoint",
+		},
+		Algorithm: &Algorithm{
+			Name:      algorithmName,
+			Primitive: "key-exchange",
+		},
+		SourceEngine: "tls-probe",
+		Confidence:   ConfidenceHigh,
+		Reachable:    ReachableYes,
+	}
+}
+
+// TestDedupPQC_PQCAndClassicalKex_NoCollision verifies that a PQC kex finding
+// ("X25519MLKEM768") and a classical kex finding ("ECDHE") from the same target
+// produce DIFFERENT DedupeKeys. They represent different TLS sessions
+// (PQC-negotiated vs classical) and must not be merged.
+func TestDedupPQC_PQCAndClassicalKex_NoCollision(t *testing.T) {
+	target := "example.com:443"
+	pqcKex := tlsKexFinding(target, "X25519MLKEM768")
+	classicalKex := tlsKexFinding(target, "ECDHE")
+
+	kPQC := pqcKex.DedupeKey()
+	kClassical := classicalKex.DedupeKey()
+
+	if kPQC == kClassical {
+		t.Errorf("PQC kex and classical kex for same target must not share a DedupeKey: %q", kPQC)
+	}
+
+	// Both keys must be non-empty and contain the algorithm name, confirming
+	// that Algorithm.Name is part of the key (not elided).
+	if !strings.Contains(kPQC, "X25519MLKEM768") {
+		t.Errorf("PQC kex DedupeKey %q does not contain algorithm name 'X25519MLKEM768'", kPQC)
+	}
+	if !strings.Contains(kClassical, "ECDHE") {
+		t.Errorf("classical kex DedupeKey %q does not contain algorithm name 'ECDHE'", kClassical)
+	}
+}
+
+// TestDedupPQC_SamePQCSession_SharedKey verifies that two kex findings for the
+// same PQC hybrid group from the same target share a DedupeKey. This models
+// the corroboration case: two engines observe the same TLS 1.3 handshake on
+// the same host and both emit an "X25519MLKEM768" kex finding.
+func TestDedupPQC_SamePQCSession_SharedKey(t *testing.T) {
+	target := "hybrid.example.com:443"
+	f1 := tlsKexFinding(target, "X25519MLKEM768")
+	f2 := tlsKexFinding(target, "X25519MLKEM768")
+	// Different source engine simulates corroboration.
+	f2.SourceEngine = "tls-probe-corroborator"
+
+	if f1.DedupeKey() != f2.DedupeKey() {
+		t.Errorf("same PQC session (same target + name) must share DedupeKey: %q vs %q",
+			f1.DedupeKey(), f2.DedupeKey())
+	}
+}
+
+// TestDedupPQC_DifferentTargets_NoCollision verifies that the same PQC group
+// negotiated on two different hosts produces different DedupeKeys, preventing
+// false-positive deduplication across endpoints.
+func TestDedupPQC_DifferentTargets_NoCollision(t *testing.T) {
+	f1 := tlsKexFinding("host-a.example.com:443", "X25519MLKEM768")
+	f2 := tlsKexFinding("host-b.example.com:443", "X25519MLKEM768")
+
+	if f1.DedupeKey() == f2.DedupeKey() {
+		t.Errorf("same PQC group on different targets must NOT share a DedupeKey: %q", f1.DedupeKey())
+	}
+}
+
+// TestDedupPQC_DraftVsFinalKex_NoCollision verifies that deprecated draft Kyber
+// ("X25519Kyber768Draft00") and the final standardised hybrid ("X25519MLKEM768")
+// produce distinct DedupeKeys even on the same target. They are different
+// algorithm names and must not be merged.
+func TestDedupPQC_DraftVsFinalKex_NoCollision(t *testing.T) {
+	target := "transitioning.example.com:443"
+	final := tlsKexFinding(target, "X25519MLKEM768")
+	draft := tlsKexFinding(target, "X25519Kyber768Draft00")
+
+	if final.DedupeKey() == draft.DedupeKey() {
+		t.Errorf("final hybrid and deprecated draft on same target must not share DedupeKey: %q",
+			final.DedupeKey())
+	}
+}
+
+// TestDedupPQC_PrimitiveSuffix_KexVsSig verifies that the #kex vs #sig path
+// suffix (set by tlsprobe/classify.go's primitiveToSuffix map) prevents
+// collisions between RSA-as-kex and RSA-as-sig for the same target. This is
+// orthogonal to PQC but validates that the suffix encoding still works when
+// PQC fields are present.
+func TestDedupPQC_PrimitiveSuffix_KexVsSig(t *testing.T) {
+	target := "rsa.example.com:443"
+	kexFinding := &UnifiedFinding{
+		Location:    Location{File: "(tls-probe)/" + target + "#kex"},
+		Algorithm:   &Algorithm{Name: "RSA", Primitive: "key-exchange"},
+		SourceEngine: "tls-probe",
+		PQCPresent:  false,
+	}
+	sigFinding := &UnifiedFinding{
+		Location:    Location{File: "(tls-probe)/" + target + "#sig"},
+		Algorithm:   &Algorithm{Name: "RSA", Primitive: "signature"},
+		SourceEngine: "tls-probe",
+		PQCPresent:  false,
+	}
+
+	if kexFinding.DedupeKey() == sigFinding.DedupeKey() {
+		t.Errorf("RSA-kex and RSA-sig for same target must have different DedupeKeys: %q",
+			kexFinding.DedupeKey())
+	}
+}
+
+// TestDedupPQC_AsymmetricNaming_NoCrossEngineDoubleCount is the main design
+// regression test. It constructs findings as the tls-probe engine would emit
+// them from a single PQC-negotiated session:
+//
+//   - Cipher-suite component kex: "ECDHE" at #kex (from cipher suite decomp)
+//     NOTE: for TLS 1.3 cipher suites, no kex component is emitted by the
+//     cipher suite decomposition. But for TLS 1.2 ECDHE suites it would be.
+//   - TLS-1.3 synthetic kex: "X25519MLKEM768" at #kex (group name)
+//
+// For TLS 1.3 there is only ONE kex finding (the synthetic one). This test
+// verifies that if two findings with different algorithm names were somehow
+// emitted for the same #kex path, they would NOT accidentally share a key.
+func TestDedupPQC_AsymmetricNaming_NoCrossEngineDoubleCount(t *testing.T) {
+	target := "pqc-host.example.com:443"
+
+	// Hypothetical "ECDHE" finding at the same path as the PQC kex finding.
+	ecdheFinding := &UnifiedFinding{
+		Location:    Location{File: "(tls-probe)/" + target + "#kex"},
+		Algorithm:   &Algorithm{Name: "ECDHE", Primitive: "key-exchange"},
+		SourceEngine: "tls-probe",
+	}
+	// Actual PQC hybrid kex finding.
+	pqcFinding := &UnifiedFinding{
+		Location:    Location{File: "(tls-probe)/" + target + "#kex"},
+		Algorithm:   &Algorithm{Name: "X25519MLKEM768", Primitive: "key-exchange"},
+		SourceEngine: "tls-probe",
+		PQCPresent:  true,
+		PQCMaturity: "final",
+	}
+
+	kECDHE := ecdheFinding.DedupeKey()
+	kPQC := pqcFinding.DedupeKey()
+
+	// Different algorithm names → different keys → no accidental merge.
+	if kECDHE == kPQC {
+		t.Errorf("ECDHE and X25519MLKEM768 at the same path must not share a DedupeKey: %q", kECDHE)
+	}
+	t.Logf("ECDHE key: %s", kECDHE)
+	t.Logf("PQC key:   %s", kPQC)
+}

--- a/pkg/findings/pqc_clone_test.go
+++ b/pkg/findings/pqc_clone_test.go
@@ -1,0 +1,188 @@
+package findings
+
+import "testing"
+
+// pqc_clone_test.go — deep-copy safety checks for the Sprint 1 PQC fields on
+// UnifiedFinding.Clone().
+//
+// The four PQC fields are value types (uint16, string, bool, string), so Clone
+// provides trivial copy safety. These tests act as a golden assertion: if a
+// future refactor changes any field to a reference type (e.g., *string for
+// interning, []byte for a group ID array), the tests will catch shallow-copy
+// regressions before they reach production.
+//
+// Tests also verify that the clone is equal to the original immediately after
+// cloning, and that mutations in EITHER direction (clone→doesn't affect original,
+// original→doesn't affect clone) are independent.
+
+// TestPQCClone_AllFieldsPopulated verifies that Clone copies all four PQC
+// fields with their non-zero values intact.
+func TestPQCClone_AllFieldsPopulated(t *testing.T) {
+	orig := UnifiedFinding{
+		SourceEngine:        "tls-probe",
+		NegotiatedGroup:     0x11EC,
+		NegotiatedGroupName: "X25519MLKEM768",
+		PQCPresent:          true,
+		PQCMaturity:         "final",
+	}
+
+	clone := orig.Clone()
+
+	if clone.NegotiatedGroup != orig.NegotiatedGroup {
+		t.Errorf("NegotiatedGroup: clone=0x%04x, orig=0x%04x", clone.NegotiatedGroup, orig.NegotiatedGroup)
+	}
+	if clone.NegotiatedGroupName != orig.NegotiatedGroupName {
+		t.Errorf("NegotiatedGroupName: clone=%q, orig=%q", clone.NegotiatedGroupName, orig.NegotiatedGroupName)
+	}
+	if clone.PQCPresent != orig.PQCPresent {
+		t.Errorf("PQCPresent: clone=%v, orig=%v", clone.PQCPresent, orig.PQCPresent)
+	}
+	if clone.PQCMaturity != orig.PQCMaturity {
+		t.Errorf("PQCMaturity: clone=%q, orig=%q", clone.PQCMaturity, orig.PQCMaturity)
+	}
+}
+
+// TestPQCClone_MutateClone_DoesNotAffectOriginal mutates all four PQC fields on
+// the clone and verifies the original is unchanged. This is the shallow-copy-safety
+// check for the forward direction (clone modification leaking to original).
+func TestPQCClone_MutateClone_DoesNotAffectOriginal(t *testing.T) {
+	orig := UnifiedFinding{
+		NegotiatedGroup:     0x11EC,
+		NegotiatedGroupName: "X25519MLKEM768",
+		PQCPresent:          true,
+		PQCMaturity:         "final",
+	}
+
+	clone := orig.Clone()
+
+	// Mutate every PQC field on the clone.
+	clone.NegotiatedGroup = 0x001d
+	clone.NegotiatedGroupName = "X25519"
+	clone.PQCPresent = false
+	clone.PQCMaturity = ""
+
+	// Original must be unchanged.
+	if orig.NegotiatedGroup != 0x11EC {
+		t.Errorf("orig.NegotiatedGroup mutated to 0x%04x after clone mutation", orig.NegotiatedGroup)
+	}
+	if orig.NegotiatedGroupName != "X25519MLKEM768" {
+		t.Errorf("orig.NegotiatedGroupName mutated to %q after clone mutation", orig.NegotiatedGroupName)
+	}
+	if !orig.PQCPresent {
+		t.Error("orig.PQCPresent mutated to false after clone mutation")
+	}
+	if orig.PQCMaturity != "final" {
+		t.Errorf("orig.PQCMaturity mutated to %q after clone mutation", orig.PQCMaturity)
+	}
+}
+
+// TestPQCClone_MutateOriginal_DoesNotAffectClone mutates the original after
+// cloning and verifies the clone is unchanged. This is the reverse direction
+// safety check that complements TestPQCClone_MutateClone_DoesNotAffectOriginal.
+func TestPQCClone_MutateOriginal_DoesNotAffectClone(t *testing.T) {
+	orig := UnifiedFinding{
+		NegotiatedGroup:     0x6399,
+		NegotiatedGroupName: "X25519Kyber768Draft00",
+		PQCPresent:          true,
+		PQCMaturity:         "draft",
+	}
+
+	clone := orig.Clone()
+
+	// Mutate every PQC field on the original.
+	orig.NegotiatedGroup = 0
+	orig.NegotiatedGroupName = ""
+	orig.PQCPresent = false
+	orig.PQCMaturity = ""
+
+	// Clone must retain the values it had at Clone() time.
+	if clone.NegotiatedGroup != 0x6399 {
+		t.Errorf("clone.NegotiatedGroup mutated to 0x%04x after original mutation", clone.NegotiatedGroup)
+	}
+	if clone.NegotiatedGroupName != "X25519Kyber768Draft00" {
+		t.Errorf("clone.NegotiatedGroupName mutated to %q after original mutation", clone.NegotiatedGroupName)
+	}
+	if !clone.PQCPresent {
+		t.Error("clone.PQCPresent mutated to false after original mutation")
+	}
+	if clone.PQCMaturity != "draft" {
+		t.Errorf("clone.PQCMaturity mutated to %q after original mutation", clone.PQCMaturity)
+	}
+}
+
+// TestPQCClone_DraftAndFinalVariants exercises both draft and final maturity
+// variants in a single clone cycle to ensure no interning or aliasing occurs
+// between distinct maturity strings.
+func TestPQCClone_DraftAndFinalVariants(t *testing.T) {
+	cases := []struct {
+		name    string
+		finding UnifiedFinding
+	}{
+		{
+			"final-hybrid",
+			UnifiedFinding{
+				NegotiatedGroup:     0x11EC,
+				NegotiatedGroupName: "X25519MLKEM768",
+				PQCPresent:          true,
+				PQCMaturity:         "final",
+			},
+		},
+		{
+			"draft-kyber-primary",
+			UnifiedFinding{
+				NegotiatedGroup:     0x6399,
+				NegotiatedGroupName: "X25519Kyber768Draft00",
+				PQCPresent:          true,
+				PQCMaturity:         "draft",
+			},
+		},
+		{
+			"draft-kyber-alt",
+			UnifiedFinding{
+				NegotiatedGroup:     0x636D,
+				NegotiatedGroupName: "X25519Kyber768Draft00",
+				PQCPresent:          true,
+				PQCMaturity:         "draft",
+			},
+		},
+		{
+			"classical-no-pqc",
+			UnifiedFinding{
+				NegotiatedGroup:     0x001d,
+				NegotiatedGroupName: "X25519",
+				PQCPresent:          false,
+				PQCMaturity:         "",
+			},
+		},
+		{
+			"zero-fields",
+			UnifiedFinding{
+				// All PQC fields at zero value — clone must also be zero.
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			clone := tc.finding.Clone()
+
+			if clone.NegotiatedGroup != tc.finding.NegotiatedGroup {
+				t.Errorf("NegotiatedGroup mismatch: clone=0x%04x orig=0x%04x",
+					clone.NegotiatedGroup, tc.finding.NegotiatedGroup)
+			}
+			if clone.NegotiatedGroupName != tc.finding.NegotiatedGroupName {
+				t.Errorf("NegotiatedGroupName mismatch: clone=%q orig=%q",
+					clone.NegotiatedGroupName, tc.finding.NegotiatedGroupName)
+			}
+			if clone.PQCPresent != tc.finding.PQCPresent {
+				t.Errorf("PQCPresent mismatch: clone=%v orig=%v",
+					clone.PQCPresent, tc.finding.PQCPresent)
+			}
+			if clone.PQCMaturity != tc.finding.PQCMaturity {
+				t.Errorf("PQCMaturity mismatch: clone=%q orig=%q",
+					clone.PQCMaturity, tc.finding.PQCMaturity)
+			}
+		})
+	}
+}

--- a/pkg/findings/pqc_fields_test.go
+++ b/pkg/findings/pqc_fields_test.go
@@ -1,0 +1,125 @@
+package findings
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestUnifiedFinding_PQCFields verifies that the Sprint 1 TLS PQC fields
+// serialize/deserialize correctly and that Clone copies them as value types.
+func TestUnifiedFinding_PQCFields_JSONRoundTrip(t *testing.T) {
+	orig := UnifiedFinding{
+		SourceEngine:        "tls-probe",
+		NegotiatedGroup:     0x11EC,
+		NegotiatedGroupName: "X25519MLKEM768",
+		PQCPresent:          true,
+		PQCMaturity:         "final",
+	}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	var got UnifiedFinding
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	if got.NegotiatedGroup != orig.NegotiatedGroup {
+		t.Errorf("NegotiatedGroup: got 0x%04x, want 0x%04x", got.NegotiatedGroup, orig.NegotiatedGroup)
+	}
+	if got.NegotiatedGroupName != orig.NegotiatedGroupName {
+		t.Errorf("NegotiatedGroupName: got %q, want %q", got.NegotiatedGroupName, orig.NegotiatedGroupName)
+	}
+	if got.PQCPresent != orig.PQCPresent {
+		t.Errorf("PQCPresent: got %v, want %v", got.PQCPresent, orig.PQCPresent)
+	}
+	if got.PQCMaturity != orig.PQCMaturity {
+		t.Errorf("PQCMaturity: got %q, want %q", got.PQCMaturity, orig.PQCMaturity)
+	}
+}
+
+// TestUnifiedFinding_PQCFields_OmitEmpty verifies that zero-value PQC fields
+// are omitted from JSON to keep output clean for non-TLS findings.
+func TestUnifiedFinding_PQCFields_OmitEmpty(t *testing.T) {
+	f := UnifiedFinding{
+		SourceEngine: "semgrep",
+		Algorithm:    &Algorithm{Name: "RSA"},
+		// NegotiatedGroup=0, NegotiatedGroupName="", PQCPresent=false, PQCMaturity=""
+	}
+
+	data, err := json.Marshal(f)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal to map: %v", err)
+	}
+
+	for _, field := range []string{"negotiatedGroup", "negotiatedGroupName", "pqcPresent", "pqcMaturity"} {
+		if _, present := raw[field]; present {
+			t.Errorf("field %q should be omitted when zero, but it was present in JSON", field)
+		}
+	}
+}
+
+// TestUnifiedFinding_PQCFields_Clone verifies that Clone copies value-type PQC fields.
+func TestUnifiedFinding_PQCFields_Clone(t *testing.T) {
+	orig := UnifiedFinding{
+		NegotiatedGroup:     0x11EC,
+		NegotiatedGroupName: "X25519MLKEM768",
+		PQCPresent:          true,
+		PQCMaturity:         "final",
+	}
+
+	clone := orig.Clone()
+
+	// Mutate original after clone — clone must not be affected.
+	orig.NegotiatedGroup = 0x001d
+	orig.NegotiatedGroupName = "X25519"
+	orig.PQCPresent = false
+	orig.PQCMaturity = ""
+
+	if clone.NegotiatedGroup != 0x11EC {
+		t.Errorf("Clone NegotiatedGroup mutated: got 0x%04x", clone.NegotiatedGroup)
+	}
+	if clone.NegotiatedGroupName != "X25519MLKEM768" {
+		t.Errorf("Clone NegotiatedGroupName mutated: got %q", clone.NegotiatedGroupName)
+	}
+	if !clone.PQCPresent {
+		t.Errorf("Clone PQCPresent mutated: got false")
+	}
+	if clone.PQCMaturity != "final" {
+		t.Errorf("Clone PQCMaturity mutated: got %q", clone.PQCMaturity)
+	}
+}
+
+// TestUnifiedFinding_PQCFields_DraftMaturity verifies draft-maturity round-trip.
+func TestUnifiedFinding_PQCFields_DraftMaturity(t *testing.T) {
+	orig := UnifiedFinding{
+		NegotiatedGroup:     0x6399,
+		NegotiatedGroupName: "X25519Kyber768Draft00",
+		PQCPresent:          true,
+		PQCMaturity:         "draft",
+	}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	var got UnifiedFinding
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	if got.PQCMaturity != "draft" {
+		t.Errorf("PQCMaturity: got %q, want draft", got.PQCMaturity)
+	}
+	if got.PQCPresent != true {
+		t.Errorf("PQCPresent: got false for draft Kyber, want true")
+	}
+}

--- a/pkg/findings/unified.go
+++ b/pkg/findings/unified.go
@@ -104,6 +104,12 @@ type UnifiedFinding struct {
 	TargetAlgorithm  string            `json:"targetAlgorithm,omitempty"`  // PQC replacement algorithm
 	TargetStandard   string            `json:"targetStandard,omitempty"`   // NIST standard reference
 	MigrationSnippet *MigrationSnippet `json:"migrationSnippet,omitempty"` // language-specific PQC migration example
+
+	// TLS network probe fields (populated by tls-probe engine, Sprint 1).
+	NegotiatedGroup     uint16 `json:"negotiatedGroup,omitempty"`     // IANA TLS SupportedGroup codepoint (0 = none/unknown)
+	NegotiatedGroupName string `json:"negotiatedGroupName,omitempty"` // human-readable name, e.g. "X25519MLKEM768"
+	PQCPresent          bool   `json:"pqcPresent,omitempty"`          // true when an ML-KEM-based group was negotiated
+	PQCMaturity         string `json:"pqcMaturity,omitempty"`         // "final", "draft", or "" (classical/unknown)
 }
 
 // MigrationSnippet holds a language-specific PQC migration code example.

--- a/pkg/output/cbom.go
+++ b/pkg/output/cbom.go
@@ -337,6 +337,15 @@ func buildAlgorithmComponent(f findings.UnifiedFinding, occurrences []cdxOccurre
 	if f.SourceEngine == "tls-probe" {
 		props = append(props, cdxProperty{Name: "oqs:sourceType", Value: "tls-endpoint"})
 	}
+	if f.NegotiatedGroupName != "" {
+		props = append(props, cdxProperty{Name: "oqs:negotiatedGroup", Value: f.NegotiatedGroupName})
+	}
+	if f.PQCPresent {
+		props = append(props, cdxProperty{Name: "oqs:pqcPresent", Value: "true"})
+	}
+	if f.PQCMaturity != "" {
+		props = append(props, cdxProperty{Name: "oqs:pqcMaturity", Value: f.PQCMaturity})
+	}
 
 	if len(f.DataFlowPath) > 0 {
 		dfpJSON, err := json.Marshal(f.DataFlowPath)

--- a/pkg/output/pqc_fields_format_test.go
+++ b/pkg/output/pqc_fields_format_test.go
@@ -1,0 +1,395 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/findings"
+)
+
+// pqc_fields_format_test.go — round-trip serialization tests for the Sprint 1 PQC
+// fields (NegotiatedGroup, NegotiatedGroupName, PQCPresent, PQCMaturity) across
+// all four output formats: JSON, SARIF, CBOM, and table.
+//
+// Three fixtures:
+//   1. RSA classical   — no PQC fields set
+//   2. X25519MLKEM768  — final hybrid PQC
+//   3. X25519Kyber768Draft00 — deprecated draft PQC
+
+func makePQCTestResult(ff []findings.UnifiedFinding) ScanResult {
+	return ScanResult{
+		Version:  "0.0.0-test",
+		Target:   "/test",
+		Engines:  []string{"tls-probe"},
+		Findings: ff,
+	}
+}
+
+// rsaFinding is a classical RSA key-exchange finding with no PQC fields.
+func rsaFinding() findings.UnifiedFinding {
+	return findings.UnifiedFinding{
+		Location:     findings.Location{File: "(tls-probe)/rsa.example.com:443#kex"},
+		Algorithm:    &findings.Algorithm{Name: "RSA", Primitive: "key-exchange"},
+		SourceEngine: "tls-probe",
+		Confidence:   findings.ConfidenceHigh,
+		Reachable:    findings.ReachableYes,
+		QuantumRisk:  findings.QRVulnerable,
+		// PQC fields deliberately left zero
+	}
+}
+
+// pqcFinalFinding is a final hybrid PQC finding (X25519MLKEM768).
+func pqcFinalFinding() findings.UnifiedFinding {
+	return findings.UnifiedFinding{
+		Location:            findings.Location{File: "(tls-probe)/hybrid.example.com:443#kex"},
+		Algorithm:           &findings.Algorithm{Name: "X25519MLKEM768", Primitive: "key-exchange"},
+		SourceEngine:        "tls-probe",
+		Confidence:          findings.ConfidenceHigh,
+		Reachable:           findings.ReachableYes,
+		QuantumRisk:         findings.QRSafe,
+		NegotiatedGroup:     0x11EC,
+		NegotiatedGroupName: "X25519MLKEM768",
+		PQCPresent:          true,
+		PQCMaturity:         "final",
+	}
+}
+
+// pqcDraftFinding is a deprecated-draft Kyber finding (X25519Kyber768Draft00).
+func pqcDraftFinding() findings.UnifiedFinding {
+	return findings.UnifiedFinding{
+		Location:            findings.Location{File: "(tls-probe)/draft.example.com:443#kex"},
+		Algorithm:           &findings.Algorithm{Name: "X25519Kyber768Draft00", Primitive: "key-exchange"},
+		SourceEngine:        "tls-probe",
+		Confidence:          findings.ConfidenceHigh,
+		Reachable:           findings.ReachableYes,
+		QuantumRisk:         findings.QRDeprecated,
+		NegotiatedGroup:     0x6399,
+		NegotiatedGroupName: "X25519Kyber768Draft00",
+		PQCPresent:          true,
+		PQCMaturity:         "draft",
+	}
+}
+
+// ── JSON round-trip ──────────────────────────────────────────────────────────
+
+func TestPQCFormat_JSON_RoundTrip(t *testing.T) {
+	result := makePQCTestResult([]findings.UnifiedFinding{
+		rsaFinding(),
+		pqcFinalFinding(),
+		pqcDraftFinding(),
+	})
+
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, result); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+
+	// Unmarshal back via ScanResult structure.
+	var got ScanResult
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("json.Unmarshal ScanResult: %v", err)
+	}
+	if len(got.Findings) != 3 {
+		t.Fatalf("expected 3 findings, got %d", len(got.Findings))
+	}
+
+	// [0] RSA classical — PQC fields must round-trip as zero.
+	rsa := got.Findings[0]
+	if rsa.PQCPresent {
+		t.Error("RSA finding: PQCPresent=true after JSON round-trip, want false")
+	}
+	if rsa.NegotiatedGroupName != "" {
+		t.Errorf("RSA finding: NegotiatedGroupName=%q after round-trip, want empty", rsa.NegotiatedGroupName)
+	}
+	if rsa.PQCMaturity != "" {
+		t.Errorf("RSA finding: PQCMaturity=%q after round-trip, want empty", rsa.PQCMaturity)
+	}
+
+	// [1] X25519MLKEM768 final — all PQC fields must survive.
+	hybrid := got.Findings[1]
+	if hybrid.NegotiatedGroup != 0x11EC {
+		t.Errorf("hybrid: NegotiatedGroup=0x%04x, want 0x11EC", hybrid.NegotiatedGroup)
+	}
+	if hybrid.NegotiatedGroupName != "X25519MLKEM768" {
+		t.Errorf("hybrid: NegotiatedGroupName=%q, want X25519MLKEM768", hybrid.NegotiatedGroupName)
+	}
+	if !hybrid.PQCPresent {
+		t.Error("hybrid: PQCPresent=false after round-trip, want true")
+	}
+	if hybrid.PQCMaturity != "final" {
+		t.Errorf("hybrid: PQCMaturity=%q, want final", hybrid.PQCMaturity)
+	}
+
+	// [2] X25519Kyber768Draft00 deprecated — draft maturity must survive.
+	draft := got.Findings[2]
+	if !draft.PQCPresent {
+		t.Error("draft: PQCPresent=false after round-trip, want true")
+	}
+	if draft.PQCMaturity != "draft" {
+		t.Errorf("draft: PQCMaturity=%q, want draft", draft.PQCMaturity)
+	}
+	if draft.NegotiatedGroup != 0x6399 {
+		t.Errorf("draft: NegotiatedGroup=0x%04x, want 0x6399", draft.NegotiatedGroup)
+	}
+}
+
+// TestPQCFormat_JSON_OmitEmpty verifies that zero-value PQC fields are absent
+// from the JSON output for the RSA classical finding. The omitempty tags on
+// UnifiedFinding must suppress these keys so non-TLS findings stay compact.
+func TestPQCFormat_JSON_OmitEmpty(t *testing.T) {
+	result := makePQCTestResult([]findings.UnifiedFinding{rsaFinding()})
+
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, result); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+
+	// Extract the first finding as a raw JSON map to inspect key presence.
+	var raw struct {
+		Findings []map[string]json.RawMessage `json:"findings"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	if len(raw.Findings) == 0 {
+		t.Fatal("no findings in JSON output")
+	}
+
+	f := raw.Findings[0]
+	for _, key := range []string{"negotiatedGroup", "negotiatedGroupName", "pqcPresent", "pqcMaturity"} {
+		if _, present := f[key]; present {
+			t.Errorf("field %q must be omitted for classical (zero-value) finding, but it was present", key)
+		}
+	}
+}
+
+// ── SARIF round-trip ─────────────────────────────────────────────────────────
+
+func TestPQCFormat_SARIF_PQCFieldsInProperties(t *testing.T) {
+	result := makePQCTestResult([]findings.UnifiedFinding{
+		rsaFinding(),
+		pqcFinalFinding(),
+		pqcDraftFinding(),
+	})
+
+	var buf bytes.Buffer
+	if err := WriteSARIF(&buf, result); err != nil {
+		t.Fatalf("WriteSARIF: %v", err)
+	}
+
+	// Parse into a generic map to inspect the properties sub-object.
+	var sarifDoc struct {
+		Runs []struct {
+			Results []struct {
+				Properties map[string]json.RawMessage `json:"properties"`
+			} `json:"results"`
+		} `json:"runs"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &sarifDoc); err != nil {
+		t.Fatalf("unmarshal SARIF: %v", err)
+	}
+	if len(sarifDoc.Runs) == 0 || len(sarifDoc.Runs[0].Results) != 3 {
+		t.Fatalf("expected 3 SARIF results, got %d", len(sarifDoc.Runs[0].Results))
+	}
+
+	// RSA finding: pqcPresent, pqcMaturity, negotiatedGroup must be absent.
+	rsaProps := sarifDoc.Runs[0].Results[0].Properties
+	for _, key := range []string{"pqcPresent", "pqcMaturity", "negotiatedGroup"} {
+		if _, ok := rsaProps[key]; ok {
+			t.Errorf("SARIF RSA finding: properties[%q] present, want absent", key)
+		}
+	}
+
+	// Hybrid final finding: all three PQC keys must be present.
+	hybridProps := sarifDoc.Runs[0].Results[1].Properties
+	if _, ok := hybridProps["pqcPresent"]; !ok {
+		t.Error("SARIF hybrid finding: properties[\"pqcPresent\"] absent")
+	}
+	if _, ok := hybridProps["negotiatedGroup"]; !ok {
+		t.Error("SARIF hybrid finding: properties[\"negotiatedGroup\"] absent")
+	}
+	var maturity string
+	if v, ok := hybridProps["pqcMaturity"]; ok {
+		_ = json.Unmarshal(v, &maturity)
+	} else {
+		t.Error("SARIF hybrid finding: properties[\"pqcMaturity\"] absent")
+	}
+	if maturity != "final" {
+		t.Errorf("SARIF hybrid finding: pqcMaturity=%q, want final", maturity)
+	}
+
+	// Draft finding: pqcMaturity must be "draft".
+	draftProps := sarifDoc.Runs[0].Results[2].Properties
+	var draftMaturity string
+	if v, ok := draftProps["pqcMaturity"]; ok {
+		_ = json.Unmarshal(v, &draftMaturity)
+	} else {
+		t.Error("SARIF draft finding: properties[\"pqcMaturity\"] absent")
+	}
+	if draftMaturity != "draft" {
+		t.Errorf("SARIF draft finding: pqcMaturity=%q, want draft", draftMaturity)
+	}
+}
+
+// ── CBOM round-trip ──────────────────────────────────────────────────────────
+
+func TestPQCFormat_CBOM_OQSPropertyConventions(t *testing.T) {
+	result := makePQCTestResult([]findings.UnifiedFinding{
+		rsaFinding(),
+		pqcFinalFinding(),
+		pqcDraftFinding(),
+	})
+
+	var buf bytes.Buffer
+	if err := WriteCBOM(&buf, result); err != nil {
+		t.Fatalf("WriteCBOM: %v", err)
+	}
+
+	// Parse CBOM to examine component properties.
+	var bom struct {
+		Components []struct {
+			Name       string `json:"name"`
+			Properties []struct {
+				Name  string `json:"name"`
+				Value string `json:"value"`
+			} `json:"properties"`
+		} `json:"components"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &bom); err != nil {
+		t.Fatalf("unmarshal CBOM: %v", err)
+	}
+	if len(bom.Components) < 3 {
+		t.Fatalf("expected at least 3 CBOM components, got %d", len(bom.Components))
+	}
+
+	// Build a helper: find property value by name for a component.
+	findProp := func(props []struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	}, name string) (string, bool) {
+		for _, p := range props {
+			if p.Name == name {
+				return p.Value, true
+			}
+		}
+		return "", false
+	}
+
+	// RSA component: oqs:pqcPresent and oqs:pqcMaturity must be absent.
+	rsaProps := bom.Components[0].Properties
+	for _, prop := range []string{"oqs:pqcPresent", "oqs:pqcMaturity", "oqs:negotiatedGroup"} {
+		if v, ok := findProp(rsaProps, prop); ok {
+			t.Errorf("CBOM RSA component: property %q present (value=%q), want absent", prop, v)
+		}
+	}
+
+	// Hybrid component: oqs:pqcPresent="true", oqs:pqcMaturity="final",
+	// oqs:negotiatedGroup="X25519MLKEM768" must all be present.
+	hybridProps := bom.Components[1].Properties
+	if v, ok := findProp(hybridProps, "oqs:pqcPresent"); !ok || v != "true" {
+		t.Errorf("CBOM hybrid component: oqs:pqcPresent=%q ok=%v, want \"true\" present", v, ok)
+	}
+	if v, ok := findProp(hybridProps, "oqs:pqcMaturity"); !ok || v != "final" {
+		t.Errorf("CBOM hybrid component: oqs:pqcMaturity=%q ok=%v, want \"final\" present", v, ok)
+	}
+	if v, ok := findProp(hybridProps, "oqs:negotiatedGroup"); !ok || v != "X25519MLKEM768" {
+		t.Errorf("CBOM hybrid component: oqs:negotiatedGroup=%q ok=%v, want \"X25519MLKEM768\"", v, ok)
+	}
+
+	// Draft component: oqs:pqcMaturity must be "draft".
+	draftProps := bom.Components[2].Properties
+	if v, ok := findProp(draftProps, "oqs:pqcMaturity"); !ok || v != "draft" {
+		t.Errorf("CBOM draft component: oqs:pqcMaturity=%q ok=%v, want \"draft\" present", v, ok)
+	}
+	// oqs:pqcPresent must also be set for draft (PQCPresent=true).
+	if v, ok := findProp(draftProps, "oqs:pqcPresent"); !ok || v != "true" {
+		t.Errorf("CBOM draft component: oqs:pqcPresent=%q ok=%v, want \"true\" present", v, ok)
+	}
+
+	// CycloneDX 1.7 property name convention: all oqs:pqc* names must use
+	// the "oqs:" namespace prefix — no bare "pqcPresent" keys.
+	for i, comp := range bom.Components {
+		for _, p := range comp.Properties {
+			if strings.HasPrefix(p.Name, "pqc") && !strings.HasPrefix(p.Name, "oqs:") {
+				t.Errorf("component[%d] %q: property %q lacks oqs: namespace prefix (CycloneDX 1.7 convention)",
+					i, comp.Name, p.Name)
+			}
+		}
+	}
+}
+
+// ── Table format ─────────────────────────────────────────────────────────────
+
+// TestPQCFormat_Table_PQCBadges verifies that the table renderer emits [PQC]
+// for final hybrid findings and [PQC:DRAFT] for deprecated draft findings,
+// and that the RSA classical finding carries neither badge.
+func TestPQCFormat_Table_PQCBadges(t *testing.T) {
+	result := makePQCTestResult([]findings.UnifiedFinding{
+		rsaFinding(),
+		pqcFinalFinding(),
+		pqcDraftFinding(),
+	})
+
+	var buf bytes.Buffer
+	if err := WriteTable(&buf, result); err != nil {
+		t.Fatalf("WriteTable: %v", err)
+	}
+	out := buf.String()
+
+	// Strip ANSI colour codes for reliable string matching.
+	out = stripANSI(out)
+
+	// Final hybrid must emit [PQC] badge.
+	if !strings.Contains(out, "[PQC]") {
+		t.Errorf("table output: expected [PQC] badge for X25519MLKEM768 (final hybrid), not found:\n%s", out)
+	}
+
+	// Deprecated draft must emit [PQC:DRAFT] badge.
+	if !strings.Contains(out, "[PQC:DRAFT]") {
+		t.Errorf("table output: expected [PQC:DRAFT] badge for X25519Kyber768Draft00, not found:\n%s", out)
+	}
+
+	// Identify the lines containing each algorithm name and check badge placement.
+	lines := strings.Split(out, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "X25519MLKEM768") && !strings.Contains(line, "Draft") {
+			if !strings.Contains(line, "[PQC]") {
+				t.Errorf("X25519MLKEM768 line missing [PQC] badge: %q", line)
+			}
+		}
+		if strings.Contains(line, "X25519Kyber768Draft00") {
+			if !strings.Contains(line, "[PQC:DRAFT]") {
+				t.Errorf("X25519Kyber768Draft00 line missing [PQC:DRAFT] badge: %q", line)
+			}
+		}
+		if strings.Contains(line, "RSA") && strings.Contains(line, "algorithm") {
+			// RSA line must not carry a PQC badge.
+			if strings.Contains(line, "[PQC]") {
+				t.Errorf("RSA line incorrectly carries [PQC] badge: %q", line)
+			}
+		}
+	}
+}
+
+// stripANSI removes ANSI escape sequences from s so badge checks work
+// regardless of whether colour output is enabled.
+func stripANSI(s string) string {
+	var out strings.Builder
+	i := 0
+	for i < len(s) {
+		if s[i] == '\033' && i+1 < len(s) && s[i+1] == '[' {
+			// Consume until 'm'.
+			j := i + 2
+			for j < len(s) && s[j] != 'm' {
+				j++
+			}
+			i = j + 1
+			continue
+		}
+		out.WriteByte(s[i])
+		i++
+	}
+	return out.String()
+}

--- a/pkg/output/pqc_fields_format_test.go
+++ b/pkg/output/pqc_fields_format_test.go
@@ -194,9 +194,9 @@ func TestPQCFormat_SARIF_PQCFieldsInProperties(t *testing.T) {
 		t.Fatalf("expected 3 SARIF results, got %d", len(sarifDoc.Runs[0].Results))
 	}
 
-	// RSA finding: pqcPresent, pqcMaturity, negotiatedGroup must be absent.
+	// RSA finding: pqcPresent, pqcMaturity, negotiatedGroupName must be absent.
 	rsaProps := sarifDoc.Runs[0].Results[0].Properties
-	for _, key := range []string{"pqcPresent", "pqcMaturity", "negotiatedGroup"} {
+	for _, key := range []string{"pqcPresent", "pqcMaturity", "negotiatedGroupName"} {
 		if _, ok := rsaProps[key]; ok {
 			t.Errorf("SARIF RSA finding: properties[%q] present, want absent", key)
 		}
@@ -207,8 +207,8 @@ func TestPQCFormat_SARIF_PQCFieldsInProperties(t *testing.T) {
 	if _, ok := hybridProps["pqcPresent"]; !ok {
 		t.Error("SARIF hybrid finding: properties[\"pqcPresent\"] absent")
 	}
-	if _, ok := hybridProps["negotiatedGroup"]; !ok {
-		t.Error("SARIF hybrid finding: properties[\"negotiatedGroup\"] absent")
+	if _, ok := hybridProps["negotiatedGroupName"]; !ok {
+		t.Error("SARIF hybrid finding: properties[\"negotiatedGroupName\"] absent")
 	}
 	var maturity string
 	if v, ok := hybridProps["pqcMaturity"]; ok {

--- a/pkg/output/sarif.go
+++ b/pkg/output/sarif.go
@@ -233,6 +233,15 @@ func findingToSARIF(f findings.UnifiedFinding, scanTarget string, ruleIndex map[
 			"explanation": f.MigrationSnippet.Explanation,
 		}
 	}
+	if f.NegotiatedGroupName != "" {
+		props["negotiatedGroup"] = f.NegotiatedGroupName
+	}
+	if f.PQCPresent {
+		props["pqcPresent"] = true
+	}
+	if f.PQCMaturity != "" {
+		props["pqcMaturity"] = f.PQCMaturity
+	}
 	result.Properties = props
 
 	return result

--- a/pkg/output/sarif.go
+++ b/pkg/output/sarif.go
@@ -234,7 +234,7 @@ func findingToSARIF(f findings.UnifiedFinding, scanTarget string, ruleIndex map[
 		}
 	}
 	if f.NegotiatedGroupName != "" {
-		props["negotiatedGroup"] = f.NegotiatedGroupName
+		props["negotiatedGroupName"] = f.NegotiatedGroupName
 	}
 	if f.PQCPresent {
 		props["pqcPresent"] = true

--- a/pkg/output/sarif_test.go
+++ b/pkg/output/sarif_test.go
@@ -1264,6 +1264,67 @@ func TestSARIF_MigrationProperties(t *testing.T) {
 	}
 }
 
+// TestSARIF_NegotiatedGroupFieldSeparation verifies that the SARIF property for
+// the human-readable group name is keyed "negotiatedGroupName" (not "negotiatedGroup"),
+// preventing a collision with the JSON field negotiatedGroup (uint16 codepoint).
+// JSON: negotiatedGroup = uint16, negotiatedGroupName = string.
+// SARIF result.properties: negotiatedGroupName = string (name only; codepoint not emitted).
+func TestSARIF_NegotiatedGroupFieldSeparation(t *testing.T) {
+	const codepoint = uint16(0x11EC) // X25519MLKEM768
+	const name = "X25519MLKEM768"
+
+	ff := []findings.UnifiedFinding{
+		{
+			Location:            findings.Location{File: "/project/server.go", Line: 1},
+			Algorithm:           &findings.Algorithm{Name: name, Primitive: "key-exchange"},
+			Confidence:          findings.ConfidenceHigh,
+			SourceEngine:        "tls-probe",
+			Reachable:           findings.ReachableYes,
+			NegotiatedGroup:     codepoint,
+			NegotiatedGroupName: name,
+			PQCPresent:          true,
+		},
+	}
+
+	// ── JSON marshaling: uint16 codepoint under "negotiatedGroup" ────────────
+	jsonBytes, err := json.Marshal(ff[0])
+	if err != nil {
+		t.Fatalf("json.Marshal UnifiedFinding: %v", err)
+	}
+	var jsonMap map[string]interface{}
+	if err := json.Unmarshal(jsonBytes, &jsonMap); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if cpt, ok := jsonMap["negotiatedGroup"].(float64); !ok || uint16(cpt) != codepoint {
+		t.Errorf("JSON negotiatedGroup = %v, want uint16 codepoint %d", jsonMap["negotiatedGroup"], codepoint)
+	}
+	if n, ok := jsonMap["negotiatedGroupName"].(string); !ok || n != name {
+		t.Errorf("JSON negotiatedGroupName = %v, want %q", jsonMap["negotiatedGroupName"], name)
+	}
+
+	// ── SARIF result.properties: string name under "negotiatedGroupName" ─────
+	buf := writeSARIFFor(t, ff, "/project")
+	var raw map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &raw); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	runs := raw["runs"].([]interface{})
+	result := runs[0].(map[string]interface{})["results"].([]interface{})[0].(map[string]interface{})
+	props, ok := result["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatal("result.properties missing")
+	}
+
+	gotName, ok := props["negotiatedGroupName"].(string)
+	if !ok || gotName != name {
+		t.Errorf("SARIF properties.negotiatedGroupName = %v, want %q", props["negotiatedGroupName"], name)
+	}
+	// The old collision key must not appear.
+	if v, present := props["negotiatedGroup"]; present {
+		t.Errorf("SARIF properties.negotiatedGroup must be absent (old collision key), got %v", v)
+	}
+}
+
 // TestSARIF_NoMigrationWhenEmpty verifies that findings with no migration data
 // do NOT produce targetAlgorithm or migrationSnippet keys in result.properties.
 func TestSARIF_NoMigrationWhenEmpty(t *testing.T) {

--- a/pkg/output/table.go
+++ b/pkg/output/table.go
@@ -32,7 +32,7 @@ func WriteTable(w io.Writer, result ScanResult) error {
 	fmt.Fprintf(w, "\nOQS Scanner v%s — %s\n", result.Version, result.Target)
 	fmt.Fprintf(w, "Engines: %s\n", strings.Join(result.Engines, ", "))
 	fmt.Fprintf(w, "%s\n", strings.Repeat("─", 80))
-	fmt.Fprintf(w, "%s\n", colorize("90", "Legend: [QV]=Vulnerable [QW]=Weakened [QS]=Safe [QR]=Resistant [DEP]=Deprecated [HNDL:IMM/DEF]=Harvest-Now-Decrypt-Later"))
+	fmt.Fprintf(w, "%s\n", colorize("90", "Legend: [QV]=Vulnerable [QW]=Weakened [QS]=Safe [QR]=Resistant [DEP]=Deprecated [HNDL:IMM/DEF]=Harvest-Now-Decrypt-Later [PQC]=PQC-negotiated"))
 	fmt.Fprintln(w)
 
 	// Column widths
@@ -101,6 +101,18 @@ func WriteTable(w io.Writer, result ScanResult) error {
 				details += " "
 			}
 			details += hndlBadge
+		}
+
+		// PQC-presence badge (tls-probe findings only)
+		if f.PQCPresent {
+			pqcBadge := colorize("32", "[PQC]")
+			if f.PQCMaturity == "draft" {
+				pqcBadge = colorize("33", "[PQC:DRAFT]")
+			}
+			if details != "" {
+				details += " "
+			}
+			details += pqcBadge
 		}
 
 		// Binary artifact badge

--- a/pkg/quantum/classify.go
+++ b/pkg/quantum/classify.go
@@ -76,9 +76,15 @@ var pqcSafeFamilies = map[string]bool{
 	// Hybrid KEMs: classical + ML-KEM (IETF draft-ietf-tls-hybrid-design-16)
 	// TLS codepoint classification is handled in Sprint 1 (S1.3); name-based
 	// classification is added here so source/config findings are correct too.
-	"X25519MLKEM768":    true, // 0x11EC — production dominant (>50% Cloudflare, Oct 2025)
-	"SecP256r1MLKEM768": true, // 0x11EB
+	"X25519MLKEM768":     true, // 0x11EC — production dominant (>50% Cloudflare, Oct 2025)
+	"SecP256r1MLKEM768":  true, // 0x11EB
 	"SecP384r1MLKEM1024": true, // 0x11ED
+	"curveSM2MLKEM768":   true, // 0x11EE — SM2 hybrid (Chinese national standard pairing)
+	// Pure ML-KEM (FIPS 203) — listed with full names so extractBaseName's
+	// longest-prefix match returns the correct base (MLKEM1024 > MLKEM768/MLKEM512).
+	"MLKEM512":  true, // 0x0200
+	"MLKEM768":  true, // 0x0201
+	"MLKEM1024": true, // 0x0202
 }
 
 // kpqcEliminatedCandidates are K-PQC candidates eliminated in earlier rounds.

--- a/pkg/quantum/classify_pqc_test.go
+++ b/pkg/quantum/classify_pqc_test.go
@@ -234,7 +234,7 @@ func TestClassifyPQCEdgeCases(t *testing.T) {
 
 		// PQC-like names that don't match any family
 		{"ML-KEM-FAKE unknown", "ML-KEM-FAKE", "kem", RiskSafe, SeverityInfo},   // prefix still matches ML-KEM
-		{"MLKEM768 no hyphen", "MLKEM768", "kem", RiskVulnerable, SeverityCritical}, // no prefix match, kem primitive → vulnerable + HNDL immediate
+		{"MLKEM768 no hyphen", "MLKEM768", "kem", RiskSafe, SeverityInfo}, // added to pqcSafeFamilies (X1 fix)
 		{"Kyber-768 old name", "Kyber-768", "kem", RiskVulnerable, SeverityCritical},
 		{"Dilithium3 old name", "Dilithium3", "signature", RiskVulnerable, SeverityHigh},
 		{"Falcon-512 old name", "Falcon-512", "signature", RiskVulnerable, SeverityHigh},

--- a/pkg/quantum/classify_pure_mlkem_test.go
+++ b/pkg/quantum/classify_pure_mlkem_test.go
@@ -1,0 +1,27 @@
+package quantum
+
+import "testing"
+
+// TestClassifyAlgorithm_PureMLKEM_AndSM2Hybrid guards against pqcSafeFamilies
+// drift relative to tls_groups.go. All four names added in the X1 fix must
+// resolve to RiskSafe so that pure ML-KEM codepoints and the SM2 hybrid are
+// never mis-classified as quantum-vulnerable.
+func TestClassifyAlgorithm_PureMLKEM_AndSM2Hybrid(t *testing.T) {
+	cases := []struct {
+		name string
+	}{
+		{"MLKEM512"},
+		{"MLKEM768"},
+		{"MLKEM1024"},
+		{"curveSM2MLKEM768"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyAlgorithm(tc.name, "", 0)
+			if got.Risk != RiskSafe {
+				t.Errorf("ClassifyAlgorithm(%q): Risk=%q, want %q", tc.name, got.Risk, RiskSafe)
+			}
+		})
+	}
+}

--- a/pkg/quantum/s1_backcompat_test.go
+++ b/pkg/quantum/s1_backcompat_test.go
@@ -1,0 +1,195 @@
+package quantum
+
+// s1_backcompat_test.go — Sprint 1 backwards-compatibility golden snapshot for
+// ClassifyTLSGroup.
+//
+// Snapshots (id, Name, PQCPresent, Maturity) tuples for all codepoint categories
+// introduced in S1.3: classical ECDH/FFDH, hybrid PQC-final, pure ML-KEM, and
+// deprecated-draft Kyber. Future refactors that silently alter these tuples will
+// break the snapshot before they reach production.
+//
+// # Expected to CHANGE between registry versions
+//   - New codepoints added to s1Specimens as IANA allocates them
+//
+// # Expected to STAY STABLE
+//   - Name — canonical algorithm identifier used in findings, SARIF, and CBOM
+//   - PQCPresent — drives risk classification downstream
+//   - Maturity — distinguishes deprecated draft from FIPS-finalised standard
+//
+// To regenerate the golden file after an intentional change:
+//
+//	go test ./pkg/quantum/ -run TestS1Backcompat_TLSGroupSnapshot -update
+//
+// Commit the updated golden file alongside the code change that caused it.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// s1GroupRecord is what we snapshot per codepoint.
+type s1GroupRecord struct {
+	IDHex      string `json:"id"`
+	Name       string `json:"name"`
+	PQCPresent bool   `json:"pqcPresent"`
+	Maturity   string `json:"maturity"`
+	Known      bool   `json:"known"`
+}
+
+// s1GoldenSnapshot is the top-level S1 golden file structure.
+type s1GoldenSnapshot struct {
+	// SchemaVersion lets us detect when the snapshot format itself changes.
+	SchemaVersion string          `json:"schemaVersion"`
+	Records       []s1GroupRecord `json:"records"`
+}
+
+// s1Specimens is the fixed codepoint set covering all four categories:
+// classical ECDH/FFDH, hybrid-final (S1.3 hybrid-KEMs), pure ML-KEM, and
+// deprecated-draft Kyber (two codepoints for the same algorithm).
+var s1Specimens = []uint16{
+	// Classical ECDH
+	0x0017, // secp256r1
+	0x001d, // X25519
+	0x001e, // X448
+	// Classical FFDH
+	0x0100, // ffdhe2048
+	0x0104, // ffdhe8192
+	// Hybrid KEMs: classical ECDH + ML-KEM (FIPS 203 + IETF hybrid-design)
+	0x11EB, // SecP256r1MLKEM768
+	0x11EC, // X25519MLKEM768
+	0x11ED, // SecP384r1MLKEM1024
+	0x11EE, // curveSM2MLKEM768
+	// Pure ML-KEM (FIPS 203)
+	0x0200, // MLKEM512
+	0x0201, // MLKEM768
+	0x0202, // MLKEM1024
+	// Deprecated draft Kyber (pre-FIPS 203): two codepoints, same algorithm name
+	0x6399, // X25519Kyber768Draft00 (primary codepoint)
+	0x636D, // X25519Kyber768Draft00 (alternate codepoint)
+}
+
+const (
+	s1GoldenDir  = "testdata/s1-pqc"
+	s1GoldenFile = "testdata/s1-pqc/golden.json"
+	s1SchemaVer  = "1"
+)
+
+// buildS1Snapshot classifies all s1Specimens and returns the snapshot struct.
+func buildS1Snapshot() s1GoldenSnapshot {
+	records := make([]s1GroupRecord, len(s1Specimens))
+	for i, id := range s1Specimens {
+		info, ok := ClassifyTLSGroup(id)
+		records[i] = s1GroupRecord{
+			IDHex:      fmt.Sprintf("0x%04x", id),
+			Name:       info.Name,
+			PQCPresent: info.PQCPresent,
+			Maturity:   info.Maturity,
+			Known:      ok,
+		}
+	}
+	return s1GoldenSnapshot{SchemaVersion: s1SchemaVer, Records: records}
+}
+
+// TestS1Backcompat_TLSGroupSnapshot is the golden snapshot test for
+// ClassifyTLSGroup. Pass -update to regenerate; otherwise it reads the existing
+// golden file and compares field-by-field.
+func TestS1Backcompat_TLSGroupSnapshot(t *testing.T) {
+	current := buildS1Snapshot()
+
+	if *updateGolden {
+		data, err := json.MarshalIndent(current, "", "  ")
+		if err != nil {
+			t.Fatalf("marshal snapshot: %v", err)
+		}
+		if err := os.MkdirAll(s1GoldenDir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", s1GoldenDir, err)
+		}
+		if err := os.WriteFile(s1GoldenFile, append(data, '\n'), 0644); err != nil {
+			t.Fatalf("write golden file: %v", err)
+		}
+		t.Logf("golden file updated: %s (%d records)", s1GoldenFile, len(current.Records))
+		return
+	}
+
+	data, err := os.ReadFile(filepath.Join(".", s1GoldenFile))
+	if err != nil {
+		t.Fatalf("read golden file %q: %v\n\nRun with -update to generate it.", s1GoldenFile, err)
+	}
+
+	var golden s1GoldenSnapshot
+	if err := json.Unmarshal(data, &golden); err != nil {
+		t.Fatalf("unmarshal golden file: %v", err)
+	}
+
+	if golden.SchemaVersion != s1SchemaVer {
+		t.Fatalf("schemaVersion mismatch: golden=%q current=%q (update the test or bump the constant)",
+			golden.SchemaVersion, s1SchemaVer)
+	}
+	if len(golden.Records) != len(current.Records) {
+		t.Fatalf("record count mismatch: golden=%d current=%d (was a specimen added/removed?)",
+			len(golden.Records), len(current.Records))
+	}
+
+	for i, cur := range current.Records {
+		gold := golden.Records[i]
+
+		if cur.IDHex != gold.IDHex {
+			t.Errorf("[%d]: IDHex changed: %q → %q (specimen order must be stable)", i, gold.IDHex, cur.IDHex)
+		}
+		// STABLE: Name is the canonical algorithm identifier in findings/SARIF/CBOM.
+		if cur.Name != gold.Name {
+			t.Errorf("[%d] %s: Name changed: %q → %q (STABLE — update golden if intentional)",
+				i, gold.IDHex, gold.Name, cur.Name)
+		}
+		// STABLE: PQCPresent drives risk classification; a flip here masks quantum risk.
+		if cur.PQCPresent != gold.PQCPresent {
+			t.Errorf("[%d] %s (%s): PQCPresent changed: %v → %v (STABLE — would alter risk classification)",
+				i, gold.IDHex, gold.Name, gold.PQCPresent, cur.PQCPresent)
+		}
+		// STABLE: Maturity distinguishes deprecated draft from FIPS-finalised standard.
+		if cur.Maturity != gold.Maturity {
+			t.Errorf("[%d] %s (%s): Maturity changed: %q → %q (STABLE — update golden if intentional)",
+				i, gold.IDHex, gold.Name, gold.Maturity, cur.Maturity)
+		}
+		// STABLE: known/unknown status must not flip without intent.
+		if cur.Known != gold.Known {
+			t.Errorf("[%d] %s (%s): Known changed: %v → %v (codepoint added to or removed from registry)",
+				i, gold.IDHex, gold.Name, gold.Known, cur.Known)
+		}
+	}
+}
+
+// TestS1Backcompat_CategoryInvariants asserts cross-cutting invariants that must
+// hold for all S1 codepoints regardless of golden file content.
+func TestS1Backcompat_CategoryInvariants(t *testing.T) {
+	snap := buildS1Snapshot()
+	for _, r := range snap.Records {
+		r := r
+		t.Run(r.IDHex+"/"+r.Name, func(t *testing.T) {
+			// Every specimen must be a known codepoint.
+			if !r.Known {
+				t.Errorf("%s: specimen must be a known codepoint — was it removed from the registry?", r.IDHex)
+			}
+			// PQCPresent=true must carry a non-empty Name.
+			if r.PQCPresent && r.Name == "" {
+				t.Errorf("%s: PQCPresent=true but Name is empty", r.IDHex)
+			}
+			// Classical groups (PQCPresent=false) must have empty Maturity.
+			if !r.PQCPresent && r.Maturity != "" {
+				t.Errorf("%s (%s): classical codepoint has non-empty Maturity=%q — would imply PQC",
+					r.IDHex, r.Name, r.Maturity)
+			}
+			// Maturity must be one of the three valid values.
+			switch r.Maturity {
+			case "", "final", "draft":
+				// valid
+			default:
+				t.Errorf("%s (%s): invalid Maturity=%q (want \"\", \"final\", or \"draft\")",
+					r.IDHex, r.Name, r.Maturity)
+			}
+		})
+	}
+}

--- a/pkg/quantum/testdata/s1-pqc/golden.json
+++ b/pkg/quantum/testdata/s1-pqc/golden.json
@@ -1,0 +1,103 @@
+{
+  "schemaVersion": "1",
+  "records": [
+    {
+      "id": "0x0017",
+      "name": "secp256r1",
+      "pqcPresent": false,
+      "maturity": "",
+      "known": true
+    },
+    {
+      "id": "0x001d",
+      "name": "X25519",
+      "pqcPresent": false,
+      "maturity": "",
+      "known": true
+    },
+    {
+      "id": "0x001e",
+      "name": "X448",
+      "pqcPresent": false,
+      "maturity": "",
+      "known": true
+    },
+    {
+      "id": "0x0100",
+      "name": "ffdhe2048",
+      "pqcPresent": false,
+      "maturity": "",
+      "known": true
+    },
+    {
+      "id": "0x0104",
+      "name": "ffdhe8192",
+      "pqcPresent": false,
+      "maturity": "",
+      "known": true
+    },
+    {
+      "id": "0x11eb",
+      "name": "SecP256r1MLKEM768",
+      "pqcPresent": true,
+      "maturity": "final",
+      "known": true
+    },
+    {
+      "id": "0x11ec",
+      "name": "X25519MLKEM768",
+      "pqcPresent": true,
+      "maturity": "final",
+      "known": true
+    },
+    {
+      "id": "0x11ed",
+      "name": "SecP384r1MLKEM1024",
+      "pqcPresent": true,
+      "maturity": "final",
+      "known": true
+    },
+    {
+      "id": "0x11ee",
+      "name": "curveSM2MLKEM768",
+      "pqcPresent": true,
+      "maturity": "final",
+      "known": true
+    },
+    {
+      "id": "0x0200",
+      "name": "MLKEM512",
+      "pqcPresent": true,
+      "maturity": "final",
+      "known": true
+    },
+    {
+      "id": "0x0201",
+      "name": "MLKEM768",
+      "pqcPresent": true,
+      "maturity": "final",
+      "known": true
+    },
+    {
+      "id": "0x0202",
+      "name": "MLKEM1024",
+      "pqcPresent": true,
+      "maturity": "final",
+      "known": true
+    },
+    {
+      "id": "0x6399",
+      "name": "X25519Kyber768Draft00",
+      "pqcPresent": true,
+      "maturity": "draft",
+      "known": true
+    },
+    {
+      "id": "0x636d",
+      "name": "X25519Kyber768Draft00",
+      "pqcPresent": true,
+      "maturity": "draft",
+      "known": true
+    }
+  ]
+}

--- a/pkg/quantum/tls_groups.go
+++ b/pkg/quantum/tls_groups.go
@@ -1,0 +1,59 @@
+package quantum
+
+// GroupInfo describes a TLS SupportedGroup (named group / key-share) codepoint.
+// Sources: IANA TLS Parameters registry + NETWORK_ENGINE_PLAN.md §9.
+type GroupInfo struct {
+	Name       string // canonical human-readable name, e.g. "X25519MLKEM768"
+	PQCPresent bool   // true when at least one ML-KEM component is present
+	Maturity   string // "final" (FIPS/IETF standard), "draft" (deprecated), "" (classical)
+	RiskLevel  Risk   // quantum risk characterisation for the group
+}
+
+// tlsGroupRegistry maps IANA TLS SupportedGroup codepoints → GroupInfo.
+//
+// Hybrid codepoints (0x11EB–0x11EE) are assigned in IETF
+// draft-ietf-tls-hybrid-design and reference ML-KEM (FIPS 203).
+// Pure ML-KEM codepoints (0x0200–0x0202) are from the same draft.
+// Draft Kyber codepoints (0x6399, 0x636D) were used before FIPS 203
+// was finalised; they are deprecated and should not appear in new deployments.
+var tlsGroupRegistry = map[uint16]GroupInfo{
+	// ── Hybrid KEMs: classical ECDH + ML-KEM ────────────────────────────────
+	// IETF draft-ietf-tls-hybrid-design, codepoints from IANA provisional registry.
+	0x11EB: {Name: "SecP256r1MLKEM768", PQCPresent: true, Maturity: "final", RiskLevel: RiskSafe},
+	0x11EC: {Name: "X25519MLKEM768", PQCPresent: true, Maturity: "final", RiskLevel: RiskSafe},
+	0x11ED: {Name: "SecP384r1MLKEM1024", PQCPresent: true, Maturity: "final", RiskLevel: RiskSafe},
+	0x11EE: {Name: "curveSM2MLKEM768", PQCPresent: true, Maturity: "final", RiskLevel: RiskSafe},
+
+	// ── Pure ML-KEM (FIPS 203) ──────────────────────────────────────────────
+	0x0200: {Name: "MLKEM512", PQCPresent: true, Maturity: "final", RiskLevel: RiskSafe},
+	0x0201: {Name: "MLKEM768", PQCPresent: true, Maturity: "final", RiskLevel: RiskSafe},
+	0x0202: {Name: "MLKEM1024", PQCPresent: true, Maturity: "final", RiskLevel: RiskSafe},
+
+	// ── Deprecated draft Kyber (pre-FIPS 203) ───────────────────────────────
+	// PQCPresent=true because a PQ component is present, but Maturity="draft"
+	// and RiskLevel=RiskDeprecated signals that these codepoints must not be
+	// used in new deployments (they were finalised as X25519MLKEM768 / 0x11EC).
+	0x6399: {Name: "X25519Kyber768Draft00", PQCPresent: true, Maturity: "draft", RiskLevel: RiskDeprecated},
+	0x636D: {Name: "X25519Kyber768Draft00", PQCPresent: true, Maturity: "draft", RiskLevel: RiskDeprecated},
+
+	// ── Classical ECDH / FFDH groups ────────────────────────────────────────
+	// All broken by Shor's algorithm; PQCPresent=false.
+	0x0017: {Name: "secp256r1", PQCPresent: false, Maturity: "", RiskLevel: RiskVulnerable},
+	0x0018: {Name: "secp384r1", PQCPresent: false, Maturity: "", RiskLevel: RiskVulnerable},
+	0x0019: {Name: "secp521r1", PQCPresent: false, Maturity: "", RiskLevel: RiskVulnerable},
+	0x001d: {Name: "X25519", PQCPresent: false, Maturity: "", RiskLevel: RiskVulnerable},
+	0x001e: {Name: "X448", PQCPresent: false, Maturity: "", RiskLevel: RiskVulnerable},
+	0x0100: {Name: "ffdhe2048", PQCPresent: false, Maturity: "", RiskLevel: RiskVulnerable},
+	0x0101: {Name: "ffdhe3072", PQCPresent: false, Maturity: "", RiskLevel: RiskVulnerable},
+	0x0102: {Name: "ffdhe4096", PQCPresent: false, Maturity: "", RiskLevel: RiskVulnerable},
+	0x0103: {Name: "ffdhe6144", PQCPresent: false, Maturity: "", RiskLevel: RiskVulnerable},
+	0x0104: {Name: "ffdhe8192", PQCPresent: false, Maturity: "", RiskLevel: RiskVulnerable},
+}
+
+// ClassifyTLSGroup looks up a TLS SupportedGroup codepoint in the registry.
+// Returns (GroupInfo, true) for known codepoints, (GroupInfo{}, false) for
+// unknown ones. Callers must treat unknown codepoints as PQCPresent=false.
+func ClassifyTLSGroup(id uint16) (GroupInfo, bool) {
+	info, ok := tlsGroupRegistry[id]
+	return info, ok
+}

--- a/pkg/quantum/tls_groups.go
+++ b/pkg/quantum/tls_groups.go
@@ -6,7 +6,9 @@ type GroupInfo struct {
 	Name       string // canonical human-readable name, e.g. "X25519MLKEM768"
 	PQCPresent bool   // true when at least one ML-KEM component is present
 	Maturity   string // "final" (FIPS/IETF standard), "draft" (deprecated), "" (classical)
-	RiskLevel  Risk   // quantum risk characterisation for the group
+	// RiskLevel was removed: callers derive risk via ClassifyAlgorithm(groupInfo.Name)
+	// to avoid duplicating the classification logic here. No production code consumed
+	// the field (Option A chosen over Option B, X3 fix).
 }
 
 // tlsGroupRegistry maps IANA TLS SupportedGroup codepoints → GroupInfo.
@@ -19,35 +21,35 @@ type GroupInfo struct {
 var tlsGroupRegistry = map[uint16]GroupInfo{
 	// ── Hybrid KEMs: classical ECDH + ML-KEM ────────────────────────────────
 	// IETF draft-ietf-tls-hybrid-design, codepoints from IANA provisional registry.
-	0x11EB: {Name: "SecP256r1MLKEM768", PQCPresent: true, Maturity: "final", RiskLevel: RiskSafe},
-	0x11EC: {Name: "X25519MLKEM768", PQCPresent: true, Maturity: "final", RiskLevel: RiskSafe},
-	0x11ED: {Name: "SecP384r1MLKEM1024", PQCPresent: true, Maturity: "final", RiskLevel: RiskSafe},
-	0x11EE: {Name: "curveSM2MLKEM768", PQCPresent: true, Maturity: "final", RiskLevel: RiskSafe},
+	0x11EB: {Name: "SecP256r1MLKEM768", PQCPresent: true, Maturity: "final"},
+	0x11EC: {Name: "X25519MLKEM768", PQCPresent: true, Maturity: "final"},
+	0x11ED: {Name: "SecP384r1MLKEM1024", PQCPresent: true, Maturity: "final"},
+	0x11EE: {Name: "curveSM2MLKEM768", PQCPresent: true, Maturity: "final"},
 
 	// ── Pure ML-KEM (FIPS 203) ──────────────────────────────────────────────
-	0x0200: {Name: "MLKEM512", PQCPresent: true, Maturity: "final", RiskLevel: RiskSafe},
-	0x0201: {Name: "MLKEM768", PQCPresent: true, Maturity: "final", RiskLevel: RiskSafe},
-	0x0202: {Name: "MLKEM1024", PQCPresent: true, Maturity: "final", RiskLevel: RiskSafe},
+	0x0200: {Name: "MLKEM512", PQCPresent: true, Maturity: "final"},
+	0x0201: {Name: "MLKEM768", PQCPresent: true, Maturity: "final"},
+	0x0202: {Name: "MLKEM1024", PQCPresent: true, Maturity: "final"},
 
 	// ── Deprecated draft Kyber (pre-FIPS 203) ───────────────────────────────
 	// PQCPresent=true because a PQ component is present, but Maturity="draft"
-	// and RiskLevel=RiskDeprecated signals that these codepoints must not be
-	// used in new deployments (they were finalised as X25519MLKEM768 / 0x11EC).
-	0x6399: {Name: "X25519Kyber768Draft00", PQCPresent: true, Maturity: "draft", RiskLevel: RiskDeprecated},
-	0x636D: {Name: "X25519Kyber768Draft00", PQCPresent: true, Maturity: "draft", RiskLevel: RiskDeprecated},
+	// signals that these codepoints must not be used in new deployments
+	// (they were finalised as X25519MLKEM768 / 0x11EC).
+	0x6399: {Name: "X25519Kyber768Draft00", PQCPresent: true, Maturity: "draft"},
+	0x636D: {Name: "X25519Kyber768Draft00", PQCPresent: true, Maturity: "draft"},
 
 	// ── Classical ECDH / FFDH groups ────────────────────────────────────────
 	// All broken by Shor's algorithm; PQCPresent=false.
-	0x0017: {Name: "secp256r1", PQCPresent: false, Maturity: "", RiskLevel: RiskVulnerable},
-	0x0018: {Name: "secp384r1", PQCPresent: false, Maturity: "", RiskLevel: RiskVulnerable},
-	0x0019: {Name: "secp521r1", PQCPresent: false, Maturity: "", RiskLevel: RiskVulnerable},
-	0x001d: {Name: "X25519", PQCPresent: false, Maturity: "", RiskLevel: RiskVulnerable},
-	0x001e: {Name: "X448", PQCPresent: false, Maturity: "", RiskLevel: RiskVulnerable},
-	0x0100: {Name: "ffdhe2048", PQCPresent: false, Maturity: "", RiskLevel: RiskVulnerable},
-	0x0101: {Name: "ffdhe3072", PQCPresent: false, Maturity: "", RiskLevel: RiskVulnerable},
-	0x0102: {Name: "ffdhe4096", PQCPresent: false, Maturity: "", RiskLevel: RiskVulnerable},
-	0x0103: {Name: "ffdhe6144", PQCPresent: false, Maturity: "", RiskLevel: RiskVulnerable},
-	0x0104: {Name: "ffdhe8192", PQCPresent: false, Maturity: "", RiskLevel: RiskVulnerable},
+	0x0017: {Name: "secp256r1", PQCPresent: false, Maturity: ""},
+	0x0018: {Name: "secp384r1", PQCPresent: false, Maturity: ""},
+	0x0019: {Name: "secp521r1", PQCPresent: false, Maturity: ""},
+	0x001d: {Name: "X25519", PQCPresent: false, Maturity: ""},
+	0x001e: {Name: "X448", PQCPresent: false, Maturity: ""},
+	0x0100: {Name: "ffdhe2048", PQCPresent: false, Maturity: ""},
+	0x0101: {Name: "ffdhe3072", PQCPresent: false, Maturity: ""},
+	0x0102: {Name: "ffdhe4096", PQCPresent: false, Maturity: ""},
+	0x0103: {Name: "ffdhe6144", PQCPresent: false, Maturity: ""},
+	0x0104: {Name: "ffdhe8192", PQCPresent: false, Maturity: ""},
 }
 
 // ClassifyTLSGroup looks up a TLS SupportedGroup codepoint in the registry.

--- a/pkg/quantum/tls_groups_fuzz_test.go
+++ b/pkg/quantum/tls_groups_fuzz_test.go
@@ -1,0 +1,96 @@
+package quantum
+
+import "testing"
+
+// tls_groups_fuzz_test.go — fuzz tests for ClassifyTLSGroup.
+//
+// FuzzClassifyTLSGroup exercises the function with arbitrary uint16 codepoints
+// and verifies two invariants that must hold for all inputs:
+//
+//   1. The function never panics.
+//   2. When ok=false, GroupInfo is the zero value (callers rely on PQCPresent=false
+//      for unknown codepoints; a non-zero GroupInfo would be a latent bug).
+//   3. When ok=true, Name is non-empty (a PQCPresent=true finding with an empty
+//      Name would produce malformed algorithm classifications downstream).
+//
+// The seed corpus covers all 19 registered codepoints plus several unknowns.
+// During normal `go test` runs, the fuzzer executes seed entries only (fast).
+//
+// To run an extended fuzz session:
+//
+//	go test -fuzz=FuzzClassifyTLSGroup ./pkg/quantum/ -fuzztime=30s
+//
+// To run the full corpus (seed + any saved inputs):
+//
+//	go test -fuzz=FuzzClassifyTLSGroup ./pkg/quantum/ -fuzztime=10s -test.v
+func FuzzClassifyTLSGroup(f *testing.F) {
+	// ── Seed corpus: all 19 registered codepoints ───────────────────────────
+	// Hybrid KEMs (IETF draft-ietf-tls-hybrid-design)
+	f.Add(uint16(0x11EB)) // SecP256r1MLKEM768
+	f.Add(uint16(0x11EC)) // X25519MLKEM768
+	f.Add(uint16(0x11ED)) // SecP384r1MLKEM1024
+	f.Add(uint16(0x11EE)) // curveSM2MLKEM768
+	// Pure ML-KEM (FIPS 203)
+	f.Add(uint16(0x0200)) // MLKEM512
+	f.Add(uint16(0x0201)) // MLKEM768
+	f.Add(uint16(0x0202)) // MLKEM1024
+	// Deprecated draft Kyber
+	f.Add(uint16(0x6399)) // X25519Kyber768Draft00 (primary codepoint)
+	f.Add(uint16(0x636D)) // X25519Kyber768Draft00 (alternate codepoint)
+	// Classical ECDH
+	f.Add(uint16(0x0017)) // secp256r1
+	f.Add(uint16(0x0018)) // secp384r1
+	f.Add(uint16(0x0019)) // secp521r1
+	f.Add(uint16(0x001d)) // X25519
+	f.Add(uint16(0x001e)) // X448
+	// Classical FFDH
+	f.Add(uint16(0x0100)) // ffdhe2048
+	f.Add(uint16(0x0101)) // ffdhe3072
+	f.Add(uint16(0x0102)) // ffdhe4096
+	f.Add(uint16(0x0103)) // ffdhe6144
+	f.Add(uint16(0x0104)) // ffdhe8192
+	// ── Unknown codepoints ─────────────────────────────────────────────────
+	f.Add(uint16(0x0000)) // zero — no named group
+	f.Add(uint16(0xFFFF)) // max uint16
+	f.Add(uint16(0x9999)) // arbitrary unknown
+	f.Add(uint16(0x11EA)) // boundary: one below SecP256r1MLKEM768
+	f.Add(uint16(0x11EF)) // boundary: one above curveSM2MLKEM768
+	f.Add(uint16(0x0001)) // gap below registered range
+	f.Add(uint16(0x0500)) // gap between FFDH and Pure ML-KEM
+	f.Add(uint16(0x1234)) // arbitrary unregistered
+	f.Add(uint16(0xABCD)) // arbitrary unregistered
+	f.Add(uint16(0x7777)) // arbitrary unregistered
+
+	f.Fuzz(func(t *testing.T, id uint16) {
+		// Invariant 1: must never panic.
+		// (defer/recover is implicit in the fuzzer harness, but explicit here
+		// as documentation of the no-panic contract.)
+		info, ok := ClassifyTLSGroup(id)
+
+		if !ok {
+			// Invariant 2: unknown codepoint → zero GroupInfo.
+			if info != (GroupInfo{}) {
+				t.Errorf("ClassifyTLSGroup(0x%04x): ok=false but GroupInfo is non-zero: %+v", id, info)
+			}
+			// Corollary: must not claim PQC presence.
+			if info.PQCPresent {
+				t.Errorf("ClassifyTLSGroup(0x%04x): ok=false but PQCPresent=true", id)
+			}
+			return
+		}
+
+		// Invariant 3: known codepoint → non-empty Name.
+		if info.Name == "" {
+			t.Errorf("ClassifyTLSGroup(0x%04x): ok=true but Name is empty", id)
+		}
+
+		// Corollary: Maturity is one of the three valid values.
+		switch info.Maturity {
+		case "", "final", "draft":
+			// valid
+		default:
+			t.Errorf("ClassifyTLSGroup(0x%04x): unexpected Maturity=%q (want \"\", \"final\", or \"draft\")",
+				id, info.Maturity)
+		}
+	})
+}

--- a/pkg/quantum/tls_groups_matrix_test.go
+++ b/pkg/quantum/tls_groups_matrix_test.go
@@ -9,46 +9,48 @@ import (
 // ClassifyTLSGroup.
 //
 // Coverage:
-//   - All 19 known codepoints × (Name, PQCPresent, Maturity, RiskLevel) tuple
+//   - All 19 known codepoints × (Name, PQCPresent, Maturity) tuple
 //   - 10 unknown codepoints → (GroupInfo{}, false)
 //   - Boundary codepoints adjacent to the hybrid-KEM range → unknown
 //   - Invariant: only 0x6399 and 0x636D may carry Maturity=="draft"
+//
+// Note: RiskLevel was removed from GroupInfo (X3 fix). Risk is now derived by
+// callers via ClassifyAlgorithm(groupInfo.Name) to avoid duplication.
 
 func TestTLSGroupMatrix_AllKnownCodepoints(t *testing.T) {
 	type wantTuple struct {
 		Name       string
 		PQCPresent bool
 		Maturity   string
-		RiskLevel  Risk
 	}
 	tests := []struct {
 		id   uint16
 		want wantTuple
 	}{
 		// ── Hybrid KEMs: classical ECDH + ML-KEM (IETF draft-ietf-tls-hybrid-design)
-		{0x11EB, wantTuple{"SecP256r1MLKEM768", true, "final", RiskSafe}},
-		{0x11EC, wantTuple{"X25519MLKEM768", true, "final", RiskSafe}},
-		{0x11ED, wantTuple{"SecP384r1MLKEM1024", true, "final", RiskSafe}},
-		{0x11EE, wantTuple{"curveSM2MLKEM768", true, "final", RiskSafe}},
+		{0x11EB, wantTuple{"SecP256r1MLKEM768", true, "final"}},
+		{0x11EC, wantTuple{"X25519MLKEM768", true, "final"}},
+		{0x11ED, wantTuple{"SecP384r1MLKEM1024", true, "final"}},
+		{0x11EE, wantTuple{"curveSM2MLKEM768", true, "final"}},
 		// ── Pure ML-KEM (FIPS 203)
-		{0x0200, wantTuple{"MLKEM512", true, "final", RiskSafe}},
-		{0x0201, wantTuple{"MLKEM768", true, "final", RiskSafe}},
-		{0x0202, wantTuple{"MLKEM1024", true, "final", RiskSafe}},
+		{0x0200, wantTuple{"MLKEM512", true, "final"}},
+		{0x0201, wantTuple{"MLKEM768", true, "final"}},
+		{0x0202, wantTuple{"MLKEM1024", true, "final"}},
 		// ── Deprecated draft Kyber (pre-FIPS 203)
-		{0x6399, wantTuple{"X25519Kyber768Draft00", true, "draft", RiskDeprecated}},
-		{0x636D, wantTuple{"X25519Kyber768Draft00", true, "draft", RiskDeprecated}},
+		{0x6399, wantTuple{"X25519Kyber768Draft00", true, "draft"}},
+		{0x636D, wantTuple{"X25519Kyber768Draft00", true, "draft"}},
 		// ── Classical ECDH
-		{0x0017, wantTuple{"secp256r1", false, "", RiskVulnerable}},
-		{0x0018, wantTuple{"secp384r1", false, "", RiskVulnerable}},
-		{0x0019, wantTuple{"secp521r1", false, "", RiskVulnerable}},
-		{0x001d, wantTuple{"X25519", false, "", RiskVulnerable}},
-		{0x001e, wantTuple{"X448", false, "", RiskVulnerable}},
+		{0x0017, wantTuple{"secp256r1", false, ""}},
+		{0x0018, wantTuple{"secp384r1", false, ""}},
+		{0x0019, wantTuple{"secp521r1", false, ""}},
+		{0x001d, wantTuple{"X25519", false, ""}},
+		{0x001e, wantTuple{"X448", false, ""}},
 		// ── Classical FFDH
-		{0x0100, wantTuple{"ffdhe2048", false, "", RiskVulnerable}},
-		{0x0101, wantTuple{"ffdhe3072", false, "", RiskVulnerable}},
-		{0x0102, wantTuple{"ffdhe4096", false, "", RiskVulnerable}},
-		{0x0103, wantTuple{"ffdhe6144", false, "", RiskVulnerable}},
-		{0x0104, wantTuple{"ffdhe8192", false, "", RiskVulnerable}},
+		{0x0100, wantTuple{"ffdhe2048", false, ""}},
+		{0x0101, wantTuple{"ffdhe3072", false, ""}},
+		{0x0102, wantTuple{"ffdhe4096", false, ""}},
+		{0x0103, wantTuple{"ffdhe6144", false, ""}},
+		{0x0104, wantTuple{"ffdhe8192", false, ""}},
 	}
 
 	for _, tc := range tests {
@@ -66,9 +68,6 @@ func TestTLSGroupMatrix_AllKnownCodepoints(t *testing.T) {
 			}
 			if info.Maturity != tc.want.Maturity {
 				t.Errorf("Maturity = %q, want %q", info.Maturity, tc.want.Maturity)
-			}
-			if info.RiskLevel != tc.want.RiskLevel {
-				t.Errorf("RiskLevel = %q, want %q", info.RiskLevel, tc.want.RiskLevel)
 			}
 		})
 	}
@@ -212,9 +211,6 @@ func TestTLSGroupMatrix_ClassicalPQCPresentFalse(t *testing.T) {
 		}
 		if info.Maturity != "" {
 			t.Errorf("0x%04x (%s): Maturity=%q for classical group — should be empty", id, info.Name, info.Maturity)
-		}
-		if info.RiskLevel != RiskVulnerable {
-			t.Errorf("0x%04x (%s): RiskLevel=%q, want RiskVulnerable", id, info.Name, info.RiskLevel)
 		}
 	}
 }

--- a/pkg/quantum/tls_groups_matrix_test.go
+++ b/pkg/quantum/tls_groups_matrix_test.go
@@ -1,0 +1,220 @@
+package quantum
+
+import (
+	"fmt"
+	"testing"
+)
+
+// tls_groups_matrix_test.go — exhaustive codepoint × expected-tuple matrix for
+// ClassifyTLSGroup.
+//
+// Coverage:
+//   - All 19 known codepoints × (Name, PQCPresent, Maturity, RiskLevel) tuple
+//   - 10 unknown codepoints → (GroupInfo{}, false)
+//   - Boundary codepoints adjacent to the hybrid-KEM range → unknown
+//   - Invariant: only 0x6399 and 0x636D may carry Maturity=="draft"
+
+func TestTLSGroupMatrix_AllKnownCodepoints(t *testing.T) {
+	type wantTuple struct {
+		Name       string
+		PQCPresent bool
+		Maturity   string
+		RiskLevel  Risk
+	}
+	tests := []struct {
+		id   uint16
+		want wantTuple
+	}{
+		// ── Hybrid KEMs: classical ECDH + ML-KEM (IETF draft-ietf-tls-hybrid-design)
+		{0x11EB, wantTuple{"SecP256r1MLKEM768", true, "final", RiskSafe}},
+		{0x11EC, wantTuple{"X25519MLKEM768", true, "final", RiskSafe}},
+		{0x11ED, wantTuple{"SecP384r1MLKEM1024", true, "final", RiskSafe}},
+		{0x11EE, wantTuple{"curveSM2MLKEM768", true, "final", RiskSafe}},
+		// ── Pure ML-KEM (FIPS 203)
+		{0x0200, wantTuple{"MLKEM512", true, "final", RiskSafe}},
+		{0x0201, wantTuple{"MLKEM768", true, "final", RiskSafe}},
+		{0x0202, wantTuple{"MLKEM1024", true, "final", RiskSafe}},
+		// ── Deprecated draft Kyber (pre-FIPS 203)
+		{0x6399, wantTuple{"X25519Kyber768Draft00", true, "draft", RiskDeprecated}},
+		{0x636D, wantTuple{"X25519Kyber768Draft00", true, "draft", RiskDeprecated}},
+		// ── Classical ECDH
+		{0x0017, wantTuple{"secp256r1", false, "", RiskVulnerable}},
+		{0x0018, wantTuple{"secp384r1", false, "", RiskVulnerable}},
+		{0x0019, wantTuple{"secp521r1", false, "", RiskVulnerable}},
+		{0x001d, wantTuple{"X25519", false, "", RiskVulnerable}},
+		{0x001e, wantTuple{"X448", false, "", RiskVulnerable}},
+		// ── Classical FFDH
+		{0x0100, wantTuple{"ffdhe2048", false, "", RiskVulnerable}},
+		{0x0101, wantTuple{"ffdhe3072", false, "", RiskVulnerable}},
+		{0x0102, wantTuple{"ffdhe4096", false, "", RiskVulnerable}},
+		{0x0103, wantTuple{"ffdhe6144", false, "", RiskVulnerable}},
+		{0x0104, wantTuple{"ffdhe8192", false, "", RiskVulnerable}},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(fmt.Sprintf("0x%04x/%s", tc.id, tc.want.Name), func(t *testing.T) {
+			info, ok := ClassifyTLSGroup(tc.id)
+			if !ok {
+				t.Fatalf("ClassifyTLSGroup(0x%04x): ok=false, want ok=true", tc.id)
+			}
+			if info.Name != tc.want.Name {
+				t.Errorf("Name = %q, want %q", info.Name, tc.want.Name)
+			}
+			if info.PQCPresent != tc.want.PQCPresent {
+				t.Errorf("PQCPresent = %v, want %v", info.PQCPresent, tc.want.PQCPresent)
+			}
+			if info.Maturity != tc.want.Maturity {
+				t.Errorf("Maturity = %q, want %q", info.Maturity, tc.want.Maturity)
+			}
+			if info.RiskLevel != tc.want.RiskLevel {
+				t.Errorf("RiskLevel = %q, want %q", info.RiskLevel, tc.want.RiskLevel)
+			}
+		})
+	}
+}
+
+// TestTLSGroupMatrix_UnknownCodepoints verifies that 10 arbitrary unregistered
+// codepoints return (GroupInfo{}, false) and do not claim PQC presence.
+func TestTLSGroupMatrix_UnknownCodepoints(t *testing.T) {
+	unknowns := []uint16{
+		0x0000, // zero — no named group / RSA KEM session
+		0x0001, // just above zero
+		0x0003, // gap below ECDH range
+		0x0500, // between FFDH and Pure ML-KEM ranges
+		0x1000, // unregistered gap
+		0x1234, // arbitrary unregistered
+		0x7777, // arbitrary unregistered
+		0x9999, // arbitrary unregistered
+		0xABCD, // arbitrary unregistered
+		0xFFFF, // maximum uint16 — must not panic
+	}
+
+	for _, id := range unknowns {
+		id := id
+		t.Run(fmt.Sprintf("unknown/0x%04x", id), func(t *testing.T) {
+			info, ok := ClassifyTLSGroup(id)
+			if ok {
+				t.Errorf("ClassifyTLSGroup(0x%04x): ok=true, want ok=false (unknown codepoint, Name=%q)", id, info.Name)
+			}
+			// Unknown codepoints must return a zero GroupInfo.
+			if info != (GroupInfo{}) {
+				t.Errorf("ClassifyTLSGroup(0x%04x): expected zero GroupInfo{} for unknown, got %+v", id, info)
+			}
+			// Callers must treat unknown codepoints as PQCPresent=false.
+			if info.PQCPresent {
+				t.Errorf("ClassifyTLSGroup(0x%04x): PQCPresent=true for unknown codepoint", id)
+			}
+		})
+	}
+}
+
+// TestTLSGroupMatrix_BoundaryCodepoints checks codepoints immediately outside the
+// hybrid-KEM assignment range. Neither 0x11EA nor 0x11EF is registered; both
+// must return ok=false so adjacent-integer probing cannot claim PQC presence.
+func TestTLSGroupMatrix_BoundaryCodepoints(t *testing.T) {
+	boundaries := []struct {
+		id      uint16
+		comment string
+	}{
+		{0x11EA, "one below SecP256r1MLKEM768 (0x11EB)"},
+		{0x11EF, "one above curveSM2MLKEM768 (0x11EE)"},
+	}
+
+	for _, tc := range boundaries {
+		tc := tc
+		t.Run(fmt.Sprintf("boundary/0x%04x", tc.id), func(t *testing.T) {
+			info, ok := ClassifyTLSGroup(tc.id)
+			if ok {
+				t.Errorf("ClassifyTLSGroup(0x%04x) (%s): ok=true, want ok=false", tc.id, tc.comment)
+			}
+			if info != (GroupInfo{}) {
+				t.Errorf("ClassifyTLSGroup(0x%04x) (%s): non-zero GroupInfo for boundary unknown: %+v",
+					tc.id, tc.comment, info)
+			}
+		})
+	}
+}
+
+// TestTLSGroupMatrix_DraftExclusivelyFor6399And636D verifies that "draft" maturity
+// is exclusive to the two deprecated Kyber codepoints. Any other known codepoint
+// carrying Maturity=="draft" would silently misclassify a final group as deprecated.
+func TestTLSGroupMatrix_DraftExclusivelyFor6399And636D(t *testing.T) {
+	draftAllowed := map[uint16]bool{0x6399: true, 0x636D: true}
+
+	knownIDs := []uint16{
+		0x11EB, 0x11EC, 0x11ED, 0x11EE,
+		0x0200, 0x0201, 0x0202,
+		0x6399, 0x636D,
+		0x0017, 0x0018, 0x0019, 0x001d, 0x001e,
+		0x0100, 0x0101, 0x0102, 0x0103, 0x0104,
+	}
+
+	for _, id := range knownIDs {
+		info, ok := ClassifyTLSGroup(id)
+		if !ok {
+			t.Errorf("0x%04x: expected known codepoint, got ok=false", id)
+			continue
+		}
+		if info.Maturity == "draft" && !draftAllowed[id] {
+			t.Errorf("0x%04x (%s): Maturity=%q — only 0x6399 and 0x636D may have draft maturity",
+				id, info.Name, info.Maturity)
+		}
+		if draftAllowed[id] && info.Maturity != "draft" {
+			t.Errorf("0x%04x (%s): Maturity=%q — draft codepoint must have Maturity==\"draft\"",
+				id, info.Name, info.Maturity)
+		}
+	}
+}
+
+// TestTLSGroupMatrix_PQCPresentImpliesNonEmptyName asserts that every codepoint
+// returning PQCPresent=true also carries a non-empty Name. Consumers that trust
+// Name when PQCPresent=true must never observe an empty string.
+func TestTLSGroupMatrix_PQCPresentImpliesNonEmptyName(t *testing.T) {
+	pqcIDs := []uint16{
+		// hybrid
+		0x11EB, 0x11EC, 0x11ED, 0x11EE,
+		// pure ML-KEM
+		0x0200, 0x0201, 0x0202,
+		// deprecated draft (PQCPresent=true, Maturity="draft")
+		0x6399, 0x636D,
+	}
+	for _, id := range pqcIDs {
+		info, ok := ClassifyTLSGroup(id)
+		if !ok {
+			t.Errorf("0x%04x: expected known PQC codepoint, got ok=false", id)
+			continue
+		}
+		if !info.PQCPresent {
+			t.Errorf("0x%04x (%s): PQCPresent=false for known PQC codepoint", id, info.Name)
+		}
+		if info.Name == "" {
+			t.Errorf("0x%04x: PQCPresent=true but Name is empty", id)
+		}
+	}
+}
+
+// TestTLSGroupMatrix_ClassicalPQCPresentFalse verifies that no classical ECDH/FFDH
+// group claims PQC presence — a false positive here would mask quantum risk.
+func TestTLSGroupMatrix_ClassicalPQCPresentFalse(t *testing.T) {
+	classicalIDs := []uint16{
+		0x0017, 0x0018, 0x0019, 0x001d, 0x001e,
+		0x0100, 0x0101, 0x0102, 0x0103, 0x0104,
+	}
+	for _, id := range classicalIDs {
+		info, ok := ClassifyTLSGroup(id)
+		if !ok {
+			t.Errorf("0x%04x: expected known classical codepoint, got ok=false", id)
+			continue
+		}
+		if info.PQCPresent {
+			t.Errorf("0x%04x (%s): PQCPresent=true for classical group — would mask quantum risk", id, info.Name)
+		}
+		if info.Maturity != "" {
+			t.Errorf("0x%04x (%s): Maturity=%q for classical group — should be empty", id, info.Name, info.Maturity)
+		}
+		if info.RiskLevel != RiskVulnerable {
+			t.Errorf("0x%04x (%s): RiskLevel=%q, want RiskVulnerable", id, info.Name, info.RiskLevel)
+		}
+	}
+}

--- a/pkg/quantum/tls_groups_test.go
+++ b/pkg/quantum/tls_groups_test.go
@@ -58,34 +58,41 @@ func TestClassifyTLSGroup(t *testing.T) {
 	}
 }
 
-func TestClassifyTLSGroup_DraftRiskDeprecated(t *testing.T) {
-	// Draft Kyber codepoints must carry RiskDeprecated despite PQCPresent=true.
+func TestClassifyTLSGroup_DraftMaturity(t *testing.T) {
+	// Draft Kyber codepoints must carry Maturity="draft" and PQCPresent=true.
+	// Risk is derived by callers via ClassifyAlgorithm(groupInfo.Name).
 	for _, id := range []uint16{0x6399, 0x636D} {
 		info, ok := ClassifyTLSGroup(id)
 		if !ok {
 			t.Fatalf("expected known codepoint 0x%04x", id)
 		}
-		if info.RiskLevel != RiskDeprecated {
-			t.Errorf("draft codepoint 0x%04x RiskLevel=%q, want %q", id, info.RiskLevel, RiskDeprecated)
+		if info.Maturity != "draft" {
+			t.Errorf("draft codepoint 0x%04x Maturity=%q, want %q", id, info.Maturity, "draft")
+		}
+		if !info.PQCPresent {
+			t.Errorf("draft codepoint 0x%04x PQCPresent=false, want true", id)
 		}
 	}
 }
 
-func TestClassifyTLSGroup_PQCRiskSafe(t *testing.T) {
-	// Final PQC codepoints must carry RiskSafe.
+func TestClassifyTLSGroup_PQCFinalMaturity(t *testing.T) {
+	// Final PQC codepoints must carry Maturity="final" and PQCPresent=true.
 	pqcFinal := []uint16{0x11EB, 0x11EC, 0x11ED, 0x11EE, 0x0200, 0x0201, 0x0202}
 	for _, id := range pqcFinal {
 		info, ok := ClassifyTLSGroup(id)
 		if !ok {
 			t.Fatalf("expected known codepoint 0x%04x", id)
 		}
-		if info.RiskLevel != RiskSafe {
-			t.Errorf("PQC codepoint 0x%04x RiskLevel=%q, want %q", id, info.RiskLevel, RiskSafe)
+		if !info.PQCPresent {
+			t.Errorf("PQC codepoint 0x%04x PQCPresent=false, want true", id)
+		}
+		if info.Maturity != "final" {
+			t.Errorf("PQC codepoint 0x%04x Maturity=%q, want %q", id, info.Maturity, "final")
 		}
 	}
 }
 
-func TestClassifyTLSGroup_ClassicalRiskVulnerable(t *testing.T) {
+func TestClassifyTLSGroup_ClassicalNoPQC(t *testing.T) {
 	classical := []uint16{0x0017, 0x0018, 0x0019, 0x001d, 0x001e, 0x0100}
 	for _, id := range classical {
 		info, ok := ClassifyTLSGroup(id)
@@ -94,9 +101,6 @@ func TestClassifyTLSGroup_ClassicalRiskVulnerable(t *testing.T) {
 		}
 		if info.PQCPresent {
 			t.Errorf("classical codepoint 0x%04x should not have PQCPresent=true", id)
-		}
-		if info.RiskLevel != RiskVulnerable {
-			t.Errorf("classical codepoint 0x%04x RiskLevel=%q, want %q", id, info.RiskLevel, RiskVulnerable)
 		}
 	}
 }

--- a/pkg/quantum/tls_groups_test.go
+++ b/pkg/quantum/tls_groups_test.go
@@ -1,0 +1,102 @@
+package quantum
+
+import "testing"
+
+func TestClassifyTLSGroup(t *testing.T) {
+	tests := []struct {
+		name       string
+		id         uint16
+		wantOK     bool
+		wantPQC    bool
+		wantName   string
+		wantMature string
+	}{
+		// Hybrid KEMs — all final, PQC present
+		{"SecP256r1MLKEM768", 0x11EB, true, true, "SecP256r1MLKEM768", "final"},
+		{"X25519MLKEM768", 0x11EC, true, true, "X25519MLKEM768", "final"},
+		{"SecP384r1MLKEM1024", 0x11ED, true, true, "SecP384r1MLKEM1024", "final"},
+		{"curveSM2MLKEM768", 0x11EE, true, true, "curveSM2MLKEM768", "final"},
+		// Pure ML-KEM — final, PQC present
+		{"MLKEM512", 0x0200, true, true, "MLKEM512", "final"},
+		{"MLKEM768", 0x0201, true, true, "MLKEM768", "final"},
+		{"MLKEM1024", 0x0202, true, true, "MLKEM1024", "final"},
+		// Draft Kyber — deprecated, PQC present but maturity=draft
+		{"X25519Kyber768Draft00 primary", 0x6399, true, true, "X25519Kyber768Draft00", "draft"},
+		{"X25519Kyber768Draft00 alt", 0x636D, true, true, "X25519Kyber768Draft00", "draft"},
+		// Classical ECDH — no PQC
+		{"X25519", 0x001d, true, false, "X25519", ""},
+		{"secp256r1", 0x0017, true, false, "secp256r1", ""},
+		{"secp384r1", 0x0018, true, false, "secp384r1", ""},
+		{"secp521r1", 0x0019, true, false, "secp521r1", ""},
+		// Classical FFDH
+		{"ffdhe2048", 0x0100, true, false, "ffdhe2048", ""},
+		// Unknown codepoint
+		{"unknown", 0xFFFF, false, false, "", ""},
+		// Zero (no named group / RSA KEM / TLS 1.2 without ECDHE)
+		{"zero", 0x0000, false, false, "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, ok := ClassifyTLSGroup(tt.id)
+			if ok != tt.wantOK {
+				t.Errorf("ClassifyTLSGroup(0x%04x) ok=%v, want %v", tt.id, ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if info.PQCPresent != tt.wantPQC {
+				t.Errorf("ClassifyTLSGroup(0x%04x).PQCPresent=%v, want %v", tt.id, info.PQCPresent, tt.wantPQC)
+			}
+			if info.Name != tt.wantName {
+				t.Errorf("ClassifyTLSGroup(0x%04x).Name=%q, want %q", tt.id, info.Name, tt.wantName)
+			}
+			if info.Maturity != tt.wantMature {
+				t.Errorf("ClassifyTLSGroup(0x%04x).Maturity=%q, want %q", tt.id, info.Maturity, tt.wantMature)
+			}
+		})
+	}
+}
+
+func TestClassifyTLSGroup_DraftRiskDeprecated(t *testing.T) {
+	// Draft Kyber codepoints must carry RiskDeprecated despite PQCPresent=true.
+	for _, id := range []uint16{0x6399, 0x636D} {
+		info, ok := ClassifyTLSGroup(id)
+		if !ok {
+			t.Fatalf("expected known codepoint 0x%04x", id)
+		}
+		if info.RiskLevel != RiskDeprecated {
+			t.Errorf("draft codepoint 0x%04x RiskLevel=%q, want %q", id, info.RiskLevel, RiskDeprecated)
+		}
+	}
+}
+
+func TestClassifyTLSGroup_PQCRiskSafe(t *testing.T) {
+	// Final PQC codepoints must carry RiskSafe.
+	pqcFinal := []uint16{0x11EB, 0x11EC, 0x11ED, 0x11EE, 0x0200, 0x0201, 0x0202}
+	for _, id := range pqcFinal {
+		info, ok := ClassifyTLSGroup(id)
+		if !ok {
+			t.Fatalf("expected known codepoint 0x%04x", id)
+		}
+		if info.RiskLevel != RiskSafe {
+			t.Errorf("PQC codepoint 0x%04x RiskLevel=%q, want %q", id, info.RiskLevel, RiskSafe)
+		}
+	}
+}
+
+func TestClassifyTLSGroup_ClassicalRiskVulnerable(t *testing.T) {
+	classical := []uint16{0x0017, 0x0018, 0x0019, 0x001d, 0x001e, 0x0100}
+	for _, id := range classical {
+		info, ok := ClassifyTLSGroup(id)
+		if !ok {
+			t.Fatalf("expected known classical codepoint 0x%04x", id)
+		}
+		if info.PQCPresent {
+			t.Errorf("classical codepoint 0x%04x should not have PQCPresent=true", id)
+		}
+		if info.RiskLevel != RiskVulnerable {
+			t.Errorf("classical codepoint 0x%04x RiskLevel=%q, want %q", id, info.RiskLevel, RiskVulnerable)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Turns on post-quantum crypto presence detection in the TLS probe by reading `ConnectionState().CurveID` after each handshake. Go 1.24+ auto-advertises X25519MLKEM768 (`0x11EC`) in outgoing TLS handshakes; this PR consumes that signal.

- **`ConnectionState().CurveID` capture** in `pkg/engines/tlsprobe/probe.go` — observations now carry the negotiated IANA group codepoint (TLS 1.2/1.3/unknown all handled gracefully).
- **New `UnifiedFinding` fields**: `NegotiatedGroup` (uint16 codepoint), `NegotiatedGroupName` (human-readable), `PQCPresent` (bool), `PQCMaturity` (`"final"` / `"draft"` / `""`). Additive, backward-compatible, `omitempty` on zero values.
- **Canonical codepoint classification table** (`pkg/quantum/tls_groups.go`) — `ClassifyTLSGroup(uint16)` returns `(GroupInfo, bool)` covering 19 codepoints: hybrid KEMs (`0x11EB/EC/ED/EE`), pure ML-KEM (`0x0200-02`), deprecated drafts (`0x6399/636D`), and classical ECDH/FFDH.
- **Concurrency tightened `10 → 5`** in `pkg/engines/tlsprobe/engine.go` — sslyze's empirical finding: >5 concurrent per-target probes trigger server-side rate limiting and false negatives.
- **Output surfacing**: JSON carries `negotiatedGroup` (uint16), SARIF carries `negotiatedGroupName` (string) plus `pqcPresent`/`pqcMaturity`, CBOM adds `oqs:pqc*` properties, table shows `[PQC]` / `[PQC:DRAFT]` badges.
- **Classification consistency fix** (X1): `curveSM2MLKEM768`, `MLKEM512/768/1024` added to `pqcSafeFamilies` so they classify as `RiskSafe` (was drifting between the new `tls_groups.go` and existing classifier).

## Test plan

- [x] `go test -race -count=1 ./...` — 45 packages, 1617 tests, 0 failures
- [x] `go test -race -count=5 ./pkg/engines/tlsprobe/... ./pkg/quantum/... ./pkg/findings/... ./pkg/output/...` — no flakes
- [x] `go vet ./...` clean, `go build` clean
- [x] `go test -fuzz=FuzzClassifyTLSGroup -fuzztime=15s` — 11M execs, 0 panics
- [x] 118 new tests across 8 categories (codepoint matrix, format round-trip, TLS 1.2/1.3 CurveID behavior, concurrency stress + goroutine-leak detection, fuzz, Clone safety, dedup asymmetry, backcompat golden)
- [x] Sprint 0 backcompat golden stable; new Sprint 1 backcompat golden committed
- [x] 4 code-reviewer issues resolved: `pqcSafeFamilies` drift, SARIF field rename, stale comment, unused `GroupInfo.RiskLevel` removed

## Known follow-ups (non-blocking)

- `pkg/output/cbom.go:341` — property name `oqs:negotiatedGroup` holds a string (semantically inconsistent with the JSON `negotiatedGroup` uint16 naming). Cosmetic; scheduled for Sprint 2 cleanup.