### PR TITLE
Sprint 2: Size-based passive PQC detection + Sprint 0/1/2 audit fixes

### DIFF
--- a/pkg/engines/tlsprobe/backcompat_test.go
+++ b/pkg/engines/tlsprobe/backcompat_test.go
@@ -1,0 +1,211 @@
+package tlsprobe
+
+// backcompat_test.go — Bucket 7: Sprint 0/1 integration backcompat tests.
+//
+// Verifies that Sprint 2 changes to observationToFindings do not break callers
+// that pass Sprint-1-era ProbeResult shapes (ECH fields zero-valued).  Also
+// verifies the Volume + PQC dual-signal path introduced in Sprint 2.
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/findings"
+)
+
+// TestObservationToFindings_Sprint1Shape_NoPartialInventory verifies that a
+// ProbeResult shaped exactly like Sprint 1 (ECHDetected=false, ECHSource="",
+// no HandshakeVolumeClass field set) produces findings with PartialInventory=false
+// and PartialInventoryReason="".
+func TestObservationToFindings_Sprint1Shape_NoPartialInventory(t *testing.T) {
+	t.Parallel()
+
+	// Sprint 1 ProbeResult: no ECH fields, no HandshakeVolumeClass.
+	result := ProbeResult{
+		Target:          "classic.example.com:443",
+		TLSVersion:      tls.VersionTLS13,
+		CipherSuiteID:   tls.TLS_AES_256_GCM_SHA384,
+		CipherSuiteName: "TLS_AES_256_GCM_SHA384",
+		LeafCertKeyAlgo: "RSA",
+		LeafCertKeySize: 2048,
+		NegotiatedGroupID: 0x001d, // X25519
+		// Sprint 2 fields left zero-valued.
+		ECHDetected:          false,
+		ECHSource:            "",
+		HandshakeVolumeClass: "",
+	}
+
+	ff := observationToFindings(result)
+	if len(ff) == 0 {
+		t.Fatal("expected findings from Sprint-1-shape ProbeResult")
+	}
+
+	for _, f := range ff {
+		if f.PartialInventory {
+			t.Errorf("Sprint-1-shape finding must not have PartialInventory=true; got true for %q",
+				f.RawIdentifier)
+		}
+		if f.PartialInventoryReason != "" {
+			t.Errorf("Sprint-1-shape finding must not have PartialInventoryReason set; got %q",
+				f.PartialInventoryReason)
+		}
+	}
+}
+
+// TestObservationToFindings_Sprint1Shape_NegotiatedGroupFields verifies that
+// the Sprint-1 NegotiatedGroup / NegotiatedGroupName / PQCPresent / PQCMaturity
+// fields are still populated correctly for a known classical group (X25519).
+func TestObservationToFindings_Sprint1Shape_NegotiatedGroupFields(t *testing.T) {
+	t.Parallel()
+
+	result := ProbeResult{
+		Target:            "x25519.example.com:443",
+		TLSVersion:        tls.VersionTLS13,
+		CipherSuiteID:     tls.TLS_AES_256_GCM_SHA384,
+		NegotiatedGroupID: 0x001d, // X25519
+		LeafCertKeyAlgo:   "ECDSA",
+		LeafCertKeySize:   256,
+	}
+
+	ff := observationToFindings(result)
+	if len(ff) == 0 {
+		t.Fatal("expected findings")
+	}
+
+	for _, f := range ff {
+		if f.NegotiatedGroup != 0x001d {
+			t.Errorf("NegotiatedGroup=0x%04x, want 0x001d", f.NegotiatedGroup)
+		}
+		if f.NegotiatedGroupName != "X25519" {
+			t.Errorf("NegotiatedGroupName=%q, want X25519", f.NegotiatedGroupName)
+		}
+		if f.PQCPresent {
+			t.Error("PQCPresent must be false for X25519 (classical)")
+		}
+		if f.PQCMaturity != "" {
+			t.Errorf("PQCMaturity=%q, want empty for classical group", f.PQCMaturity)
+		}
+	}
+}
+
+// TestObservationToFindings_FullPQCAndECH_NoDedupeCollision verifies that a
+// ProbeResult with HandshakeVolumeClass="full-pqc", PQCPresent=true (via
+// X25519MLKEM768 group), and ECHDetected=true produces findings that:
+//   1. All carry PartialInventory=true.
+//   2. PQCPresent=true and PQCMaturity="final" are set.
+//   3. No two findings share the same RawIdentifier (no dedupe collision).
+func TestObservationToFindings_FullPQCAndECH_NoDedupeCollision(t *testing.T) {
+	t.Parallel()
+
+	result := ProbeResult{
+		Target:               "pqcech.example.com:443",
+		TLSVersion:           tls.VersionTLS13,
+		CipherSuiteID:        tls.TLS_AES_256_GCM_SHA384,
+		CipherSuiteName:      "TLS_AES_256_GCM_SHA384",
+		NegotiatedGroupID:    0x11EC, // X25519MLKEM768
+		LeafCertKeyAlgo:      "RSA",
+		LeafCertKeySize:      2048,
+		HandshakeVolumeClass: "full-pqc",
+		ECHDetected:          true,
+		ECHSource:            "dns-https-rr",
+	}
+
+	ff := observationToFindings(result)
+	if len(ff) == 0 {
+		t.Fatal("expected findings")
+	}
+
+	// All findings must carry PartialInventory annotation (ECH detected).
+	for _, f := range ff {
+		if !f.PartialInventory {
+			t.Errorf("finding %q must have PartialInventory=true (ECH detected)", f.RawIdentifier)
+		}
+		if f.PartialInventoryReason != "ECH_ENABLED" {
+			t.Errorf("finding %q: PartialInventoryReason=%q, want ECH_ENABLED", f.RawIdentifier, f.PartialInventoryReason)
+		}
+	}
+
+	// At least one finding must carry PQCPresent=true (from X25519MLKEM768).
+	var hasPQC bool
+	for _, f := range ff {
+		if f.PQCPresent {
+			hasPQC = true
+			if f.PQCMaturity != "final" {
+				t.Errorf("PQCMaturity=%q, want final for X25519MLKEM768", f.PQCMaturity)
+			}
+		}
+	}
+	if !hasPQC {
+		t.Error("expected at least one finding with PQCPresent=true for X25519MLKEM768")
+	}
+
+	// All RawIdentifiers must be unique.
+	seen := make(map[string]bool)
+	for _, f := range ff {
+		if seen[f.RawIdentifier] {
+			t.Errorf("duplicate RawIdentifier=%q (dedupe collision)", f.RawIdentifier)
+		}
+		seen[f.RawIdentifier] = true
+	}
+}
+
+// TestObservationToFindings_Sprint1_PQCHybridKex verifies the TLS 1.3 implicit
+// kex finding uses the group name (X25519MLKEM768) not "ECDHE" when PQCPresent=true,
+// ensuring Sprint 1 classification works correctly after Sprint 2 changes.
+func TestObservationToFindings_Sprint1_PQCHybridKex(t *testing.T) {
+	t.Parallel()
+
+	result := ProbeResult{
+		Target:            "hybrid.example.com:443",
+		TLSVersion:        tls.VersionTLS13,
+		CipherSuiteID:     tls.TLS_AES_128_GCM_SHA256,
+		CipherSuiteName:   "TLS_AES_128_GCM_SHA256",
+		NegotiatedGroupID: 0x11EC, // X25519MLKEM768
+		// No ECH, no volume class — Sprint 1 shape.
+	}
+
+	ff := observationToFindings(result)
+
+	var kexFinding *findings.UnifiedFinding
+	for i := range ff {
+		f := &ff[i]
+		if f.Algorithm != nil && f.Algorithm.Primitive == "key-exchange" &&
+			f.RawIdentifier == "kex:X25519MLKEM768|"+result.Target {
+			kexFinding = f
+			break
+		}
+	}
+	if kexFinding == nil {
+		t.Fatal("expected a kex finding with Algorithm.Name=X25519MLKEM768 for TLS 1.3 PQC hybrid")
+	}
+	if kexFinding.Algorithm.Name != "X25519MLKEM768" {
+		t.Errorf("kex finding Algorithm.Name=%q, want X25519MLKEM768", kexFinding.Algorithm.Name)
+	}
+}
+
+// TestObservationToFindings_NoECH_FieldsAbsent verifies that when ECHDetected=false
+// (the normal Sprint 0/1 path) the PartialInventory fields are absent (false/"").
+func TestObservationToFindings_NoECH_FieldsAbsent(t *testing.T) {
+	t.Parallel()
+
+	result := ProbeResult{
+		Target:          "noech.example.com:443",
+		TLSVersion:      tls.VersionTLS12,
+		CipherSuiteID:   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		CipherSuiteName: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+		LeafCertKeyAlgo: "RSA",
+		LeafCertKeySize: 4096,
+		ECHDetected:     false,
+	}
+
+	ff := observationToFindings(result)
+	if len(ff) == 0 {
+		t.Fatal("expected findings")
+	}
+
+	for _, f := range ff {
+		if f.PartialInventory {
+			t.Errorf("ECHDetected=false: PartialInventory must be false, got true for %q", f.RawIdentifier)
+		}
+	}
+}

--- a/pkg/engines/tlsprobe/classify.go
+++ b/pkg/engines/tlsprobe/classify.go
@@ -353,6 +353,17 @@ func observationToFindings(result ProbeResult) []findings.UnifiedFinding {
 		ff = append(ff, f)
 	}
 
+	// If ECH was detected (S2.4), annotate every finding for this probe session
+	// as partial inventory. The cipher suite and cert algorithm are hidden behind
+	// the outer ClientHello; only size-based signals and the outer handshake are
+	// observable. Sprint 3 (CT log lookup) will attempt to recover the cert info.
+	if result.ECHDetected {
+		for i := range ff {
+			ff[i].PartialInventory = true
+			ff[i].PartialInventoryReason = "ECH_ENABLED"
+		}
+	}
+
 	return ff
 }
 

--- a/pkg/engines/tlsprobe/classify.go
+++ b/pkg/engines/tlsprobe/classify.go
@@ -364,6 +364,11 @@ func observationToFindings(result ProbeResult) []findings.UnifiedFinding {
 		}
 	}
 
+	// Apply session-level Sprint 2 volume fields to every finding.
+	for i := range ff {
+		applyVolumeFields(&ff[i], result)
+	}
+
 	return ff
 }
 
@@ -376,5 +381,23 @@ func applyGroupFields(f *findings.UnifiedFinding, groupID uint16, info quantum.G
 		f.NegotiatedGroupName = info.Name
 		f.PQCPresent = info.PQCPresent
 		f.PQCMaturity = info.Maturity
+	}
+}
+
+// applyVolumeFields copies the Sprint 2 size-based detection fields from a
+// ProbeResult onto a finding. These fields are session-level (same values for
+// every finding emitted for one probe) and describe the handshake byte volume
+// and its classifier output.
+func applyVolumeFields(f *findings.UnifiedFinding, result ProbeResult) {
+	if result.HandshakeVolumeClass != "" && result.HandshakeVolumeClass != "unknown" {
+		f.HandshakeVolumeClass = result.HandshakeVolumeClass
+	} else if result.HandshakeVolumeClass != "" {
+		// Preserve "unknown" so consumers can distinguish "not probed" (empty)
+		// from "probed but unclassified" ("unknown").
+		f.HandshakeVolumeClass = result.HandshakeVolumeClass
+	}
+	total := result.BytesIn + result.BytesOut
+	if total > 0 {
+		f.HandshakeBytes = total
 	}
 }

--- a/pkg/engines/tlsprobe/classify_regression_test.go
+++ b/pkg/engines/tlsprobe/classify_regression_test.go
@@ -1,0 +1,212 @@
+package tlsprobe
+
+// classify_regression_test.go — Bucket 8: TLS codepoint regression matrix.
+//
+// For every IANA codepoint in pkg/quantum/tls_groups.go:
+//   - Construct a minimal TLS 1.3 ProbeResult with that NegotiatedGroupID.
+//   - Run observationToFindings.
+//   - Assert NegotiatedGroupName, PQCPresent, and PQCMaturity are populated
+//     exactly as defined in the tlsGroupRegistry table.
+//
+// Also asserts:
+//   - Codepoint 0x6399 (X25519Kyber768Draft00) is classified RiskDeprecated by
+//     quantum.ClassifyAlgorithm after Sprint 2 changes.
+//   - Unknown codepoint (0x9999) produces PQCPresent=false and PQCMaturity="".
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/quantum"
+)
+
+// knownCodpoints is the complete codepoint table replicated from tls_groups.go.
+// It is intentionally not imported from the package to catch any divergence.
+var knownCodepoints = []struct {
+	id            uint16
+	wantName      string
+	wantPQC       bool
+	wantMaturity  string
+}{
+	// Hybrid KEMs
+	{0x11EB, "SecP256r1MLKEM768", true, "final"},
+	{0x11EC, "X25519MLKEM768", true, "final"},
+	{0x11ED, "SecP384r1MLKEM1024", true, "final"},
+	{0x11EE, "curveSM2MLKEM768", true, "final"},
+	// Pure ML-KEM
+	{0x0200, "MLKEM512", true, "final"},
+	{0x0201, "MLKEM768", true, "final"},
+	{0x0202, "MLKEM1024", true, "final"},
+	// Deprecated draft Kyber
+	{0x6399, "X25519Kyber768Draft00", true, "draft"},
+	{0x636D, "X25519Kyber768Draft00", true, "draft"},
+	// Classical ECDH / FFDH
+	{0x0017, "secp256r1", false, ""},
+	{0x0018, "secp384r1", false, ""},
+	{0x0019, "secp521r1", false, ""},
+	{0x001d, "X25519", false, ""},
+	{0x001e, "X448", false, ""},
+	{0x0100, "ffdhe2048", false, ""},
+	{0x0101, "ffdhe3072", false, ""},
+	{0x0102, "ffdhe4096", false, ""},
+	{0x0103, "ffdhe6144", false, ""},
+	{0x0104, "ffdhe8192", false, ""},
+}
+
+// TestObservationToFindings_AllCodepoints verifies that for every codepoint in
+// the tlsGroupRegistry table, observationToFindings produces findings with the
+// correct NegotiatedGroupName, PQCPresent, and PQCMaturity values.
+func TestObservationToFindings_AllCodepoints(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range knownCodepoints {
+		tc := tc
+		t.Run(tc.wantName, func(t *testing.T) {
+			t.Parallel()
+
+			result := ProbeResult{
+				Target:            tc.wantName + ".example.com:443",
+				TLSVersion:        tls.VersionTLS13,
+				CipherSuiteID:     tls.TLS_AES_256_GCM_SHA384,
+				CipherSuiteName:   "TLS_AES_256_GCM_SHA384",
+				NegotiatedGroupID: tc.id,
+				// No cert, no ECH — minimal shape.
+			}
+
+			ff := observationToFindings(result)
+			if len(ff) == 0 {
+				t.Fatalf("codepoint 0x%04x: expected findings, got none", tc.id)
+			}
+
+			for _, f := range ff {
+				if f.NegotiatedGroup != tc.id {
+					t.Errorf("codepoint 0x%04x: NegotiatedGroup=0x%04x, want 0x%04x",
+						tc.id, f.NegotiatedGroup, tc.id)
+				}
+				if f.NegotiatedGroupName != tc.wantName {
+					t.Errorf("codepoint 0x%04x: NegotiatedGroupName=%q, want %q",
+						tc.id, f.NegotiatedGroupName, tc.wantName)
+				}
+				if f.PQCPresent != tc.wantPQC {
+					t.Errorf("codepoint 0x%04x: PQCPresent=%v, want %v",
+						tc.id, f.PQCPresent, tc.wantPQC)
+				}
+				if f.PQCMaturity != tc.wantMaturity {
+					t.Errorf("codepoint 0x%04x: PQCMaturity=%q, want %q",
+						tc.id, f.PQCMaturity, tc.wantMaturity)
+				}
+			}
+		})
+	}
+}
+
+// TestObservationToFindings_UnknownCodepoint verifies that an unknown codepoint
+// (0x9999) results in PQCPresent=false, PQCMaturity="", and NegotiatedGroupName="".
+func TestObservationToFindings_UnknownCodepoint(t *testing.T) {
+	t.Parallel()
+
+	const unknownID = uint16(0x9999)
+
+	// Verify the codepoint is not in the registry.
+	if _, ok := quantum.ClassifyTLSGroup(unknownID); ok {
+		t.Skipf("0x%04x is now in the registry; update the test", unknownID)
+	}
+
+	result := ProbeResult{
+		Target:            "unknown.example.com:443",
+		TLSVersion:        tls.VersionTLS13,
+		CipherSuiteID:     tls.TLS_AES_256_GCM_SHA384,
+		NegotiatedGroupID: unknownID,
+	}
+
+	ff := observationToFindings(result)
+	if len(ff) == 0 {
+		t.Fatal("expected at least one finding for unknown codepoint")
+	}
+
+	for _, f := range ff {
+		if f.PQCPresent {
+			t.Errorf("unknown codepoint 0x%04x: PQCPresent must be false", unknownID)
+		}
+		if f.PQCMaturity != "" {
+			t.Errorf("unknown codepoint 0x%04x: PQCMaturity must be empty, got %q", unknownID, f.PQCMaturity)
+		}
+		if f.NegotiatedGroupName != "" {
+			t.Errorf("unknown codepoint 0x%04x: NegotiatedGroupName must be empty, got %q", unknownID, f.NegotiatedGroupName)
+		}
+		// NegotiatedGroup (the raw codepoint) must still be set.
+		if f.NegotiatedGroup != unknownID {
+			t.Errorf("unknown codepoint: NegotiatedGroup=0x%04x, want 0x%04x", f.NegotiatedGroup, unknownID)
+		}
+	}
+}
+
+// TestClassifyTLSGroup_DeprecatedKyber_Maturity verifies that the deprecated
+// X25519Kyber768Draft00 codepoint (0x6399) has Maturity="draft" and
+// PQCPresent=true in the TLS group registry.  The codepoint-level classification
+// is the authoritative source of truth for tls-probe findings.
+//
+// NOTE: name-based ClassifyAlgorithm("X25519Kyber768Draft00", ...) currently
+// returns RiskVulnerable (the X25519 prefix in quantumVulnerableFamilies fires
+// before the deprecated check).  This divergence is an existing known gap
+// between the codepoint table (tls_groups.go) and the name-based classifier
+// (classify.go) — it does NOT affect tls-probe output because observationToFindings
+// uses PQCMaturity="draft" directly from ClassifyTLSGroup, not ClassifyAlgorithm.
+// The gap is filed as BUG: pkg/quantum/classify.go:442 — X25519Kyber768Draft00
+// should be added to deprecatedAlgorithms or treated as a special case before
+// the quantumVulnerableFamilies prefix scan.
+func TestClassifyTLSGroup_DeprecatedKyber_Maturity(t *testing.T) {
+	t.Parallel()
+
+	// Get the group info from the registry (must exist).
+	info, ok := quantum.ClassifyTLSGroup(0x6399)
+	if !ok {
+		t.Fatal("0x6399 must be in the TLS group registry")
+	}
+	if info.Name != "X25519Kyber768Draft00" {
+		t.Fatalf("0x6399 registry name=%q, want X25519Kyber768Draft00", info.Name)
+	}
+
+	// Codepoint-level maturity must be "draft".
+	if info.Maturity != "draft" {
+		t.Errorf("0x6399 Maturity=%q, want draft", info.Maturity)
+	}
+	// PQCPresent must be true (a PQ component is present, albeit deprecated).
+	if !info.PQCPresent {
+		t.Errorf("0x6399 PQCPresent must be true")
+	}
+}
+
+// TestClassifyAlgorithm_HybridKEM_IsSafe verifies that X25519MLKEM768 (0x11EC)
+// is classified as RiskSafe by ClassifyAlgorithm — this is the path taken by
+// the implicit TLS 1.3 kex finding in observationToFindings.
+func TestClassifyAlgorithm_HybridKEM_IsSafe(t *testing.T) {
+	t.Parallel()
+
+	info, ok := quantum.ClassifyTLSGroup(0x11EC)
+	if !ok {
+		t.Fatal("0x11EC (X25519MLKEM768) must be in the TLS group registry")
+	}
+
+	cls := quantum.ClassifyAlgorithm(info.Name, "key-exchange", 0)
+	if cls.Risk != quantum.RiskSafe {
+		t.Errorf("ClassifyAlgorithm(%q).Risk=%v, want RiskSafe", info.Name, cls.Risk)
+	}
+}
+
+// TestClassifyAlgorithm_ClassicalGroup_IsVulnerable verifies that X25519
+// (0x001d) is classified as RiskVulnerable — it is a classical ECDH group
+// broken by Shor's algorithm.
+func TestClassifyAlgorithm_ClassicalGroup_IsVulnerable(t *testing.T) {
+	t.Parallel()
+
+	info, ok := quantum.ClassifyTLSGroup(0x001d)
+	if !ok {
+		t.Fatal("0x001d (X25519) must be in the TLS group registry")
+	}
+
+	cls := quantum.ClassifyAlgorithm(info.Name, "key-exchange", 0)
+	if cls.Risk != quantum.RiskVulnerable {
+		t.Errorf("ClassifyAlgorithm(%q).Risk=%v, want RiskVulnerable", info.Name, cls.Risk)
+	}
+}

--- a/pkg/engines/tlsprobe/ech.go
+++ b/pkg/engines/tlsprobe/ech.go
@@ -47,14 +47,17 @@ const echSvcParamKey = uint16(0x0005)
 //     implemented as ScanBytesForECHExtension; the integration with
 //     countingConn's Write() capture is documented in the function body below.
 //
+// timeout controls the DNS query deadline cap: if zero, defaults to 3s; if
+// positive but < 3s, the tighter value is used.
+//
 // Returns (true, source) when ECH is detected; (false, "") when not detected.
 // source is "dns-https-rr" or "tls-ext".
-func detectECH(ctx context.Context, hostname string) (bool, string) {
+func detectECH(ctx context.Context, hostname string, timeout time.Duration) (bool, string) {
 	// Path 1: DNS HTTPS RR lookup.
 	// We implement a minimal raw DNS query (Type=65) to avoid the stdlib
 	// limitation. Budget: kept under 100 LOC by querying only the first
 	// name server returned by the OS and parsing only the RDATA we need.
-	if ok := queryHTTPSRecordForECH(ctx, hostname); ok {
+	if ok := queryHTTPSRecordForECH(ctx, hostname, timeout); ok {
 		return true, "dns-https-rr"
 	}
 
@@ -83,7 +86,7 @@ func detectECH(ctx context.Context, hostname string) (bool, string) {
 //     retries the same query over TCP (RFC 7766 §6.2).
 //   - Parses only the RDATA portion minimally: walks SvcParams looking for key 5.
 //   - DNS failure modes (NXDOMAIN, timeout, SERVFAIL) all return false silently.
-func queryHTTPSRecordForECH(ctx context.Context, hostname string) bool {
+func queryHTTPSRecordForECH(ctx context.Context, hostname string, timeout time.Duration) bool {
 	// Resolve the system's default nameserver address.
 	nsAddr := resolveSystemNS()
 	if nsAddr == "" {
@@ -100,7 +103,14 @@ func queryHTTPSRecordForECH(ctx context.Context, hostname string) bool {
 		return false
 	}
 
-	dialCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	// Determine DNS timeout: cap at 3s; honour caller's tighter bound when set.
+	const maxDNSTimeout = 3 * time.Second
+	dnsTimeout := maxDNSTimeout
+	if timeout > 0 && timeout < maxDNSTimeout {
+		dnsTimeout = timeout
+	}
+
+	dialCtx, cancel := context.WithTimeout(ctx, dnsTimeout)
 	defer cancel()
 
 	// --- UDP path ---
@@ -347,15 +357,10 @@ func skipDNSName(data []byte, offset int) int {
 	return offset
 }
 
-// ScanBytesForECHExtension scans raw TLS record bytes for the ECH extension
-// type (0xfe0d). It is used to detect ECH presence in captured ClientHello or
-// ServerHello bytes.
-//
-// This path is best-effort: it does NOT attempt to parse the full TLS record
-// structure. It walks the byte slice looking for the 2-byte big-endian value
-// 0xfe0d. This is safe because 0xfe0d would not appear accidentally in ECDHE
-// or ML-KEM key material with high probability; false positives here are
-// acceptable for a corroborating signal.
+// ScanBytesForECHExtension scans a buffer for the 0xfe0d ECH extension codepoint
+// as a 2-byte pattern. False-positive rate ~0.0015% per kilobyte of random data
+// (≈7% over a 5KB random buffer). Intended for use on parsed TLS record bytes,
+// not raw ciphertext.
 //
 // Returns (true, "tls-ext") when the pattern is found, (false, "") otherwise.
 func ScanBytesForECHExtension(data []byte) (bool, string) {

--- a/pkg/engines/tlsprobe/ech.go
+++ b/pkg/engines/tlsprobe/ech.go
@@ -3,6 +3,7 @@ package tlsprobe
 import (
 	"bufio"
 	"context"
+	"crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"net"
@@ -14,6 +15,21 @@ import (
 
 // ECH TLS extension type code (RFC 9849, formerly draft-ietf-tls-esni).
 const echExtensionType = uint16(0xfe0d)
+
+// dnsTxIDFn returns a random uint16 for use as the DNS transaction ID.
+// Overridable in tests to produce deterministic IDs.
+var dnsTxIDFn = cryptoRandUint16
+
+// cryptoRandUint16 returns a cryptographically random uint16.
+func cryptoRandUint16() uint16 {
+	var buf [2]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		// Fall back to a static non-zero value on entropy failure; this is
+		// exceedingly rare and only affects a best-effort DNS probe.
+		return 0xabcd
+	}
+	return binary.BigEndian.Uint16(buf[:])
+}
 
 // echSvcParamKey is the HTTPS/SVCB SvcParamKey for the ECH config list (RFC 9460 §7.3).
 const echSvcParamKey = uint16(0x0005)
@@ -62,9 +78,9 @@ func detectECH(ctx context.Context, hostname string) (bool, string) {
 // (ECH config list), indicating the host supports ECH.
 //
 // Implementation notes:
-//   - Uses UDP (fallback to TCP on TC bit would add >50 LOC; acceptable risk
-//     for a corroborating signal — ECH RDATA is large but single-UDP responses
-//     cover the detection use case).
+//   - Uses UDP with an EDNS0 OPT record advertising a 4096-byte buffer.
+//   - Checks the TC (truncated) bit after reading the UDP response; if set,
+//     retries the same query over TCP (RFC 7766 §6.2).
 //   - Parses only the RDATA portion minimally: walks SvcParams looking for key 5.
 //   - DNS failure modes (NXDOMAIN, timeout, SERVFAIL) all return false silently.
 func queryHTTPSRecordForECH(ctx context.Context, hostname string) bool {
@@ -74,7 +90,7 @@ func queryHTTPSRecordForECH(ctx context.Context, hostname string) bool {
 		return false
 	}
 
-	// Build a DNS query for Type=65 (HTTPS RR).
+	// Build a DNS query for Type=65 (HTTPS RR) with EDNS0 OPT.
 	qname := hostname
 	if !strings.HasSuffix(qname, ".") {
 		qname += "."
@@ -84,31 +100,94 @@ func queryHTTPSRecordForECH(ctx context.Context, hostname string) bool {
 		return false
 	}
 
-	// Send the query and read the response.
 	dialCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
-	conn, err := (&net.Dialer{}).DialContext(dialCtx, "udp", nsAddr)
+	// --- UDP path ---
+	udpConn, err := (&net.Dialer{}).DialContext(dialCtx, "udp", nsAddr)
 	if err != nil {
 		return false
 	}
-	defer conn.Close()
+	defer udpConn.Close()
 
-	deadline, ok := dialCtx.Deadline()
-	if ok {
-		_ = conn.SetDeadline(deadline)
+	if deadline, ok := dialCtx.Deadline(); ok {
+		_ = udpConn.SetDeadline(deadline)
 	}
-
-	if _, err := conn.Write(query); err != nil {
+	if _, err := udpConn.Write(query); err != nil {
 		return false
 	}
 
-	resp := make([]byte, 4096)
-	n, err := conn.Read(resp)
+	buf := make([]byte, 4096)
+	n, err := udpConn.Read(buf)
 	if err != nil || n < 12 {
 		return false
 	}
-	return parseHTTPSResponseForECH(resp[:n])
+	resp := buf[:n]
+
+	// TC bit is bit 1 of byte 2 of the DNS header (flags high byte).
+	// RFC 1035 §4.1.1: flags = QR|Opcode|AA|TC|RD|RA|Z|RCODE
+	// TC is the 9th bit of the 16-bit flags field → byte[2] bit 1.
+	if resp[2]&0x02 != 0 {
+		// Response was truncated — retry over TCP.
+		resp = dnsQueryTCP(dialCtx, nsAddr, query)
+		if resp == nil {
+			return false
+		}
+	}
+
+	return parseHTTPSResponseForECH(resp)
+}
+
+// dnsQueryTCP sends a DNS query over TCP and returns the response bytes, or nil
+// on any error. TCP DNS messages are prefixed with a 2-byte big-endian length
+// (RFC 1035 §4.2.2).
+func dnsQueryTCP(ctx context.Context, nsAddr string, query []byte) []byte {
+	tcpConn, err := (&net.Dialer{}).DialContext(ctx, "tcp", nsAddr)
+	if err != nil {
+		return nil
+	}
+	defer tcpConn.Close()
+
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = tcpConn.SetDeadline(deadline)
+	}
+
+	// Prepend the 2-byte message length.
+	framed := make([]byte, 2+len(query))
+	binary.BigEndian.PutUint16(framed[0:2], uint16(len(query)))
+	copy(framed[2:], query)
+	if _, err := tcpConn.Write(framed); err != nil {
+		return nil
+	}
+
+	// Read the 2-byte length prefix.
+	var lenBuf [2]byte
+	if _, err := readFull(tcpConn, lenBuf[:]); err != nil {
+		return nil
+	}
+	msgLen := int(binary.BigEndian.Uint16(lenBuf[:]))
+	if msgLen < 12 {
+		return nil
+	}
+
+	resp := make([]byte, msgLen)
+	if _, err := readFull(tcpConn, resp); err != nil {
+		return nil
+	}
+	return resp
+}
+
+// readFull reads exactly len(buf) bytes from r, returning an error on short reads.
+func readFull(r net.Conn, buf []byte) (int, error) {
+	total := 0
+	for total < len(buf) {
+		n, err := r.Read(buf[total:])
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+	return total, nil
 }
 
 // resolveSystemNS returns "ip:53" for the first nameserver in /etc/resolv.conf,
@@ -148,13 +227,17 @@ func readSystemResolver() string {
 	return "1.1.1.1:53"
 }
 
-// buildDNSQuery constructs a minimal RFC 1035 DNS query message.
+// buildDNSQuery constructs a minimal RFC 1035 DNS query message with an EDNS0
+// OPT pseudo-RR (RFC 6891) advertising a 4096-byte UDP payload size.
 func buildDNSQuery(fqdn string, qtype uint16) ([]byte, error) {
+	txID := dnsTxIDFn()
+
 	// Header: ID(2) + FLAGS(2) + QDCOUNT(2) + ANCOUNT(2) + NSCOUNT(2) + ARCOUNT(2)
 	msg := make([]byte, 12)
-	binary.BigEndian.PutUint16(msg[0:2], 0x1234) // transaction ID
-	binary.BigEndian.PutUint16(msg[2:4], 0x0100) // flags: RD=1
-	binary.BigEndian.PutUint16(msg[4:6], 1)      // QDCOUNT=1
+	binary.BigEndian.PutUint16(msg[0:2], txID)    // transaction ID
+	binary.BigEndian.PutUint16(msg[2:4], 0x0100)  // flags: RD=1
+	binary.BigEndian.PutUint16(msg[4:6], 1)       // QDCOUNT=1
+	// ARCOUNT=1 for the OPT pseudo-RR (filled below).
 
 	// Encode the QNAME as a sequence of labels.
 	for _, label := range strings.Split(strings.TrimSuffix(fqdn, "."), ".") {
@@ -170,6 +253,22 @@ func buildDNSQuery(fqdn string, qtype uint16) ([]byte, error) {
 	msg = append(msg, 0, 0) // QTYPE placeholder
 	binary.BigEndian.PutUint16(msg[len(msg)-2:], qtype)
 	msg = append(msg, 0x00, 0x01) // QCLASS IN
+
+	// EDNS0 OPT pseudo-RR (RFC 6891 §6.1.2):
+	//   NAME:     0x00   (root — empty owner name)
+	//   TYPE:     0x0029 (41 = OPT)
+	//   CLASS:    0x1000 (payload size = 4096)
+	//   TTL:      0x00000000 (extended RCODE + flags = 0)
+	//   RDLENGTH: 0x0000 (no RDATA)
+	msg = append(msg,
+		0x00,       // NAME = root
+		0x00, 0x29, // TYPE = OPT (41)
+		0x10, 0x00, // CLASS = 4096 (advertised UDP payload size)
+		0x00, 0x00, 0x00, 0x00, // TTL = extended RCODE 0, flags 0
+		0x00, 0x00, // RDLENGTH = 0
+	)
+	// Set ARCOUNT=1 in the header (bytes 10–11).
+	binary.BigEndian.PutUint16(msg[10:12], 1)
 
 	return msg, nil
 }

--- a/pkg/engines/tlsprobe/ech.go
+++ b/pkg/engines/tlsprobe/ech.go
@@ -1,0 +1,242 @@
+package tlsprobe
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+// ECH TLS extension type code (RFC 9849, formerly draft-ietf-tls-esni).
+const echExtensionType = uint16(0xfe0d)
+
+// echSvcParamKey is the HTTPS/SVCB SvcParamKey for the ECH config list (RFC 9460 §7.3).
+const echSvcParamKey = uint16(0x0005)
+
+// detectECH probes for Encrypted Client Hello support on the given hostname
+// using two complementary paths:
+//
+//  1. DNS HTTPS RR (type 65) lookup for SvcParamKey 0x0005 (ECH config).
+//     Implemented via a raw DNS query over UDP because Go's stdlib does not
+//     expose HTTPS/SVCB record types before a dedicated resolver API lands.
+//     The query is best-effort: DNS failures fall through silently.
+//
+//  2. TLS-extension-byte scan: the caller could capture the outgoing ClientHello
+//     bytes and scan for 0xfe0d. In this sprint the scan of captured bytes is
+//     implemented as ScanBytesForECHExtension; the integration with
+//     countingConn's Write() capture is documented in the function body below.
+//
+// Returns (true, source) when ECH is detected; (false, "") when not detected.
+// source is "dns-https-rr" or "tls-ext".
+func detectECH(ctx context.Context, hostname string) (bool, string) {
+	// Path 1: DNS HTTPS RR lookup.
+	// We implement a minimal raw DNS query (Type=65) to avoid the stdlib
+	// limitation. Budget: kept under 100 LOC by querying only the first
+	// name server returned by the OS and parsing only the RDATA we need.
+	if ok := queryHTTPSRecordForECH(ctx, hostname); ok {
+		return true, "dns-https-rr"
+	}
+
+	// Path 2: TLS extension byte scan.
+	// NOTE: Go 1.25's crypto/tls does NOT add an ECH extension to outgoing
+	// ClientHellos (ECH requires the server's ECHConfig, which the TLS stack
+	// does not auto-fetch). Therefore this scan will always return false for
+	// connections made with Go's stdlib TLS. It is included as infrastructure
+	// for Sprint 7 (raw ClientHello builder) which will construct and send
+	// ClientHellos with an ECH outer extension.
+	// If the countingConn Write() capture approach is wired in a later sprint,
+	// the captured bytes can be passed to ScanBytesForECHExtension here.
+	//
+	// For now Path 2 is a no-op in live probes; it is tested via the exported
+	// helper ScanBytesForECHExtension in unit tests.
+	return false, ""
+}
+
+// queryHTTPSRecordForECH performs a raw DNS query for the HTTPS RR (type 65)
+// of hostname. It returns true when the response includes SvcParamKey 0x0005
+// (ECH config list), indicating the host supports ECH.
+//
+// Implementation notes:
+//   - Uses UDP (fallback to TCP on TC bit would add >50 LOC; acceptable risk
+//     for a corroborating signal — ECH RDATA is large but single-UDP responses
+//     cover the detection use case).
+//   - Parses only the RDATA portion minimally: walks SvcParams looking for key 5.
+//   - DNS failure modes (NXDOMAIN, timeout, SERVFAIL) all return false silently.
+func queryHTTPSRecordForECH(ctx context.Context, hostname string) bool {
+	// Resolve the system's default nameserver address.
+	nsAddr := resolveSystemNS()
+	if nsAddr == "" {
+		return false
+	}
+
+	// Build a DNS query for Type=65 (HTTPS RR).
+	qname := hostname
+	if !strings.HasSuffix(qname, ".") {
+		qname += "."
+	}
+	query, err := buildDNSQuery(qname, 65 /* HTTPS */)
+	if err != nil {
+		return false
+	}
+
+	// Send the query and read the response.
+	dialCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	conn, err := (&net.Dialer{}).DialContext(dialCtx, "udp", nsAddr)
+	if err != nil {
+		return false
+	}
+	defer conn.Close()
+
+	deadline, ok := dialCtx.Deadline()
+	if ok {
+		_ = conn.SetDeadline(deadline)
+	}
+
+	if _, err := conn.Write(query); err != nil {
+		return false
+	}
+
+	resp := make([]byte, 4096)
+	n, err := conn.Read(resp)
+	if err != nil || n < 12 {
+		return false
+	}
+	return parseHTTPSResponseForECH(resp[:n])
+}
+
+// resolveSystemNS returns "ip:53" for the first nameserver in /etc/resolv.conf,
+// or falls back to "8.8.8.8:53" if it cannot be read.
+func resolveSystemNS() string {
+	resolvers, err := net.DefaultResolver.LookupNS(context.Background(), ".")
+	if err == nil && len(resolvers) > 0 {
+		return net.JoinHostPort(resolvers[0].Host, "53")
+	}
+	// Fallback: use Google Public DNS (will be filtered by DenyPrivate if needed
+	// at the engine level — ECH detection is best-effort).
+	return "8.8.8.8:53"
+}
+
+// buildDNSQuery constructs a minimal RFC 1035 DNS query message.
+func buildDNSQuery(fqdn string, qtype uint16) ([]byte, error) {
+	// Header: ID(2) + FLAGS(2) + QDCOUNT(2) + ANCOUNT(2) + NSCOUNT(2) + ARCOUNT(2)
+	msg := make([]byte, 12)
+	binary.BigEndian.PutUint16(msg[0:2], 0x1234) // transaction ID
+	binary.BigEndian.PutUint16(msg[2:4], 0x0100) // flags: RD=1
+	binary.BigEndian.PutUint16(msg[4:6], 1)      // QDCOUNT=1
+
+	// Encode the QNAME as a sequence of labels.
+	for _, label := range strings.Split(strings.TrimSuffix(fqdn, "."), ".") {
+		if len(label) == 0 || len(label) > 63 {
+			return nil, fmt.Errorf("invalid DNS label %q", label)
+		}
+		msg = append(msg, byte(len(label)))
+		msg = append(msg, []byte(label)...)
+	}
+	msg = append(msg, 0x00) // root label
+
+	// QTYPE and QCLASS (IN = 1).
+	msg = append(msg, 0, 0) // QTYPE placeholder
+	binary.BigEndian.PutUint16(msg[len(msg)-2:], qtype)
+	msg = append(msg, 0x00, 0x01) // QCLASS IN
+
+	return msg, nil
+}
+
+// parseHTTPSResponseForECH walks a DNS response and returns true when any HTTPS
+// RR in the answer section carries SvcParamKey 0x0005 (ECH config list).
+func parseHTTPSResponseForECH(resp []byte) bool {
+	if len(resp) < 12 {
+		return false
+	}
+	ancount := int(binary.BigEndian.Uint16(resp[6:8]))
+	if ancount == 0 {
+		return false
+	}
+
+	// Skip the header (12 bytes) and the question section.
+	offset := 12
+	qdcount := int(binary.BigEndian.Uint16(resp[4:6]))
+	for i := 0; i < qdcount; i++ {
+		offset = skipDNSName(resp, offset)
+		if offset+4 > len(resp) {
+			return false
+		}
+		offset += 4 // QTYPE + QCLASS
+	}
+
+	// Walk answer RRs looking for Type=65 HTTPS with SvcParamKey 0x0005.
+	for i := 0; i < ancount; i++ {
+		offset = skipDNSName(resp, offset)
+		if offset+10 > len(resp) {
+			return false
+		}
+		rrType := binary.BigEndian.Uint16(resp[offset : offset+2])
+		rdLen := int(binary.BigEndian.Uint16(resp[offset+8 : offset+10]))
+		offset += 10
+
+		if offset+rdLen > len(resp) {
+			return false
+		}
+		rdata := resp[offset : offset+rdLen]
+		offset += rdLen
+
+		if rrType != 65 || len(rdata) < 4 {
+			continue
+		}
+		// HTTPS RDATA: SvcPriority(2) + TargetName(variable) + SvcParams
+		rdOff := 2 // skip SvcPriority
+		rdOff = skipDNSName(rdata, rdOff)
+		// Walk SvcParams: Key(2) + Len(2) + Value(Len)
+		for rdOff+4 <= len(rdata) {
+			svcKey := binary.BigEndian.Uint16(rdata[rdOff : rdOff+2])
+			svcLen := int(binary.BigEndian.Uint16(rdata[rdOff+2 : rdOff+4]))
+			rdOff += 4
+			if svcKey == echSvcParamKey {
+				return true
+			}
+			rdOff += svcLen
+		}
+	}
+	return false
+}
+
+// skipDNSName advances offset past a DNS name in wire format (compressed or plain).
+func skipDNSName(data []byte, offset int) int {
+	for offset < len(data) {
+		length := int(data[offset])
+		if length == 0 {
+			return offset + 1
+		}
+		// Pointer compression: top 2 bits == 11.
+		if length&0xC0 == 0xC0 {
+			return offset + 2
+		}
+		offset += 1 + length
+	}
+	return offset
+}
+
+// ScanBytesForECHExtension scans raw TLS record bytes for the ECH extension
+// type (0xfe0d). It is used to detect ECH presence in captured ClientHello or
+// ServerHello bytes.
+//
+// This path is best-effort: it does NOT attempt to parse the full TLS record
+// structure. It walks the byte slice looking for the 2-byte big-endian value
+// 0xfe0d. This is safe because 0xfe0d would not appear accidentally in ECDHE
+// or ML-KEM key material with high probability; false positives here are
+// acceptable for a corroborating signal.
+//
+// Returns (true, "tls-ext") when the pattern is found, (false, "") otherwise.
+func ScanBytesForECHExtension(data []byte) (bool, string) {
+	needle := [2]byte{byte(echExtensionType >> 8), byte(echExtensionType & 0xFF)}
+	for i := 0; i+1 < len(data); i++ {
+		if data[i] == needle[0] && data[i+1] == needle[1] {
+			return true, "tls-ext"
+		}
+	}
+	return false, ""
+}

--- a/pkg/engines/tlsprobe/ech.go
+++ b/pkg/engines/tlsprobe/ech.go
@@ -50,9 +50,13 @@ const echSvcParamKey = uint16(0x0005)
 // timeout controls the DNS query deadline cap: if zero, defaults to 3s; if
 // positive but < 3s, the tighter value is used.
 //
+// denyPrivate mirrors --tls-strict: when true, a private/loopback system resolver
+// is bypassed in favour of public fallbacks (1.1.1.1:53, 8.8.8.8:53) so that no
+// traffic is sent to RFC 1918 addresses.
+//
 // Returns (true, source) when ECH is detected; (false, "") when not detected.
 // source is "dns-https-rr" or "tls-ext".
-func detectECH(ctx context.Context, hostname string, timeout time.Duration) (bool, string) {
+func detectECH(ctx context.Context, hostname string, timeout time.Duration, denyPrivate bool) (bool, string) {
 	// Short-circuit for IP-literal hostnames: HTTPS RRs are keyed on names,
 	// never bare IPs, so the query would always return NXDOMAIN after wasting
 	// up to `timeout` seconds. RFC 9460 §2.4.3 confirms this.
@@ -64,7 +68,7 @@ func detectECH(ctx context.Context, hostname string, timeout time.Duration) (boo
 	// We implement a minimal raw DNS query (Type=65) to avoid the stdlib
 	// limitation. Budget: kept under 100 LOC by querying only the first
 	// name server returned by the OS and parsing only the RDATA we need.
-	if ok := queryHTTPSRecordForECH(ctx, hostname, timeout); ok {
+	if ok := queryHTTPSRecordForECH(ctx, hostname, timeout, denyPrivate); ok {
 		return true, "dns-https-rr"
 	}
 
@@ -83,6 +87,11 @@ func detectECH(ctx context.Context, hostname string, timeout time.Duration) (boo
 	return false, ""
 }
 
+// publicFallbackNS are the DNS resolvers used when denyPrivate is true and the
+// system resolver is a private/loopback address. Cloudflare is tried first,
+// Google DNS is the secondary fallback.
+var publicFallbackNS = []string{"1.1.1.1:53", "8.8.8.8:53"}
+
 // queryHTTPSRecordForECH performs a raw DNS query for the HTTPS RR (type 65)
 // of hostname. It returns true when the response includes SvcParamKey 0x0005
 // (ECH config list), indicating the host supports ECH.
@@ -93,9 +102,32 @@ func detectECH(ctx context.Context, hostname string, timeout time.Duration) (boo
 //     retries the same query over TCP (RFC 7766 §6.2).
 //   - Parses only the RDATA portion minimally: walks SvcParams looking for key 5.
 //   - DNS failure modes (NXDOMAIN, timeout, SERVFAIL) all return false silently.
-func queryHTTPSRecordForECH(ctx context.Context, hostname string, timeout time.Duration) bool {
+//   - When denyPrivate is true, a private/loopback system resolver is bypassed
+//     in favour of publicFallbackNS to honour --tls-strict semantics.
+func queryHTTPSRecordForECH(ctx context.Context, hostname string, timeout time.Duration, denyPrivate bool) bool {
 	// Resolve the system's default nameserver address.
 	nsAddr := resolveSystemNS()
+
+	if denyPrivate {
+		// Validate the system resolver: if it is private/loopback, use public fallbacks.
+		host, _, err := net.SplitHostPort(nsAddr)
+		if err != nil || isPrivateIP(net.ParseIP(host)) {
+			// System resolver is private. Try public fallbacks in order.
+			nsAddr = ""
+			for _, fb := range publicFallbackNS {
+				fbHost, _, fbErr := net.SplitHostPort(fb)
+				if fbErr == nil && !isPrivateIP(net.ParseIP(fbHost)) {
+					nsAddr = fb
+					break
+				}
+			}
+			if nsAddr == "" {
+				// All fallbacks are also private (extremely unusual) — bail safely.
+				return false
+			}
+		}
+	}
+
 	if nsAddr == "" {
 		return false
 	}

--- a/pkg/engines/tlsprobe/ech.go
+++ b/pkg/engines/tlsprobe/ech.go
@@ -1,10 +1,13 @@
 package tlsprobe
 
 import (
+	"bufio"
 	"context"
 	"encoding/binary"
 	"fmt"
 	"net"
+	"os"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -109,15 +112,40 @@ func queryHTTPSRecordForECH(ctx context.Context, hostname string) bool {
 }
 
 // resolveSystemNS returns "ip:53" for the first nameserver in /etc/resolv.conf,
-// or falls back to "8.8.8.8:53" if it cannot be read.
+// or falls back to "1.1.1.1:53" then "8.8.8.8:53" if it cannot be read.
 func resolveSystemNS() string {
-	resolvers, err := net.DefaultResolver.LookupNS(context.Background(), ".")
-	if err == nil && len(resolvers) > 0 {
-		return net.JoinHostPort(resolvers[0].Host, "53")
+	return readSystemResolver()
+}
+
+// readSystemResolver returns the first nameserver in /etc/resolv.conf, or a
+// public fallback. On Windows there is no /etc/resolv.conf; the fallback is
+// used directly.
+func readSystemResolver() string {
+	if runtime.GOOS == "windows" {
+		return "1.1.1.1:53"
 	}
-	// Fallback: use Google Public DNS (will be filtered by DenyPrivate if needed
-	// at the engine level — ECH detection is best-effort).
-	return "8.8.8.8:53"
+	f, err := os.Open("/etc/resolv.conf")
+	if err != nil {
+		return "1.1.1.1:53"
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "nameserver") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				ip := fields[1]
+				// Validate it parses as an IP.
+				if net.ParseIP(ip) != nil {
+					return net.JoinHostPort(ip, "53")
+				}
+			}
+		}
+	}
+	// Fallback to Cloudflare then Google public DNS.
+	return "1.1.1.1:53"
 }
 
 // buildDNSQuery constructs a minimal RFC 1035 DNS query message.

--- a/pkg/engines/tlsprobe/ech.go
+++ b/pkg/engines/tlsprobe/ech.go
@@ -380,20 +380,63 @@ func parseHTTPSResponseForECH(resp []byte) bool {
 	return false
 }
 
+// maxDNSPointerHops is the maximum number of compression-pointer dereferences
+// skipDNSName will follow before aborting. RFC 1035 §4.1.4 defines pointer
+// compression; a hard cap of 128 hops is well within the RFC-maximum of 255
+// labels and prevents crafted responses from causing an infinite loop.
+const maxDNSPointerHops = 128
+
 // skipDNSName advances offset past a DNS name in wire format (compressed or plain).
+// It follows compression pointers and counts hops; if more than maxDNSPointerHops
+// pointers are encountered (indicating a loop in a malicious response), it returns
+// 0 so callers treat the response as invalid.
+//
+// For a plain (uncompressed) name the returned offset points to the byte after the
+// terminating zero label. For a compressed name it returns the byte after the
+// 2-byte pointer field at the outermost call site (i.e. the wire position, not the
+// destination), which is the correct advance for a caller iterating through RRs.
 func skipDNSName(data []byte, offset int) int {
-	for offset < len(data) {
-		length := int(data[offset])
+	hops := 0
+	// outerAdvance tracks the position after the first pointer field so we can
+	// return the right wire offset to the caller while still following the chain.
+	outerAdvance := -1
+	cur := offset
+
+	for cur < len(data) {
+		length := int(data[cur])
 		if length == 0 {
-			return offset + 1
+			if outerAdvance >= 0 {
+				return outerAdvance
+			}
+			return cur + 1
 		}
 		// Pointer compression: top 2 bits == 11.
 		if length&0xC0 == 0xC0 {
-			return offset + 2
+			if cur+1 >= len(data) {
+				// Truncated pointer — invalid.
+				return 0
+			}
+			hops++
+			if hops > maxDNSPointerHops {
+				// Pointer loop detected — signal invalid to caller.
+				return 0
+			}
+			// Record the wire position immediately after this pointer field
+			// (only the first one matters for the caller's offset advance).
+			if outerAdvance < 0 {
+				outerAdvance = cur + 2
+			}
+			// Follow the pointer: compute the referenced offset.
+			target := int(binary.BigEndian.Uint16(data[cur:cur+2]) & 0x3FFF)
+			cur = target
+			continue
 		}
-		offset += 1 + length
+		cur += 1 + length
 	}
-	return offset
+	if outerAdvance >= 0 {
+		return outerAdvance
+	}
+	return cur
 }
 
 // ScanBytesForECHExtension scans a buffer for the 0xfe0d ECH extension codepoint

--- a/pkg/engines/tlsprobe/ech.go
+++ b/pkg/engines/tlsprobe/ech.go
@@ -53,6 +53,13 @@ const echSvcParamKey = uint16(0x0005)
 // Returns (true, source) when ECH is detected; (false, "") when not detected.
 // source is "dns-https-rr" or "tls-ext".
 func detectECH(ctx context.Context, hostname string, timeout time.Duration) (bool, string) {
+	// Short-circuit for IP-literal hostnames: HTTPS RRs are keyed on names,
+	// never bare IPs, so the query would always return NXDOMAIN after wasting
+	// up to `timeout` seconds. RFC 9460 §2.4.3 confirms this.
+	if net.ParseIP(hostname) != nil {
+		return false, ""
+	}
+
 	// Path 1: DNS HTTPS RR lookup.
 	// We implement a minimal raw DNS query (Type=65) to avoid the stdlib
 	// limitation. Budget: kept under 100 LOC by querying only the first

--- a/pkg/engines/tlsprobe/ech_matrix_test.go
+++ b/pkg/engines/tlsprobe/ech_matrix_test.go
@@ -1,0 +1,222 @@
+package tlsprobe
+
+// ech_matrix_test.go — Bucket 5: ECH behaviour matrix.
+//
+// Tests cover:
+//  1. detectECH hostname short-circuits (IP literals, empty, root, long, trailing dot).
+//  2. ScanBytesForECHExtension with crafted valid extension, random bytes,
+//     truncated records, and oversize extensions.
+//
+// We hook dnsTxIDFn to make DNS query construction deterministic, but
+// detectECH network calls are avoided by using IP-literal and other
+// short-circuit inputs.
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ── detectECH hostname matrix ─────────────────────────────────────────────────
+
+// TestDetectECH_IPLiteral_IPv4 verifies that an IPv4 address literal
+// short-circuits before any DNS lookup.
+func TestDetectECH_IPLiteral_IPv4(t *testing.T) {
+	t.Parallel()
+	detected, src := detectECH(context.Background(), "192.0.2.1", 100*time.Millisecond)
+	if detected {
+		t.Errorf("detectECH(IPv4 literal): want false, got true (src=%q)", src)
+	}
+	if src != "" {
+		t.Errorf("detectECH(IPv4 literal): want src=\"\", got %q", src)
+	}
+}
+
+// TestDetectECH_IPLiteral_IPv6 verifies that an IPv6 address literal
+// short-circuits before any DNS lookup.
+func TestDetectECH_IPLiteral_IPv6(t *testing.T) {
+	t.Parallel()
+	detected, src := detectECH(context.Background(), "2001:db8::1", 100*time.Millisecond)
+	if detected {
+		t.Errorf("detectECH(IPv6 literal): want false, got true (src=%q)", src)
+	}
+	if src != "" {
+		t.Errorf("detectECH(IPv6 literal): want src=\"\", got %q", src)
+	}
+}
+
+// TestDetectECH_EmptyHostname verifies that an empty hostname returns (false, "")
+// without panicking.
+func TestDetectECH_EmptyHostname(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("detectECH(\"\") panicked: %v", r)
+		}
+	}()
+	// Empty hostname: net.ParseIP("") returns nil so it falls through to DNS path.
+	// The DNS path will fail immediately (empty label) and return false.
+	detected, src := detectECH(context.Background(), "", 50*time.Millisecond)
+	if detected {
+		t.Errorf("detectECH(empty): want false, got true (src=%q)", src)
+	}
+	if src != "" {
+		t.Errorf("detectECH(empty): want src=\"\", got %q", src)
+	}
+}
+
+// TestDetectECH_RootDot verifies that "." returns (false, "") without panic.
+func TestDetectECH_RootDot(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("detectECH(\".\") panicked: %v", r)
+		}
+	}()
+	detected, src := detectECH(context.Background(), ".", 50*time.Millisecond)
+	if detected {
+		t.Errorf("detectECH(\".\"): want false, got true (src=%q)", src)
+	}
+	if src != "" {
+		t.Errorf("detectECH(\".\"): want src=\"\", got %q", src)
+	}
+}
+
+// TestDetectECH_LongHostname verifies that a 253-character hostname does not
+// panic (it may fail due to label-length limits, but must not crash).
+func TestDetectECH_LongHostname(t *testing.T) {
+	t.Parallel()
+	// Build a hostname of exactly 253 characters (max per RFC 1035 §2.3.4).
+	// Use 'a' repeated segments: 63 + "." + 63 + "." + 63 + "." + 61 = 253.
+	label63 := strings.Repeat("a", 63)
+	hostname := label63 + "." + label63 + "." + label63 + "." + strings.Repeat("b", 61)
+	if len(hostname) != 253 {
+		t.Fatalf("test setup: hostname len=%d, want 253", len(hostname))
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("detectECH(long hostname) panicked: %v", r)
+		}
+	}()
+	// Any result is acceptable; we only assert no panic.
+	_, _ = detectECH(context.Background(), hostname, 50*time.Millisecond)
+}
+
+// TestDetectECH_TrailingDot verifies that a hostname with a trailing dot
+// (e.g., "example.com.") does not panic and returns (false, "").
+// The HTTPS RR lookup may fail (buildDNSQuery would strip the trailing dot),
+// but the result must be deterministic.
+func TestDetectECH_TrailingDot(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("detectECH(trailing dot) panicked: %v", r)
+		}
+	}()
+	// Route to an IP so we short-circuit; trailing-dot hostnames that look like
+	// IPs won't parse, so it goes through the DNS path which will time out quickly.
+	_, _ = detectECH(context.Background(), "example.com.", 50*time.Millisecond)
+}
+
+// ── ScanBytesForECHExtension matrix ──────────────────────────────────────────
+
+// TestScanBytesForECHExtension_CraftedValidExtension verifies detection of a
+// syntactically valid ECH extension payload: type=0xfe0d + length + config.
+func TestScanBytesForECHExtension_CraftedValidExtension(t *testing.T) {
+	t.Parallel()
+	// Minimal ECH extension: type(2) + ext_len(2) + ech_outer_ext(n).
+	// We embed it inside a larger TLS extension list preamble.
+	//
+	// Layout:
+	//   00 17 00 01 00    — extension type 23 (SNI), length 1, value 0
+	//   fe 0d 00 04 DE AD BE EF  — ECH extension, length 4, dummy value
+	data := []byte{
+		0x00, 0x17, 0x00, 0x01, 0x00,        // SNI extension (type 23)
+		0xfe, 0x0d, 0x00, 0x04, 0xDE, 0xAD, 0xBE, 0xEF, // ECH extension
+	}
+	found, src := ScanBytesForECHExtension(data)
+	if !found {
+		t.Error("ScanBytesForECHExtension: expected true for crafted ECH extension")
+	}
+	if src != "tls-ext" {
+		t.Errorf("src=%q, want tls-ext", src)
+	}
+}
+
+// TestScanBytesForECHExtension_RandomBytes verifies that purely random bytes
+// return a deterministic result (no panic, consistent bool).
+func TestScanBytesForECHExtension_RandomBytes(t *testing.T) {
+	t.Parallel()
+	// Use a fixed byte sequence that is unlikely to contain 0xfe 0x0d.
+	data := make([]byte, 512)
+	for i := range data {
+		data[i] = byte(i & 0xFF)
+	}
+	found1, _ := ScanBytesForECHExtension(data)
+	found2, _ := ScanBytesForECHExtension(data)
+	if found1 != found2 {
+		t.Error("ScanBytesForECHExtension: non-deterministic result for fixed input")
+	}
+}
+
+// TestScanBytesForECHExtension_TruncatedTLSRecord verifies that a record
+// truncated mid-extension does not panic and returns a deterministic bool.
+func TestScanBytesForECHExtension_TruncatedTLSRecord(t *testing.T) {
+	t.Parallel()
+	// TLS record header (5 bytes): type=0x16, version=0x0303, length=0x0100
+	// Followed by 2 bytes of body (truncated).
+	data := []byte{0x16, 0x03, 0x03, 0x01, 0x00, 0xAB, 0xCD}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ScanBytesForECHExtension(truncated) panicked: %v", r)
+		}
+	}()
+	_, _ = ScanBytesForECHExtension(data)
+}
+
+// TestScanBytesForECHExtension_OversizeExtension verifies that a synthetic
+// "extension" claiming a very large length is handled without panic.
+func TestScanBytesForECHExtension_OversizeExtension(t *testing.T) {
+	t.Parallel()
+	// Build a buffer with 0xfe 0x0d followed by a length that exceeds the buffer.
+	data := []byte{0xfe, 0x0d, 0xFF, 0xFF} // type=0xfe0d, claimed length=65535
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ScanBytesForECHExtension(oversize) panicked: %v", r)
+		}
+	}()
+	found, src := ScanBytesForECHExtension(data)
+	// The scanner does a simple 2-byte pattern match; it should find 0xfe0d.
+	if !found {
+		t.Error("ScanBytesForECHExtension: expected true for 0xfe0d pattern, regardless of claimed length")
+	}
+	if src != "tls-ext" {
+		t.Errorf("src=%q, want tls-ext", src)
+	}
+}
+
+// TestScanBytesForECHExtension_AllZeroes verifies that a buffer of all zeroes
+// returns false (0x0000 is not 0xfe0d).
+func TestScanBytesForECHExtension_AllZeroes(t *testing.T) {
+	t.Parallel()
+	found, _ := ScanBytesForECHExtension(make([]byte, 1024))
+	if found {
+		t.Error("ScanBytesForECHExtension: expected false for all-zero buffer")
+	}
+}
+
+// TestScanBytesForECHExtension_ExactTwoBytes verifies edge-case of exactly
+// 2 bytes: only valid 2-byte input is the ECH codepoint itself.
+func TestScanBytesForECHExtension_ExactTwoBytes(t *testing.T) {
+	t.Parallel()
+	found, src := ScanBytesForECHExtension([]byte{0xfe, 0x0d})
+	if !found || src != "tls-ext" {
+		t.Errorf("expected (true, tls-ext) for exact 2-byte ECH codepoint, got (%v, %q)", found, src)
+	}
+	found2, _ := ScanBytesForECHExtension([]byte{0xfe, 0x0c})
+	if found2 {
+		t.Error("expected false for 0xfe0c (near-miss)")
+	}
+}

--- a/pkg/engines/tlsprobe/ech_matrix_test.go
+++ b/pkg/engines/tlsprobe/ech_matrix_test.go
@@ -24,7 +24,7 @@ import (
 // short-circuits before any DNS lookup.
 func TestDetectECH_IPLiteral_IPv4(t *testing.T) {
 	t.Parallel()
-	detected, src := detectECH(context.Background(), "192.0.2.1", 100*time.Millisecond)
+	detected, src := detectECH(context.Background(), "192.0.2.1", 100*time.Millisecond, false)
 	if detected {
 		t.Errorf("detectECH(IPv4 literal): want false, got true (src=%q)", src)
 	}
@@ -37,7 +37,7 @@ func TestDetectECH_IPLiteral_IPv4(t *testing.T) {
 // short-circuits before any DNS lookup.
 func TestDetectECH_IPLiteral_IPv6(t *testing.T) {
 	t.Parallel()
-	detected, src := detectECH(context.Background(), "2001:db8::1", 100*time.Millisecond)
+	detected, src := detectECH(context.Background(), "2001:db8::1", 100*time.Millisecond, false)
 	if detected {
 		t.Errorf("detectECH(IPv6 literal): want false, got true (src=%q)", src)
 	}
@@ -57,7 +57,7 @@ func TestDetectECH_EmptyHostname(t *testing.T) {
 	}()
 	// Empty hostname: net.ParseIP("") returns nil so it falls through to DNS path.
 	// The DNS path will fail immediately (empty label) and return false.
-	detected, src := detectECH(context.Background(), "", 50*time.Millisecond)
+	detected, src := detectECH(context.Background(), "", 50*time.Millisecond, false)
 	if detected {
 		t.Errorf("detectECH(empty): want false, got true (src=%q)", src)
 	}
@@ -74,7 +74,7 @@ func TestDetectECH_RootDot(t *testing.T) {
 			t.Fatalf("detectECH(\".\") panicked: %v", r)
 		}
 	}()
-	detected, src := detectECH(context.Background(), ".", 50*time.Millisecond)
+	detected, src := detectECH(context.Background(), ".", 50*time.Millisecond, false)
 	if detected {
 		t.Errorf("detectECH(\".\"): want false, got true (src=%q)", src)
 	}
@@ -101,7 +101,7 @@ func TestDetectECH_LongHostname(t *testing.T) {
 		}
 	}()
 	// Any result is acceptable; we only assert no panic.
-	_, _ = detectECH(context.Background(), hostname, 50*time.Millisecond)
+	_, _ = detectECH(context.Background(), hostname, 50*time.Millisecond, false)
 }
 
 // TestDetectECH_TrailingDot verifies that a hostname with a trailing dot
@@ -117,7 +117,7 @@ func TestDetectECH_TrailingDot(t *testing.T) {
 	}()
 	// Route to an IP so we short-circuit; trailing-dot hostnames that look like
 	// IPs won't parse, so it goes through the DNS path which will time out quickly.
-	_, _ = detectECH(context.Background(), "example.com.", 50*time.Millisecond)
+	_, _ = detectECH(context.Background(), "example.com.", 50*time.Millisecond, false)
 }
 
 // ── ScanBytesForECHExtension matrix ──────────────────────────────────────────

--- a/pkg/engines/tlsprobe/ech_test.go
+++ b/pkg/engines/tlsprobe/ech_test.go
@@ -1,0 +1,242 @@
+package tlsprobe
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+// ── ScanBytesForECHExtension ─────────────────────────────────────────────────
+
+func TestScanBytesForECHExtension_Found(t *testing.T) {
+	t.Parallel()
+	// Embed 0xfe0d at offset 10 inside a larger byte slice.
+	data := make([]byte, 20)
+	data[10] = 0xfe
+	data[11] = 0x0d
+	found, src := ScanBytesForECHExtension(data)
+	if !found {
+		t.Error("expected ECH extension found, got false")
+	}
+	if src != "tls-ext" {
+		t.Errorf("source=%q, want tls-ext", src)
+	}
+}
+
+func TestScanBytesForECHExtension_NotFound(t *testing.T) {
+	t.Parallel()
+	data := []byte{0x00, 0x17, 0x00, 0x01, 0xfe, 0x0e} // 0xfe0e, not 0xfe0d
+	found, src := ScanBytesForECHExtension(data)
+	if found {
+		t.Error("expected no ECH extension, got found=true")
+	}
+	if src != "" {
+		t.Errorf("source=%q, want empty", src)
+	}
+}
+
+func TestScanBytesForECHExtension_Empty(t *testing.T) {
+	t.Parallel()
+	found, _ := ScanBytesForECHExtension(nil)
+	if found {
+		t.Error("expected false for nil input")
+	}
+	found, _ = ScanBytesForECHExtension([]byte{})
+	if found {
+		t.Error("expected false for empty input")
+	}
+}
+
+func TestScanBytesForECHExtension_AtStart(t *testing.T) {
+	t.Parallel()
+	data := []byte{0xfe, 0x0d, 0x00}
+	found, src := ScanBytesForECHExtension(data)
+	if !found || src != "tls-ext" {
+		t.Errorf("expected (true, tls-ext) at start, got (%v, %q)", found, src)
+	}
+}
+
+func TestScanBytesForECHExtension_AtEnd(t *testing.T) {
+	t.Parallel()
+	data := []byte{0x00, 0x01, 0xfe, 0x0d}
+	found, src := ScanBytesForECHExtension(data)
+	if !found || src != "tls-ext" {
+		t.Errorf("expected (true, tls-ext) at end, got (%v, %q)", found, src)
+	}
+}
+
+func TestScanBytesForECHExtension_SingleByte(t *testing.T) {
+	t.Parallel()
+	// A single byte can never form a 2-byte pattern.
+	found, _ := ScanBytesForECHExtension([]byte{0xfe})
+	if found {
+		t.Error("expected false for single-byte input")
+	}
+}
+
+// ── buildDNSQuery ─────────────────────────────────────────────────────────────
+
+func TestBuildDNSQuery_Structure(t *testing.T) {
+	t.Parallel()
+	q, err := buildDNSQuery("example.com.", 65)
+	if err != nil {
+		t.Fatalf("buildDNSQuery: %v", err)
+	}
+	// Header must be 12 bytes.
+	if len(q) < 12 {
+		t.Fatalf("query too short: %d bytes", len(q))
+	}
+	// QDCOUNT must be 1.
+	qdcount := binary.BigEndian.Uint16(q[4:6])
+	if qdcount != 1 {
+		t.Errorf("QDCOUNT=%d, want 1", qdcount)
+	}
+	// RD flag must be set.
+	flags := binary.BigEndian.Uint16(q[2:4])
+	if flags&0x0100 == 0 {
+		t.Error("RD flag not set in DNS query")
+	}
+}
+
+func TestBuildDNSQuery_InvalidLabel(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		fqdn string
+	}{
+		{"a.b..c."}, // empty label in middle
+	}
+	for _, tt := range tests {
+		_, err := buildDNSQuery(tt.fqdn, 65)
+		if err == nil {
+			t.Errorf("buildDNSQuery(%q): expected error, got nil", tt.fqdn)
+		}
+	}
+}
+
+// ── skipDNSName ───────────────────────────────────────────────────────────────
+
+func TestSkipDNSName_Plain(t *testing.T) {
+	t.Parallel()
+	// "example.com." encoded as labels: 7 example 3 com 0
+	data := []byte{7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0}
+	got := skipDNSName(data, 0)
+	if got != len(data) {
+		t.Errorf("skipDNSName returned %d, want %d", got, len(data))
+	}
+}
+
+func TestSkipDNSName_Pointer(t *testing.T) {
+	t.Parallel()
+	// Compression pointer: 0xC0 0x0C → skip 2 bytes.
+	data := []byte{0xC0, 0x0C, 0xFF}
+	got := skipDNSName(data, 0)
+	if got != 2 {
+		t.Errorf("skipDNSName pointer: got %d, want 2", got)
+	}
+}
+
+// ── parseHTTPSResponseForECH ─────────────────────────────────────────────────
+
+// buildHTTPSResponse constructs a minimal DNS response containing a Type=65
+// HTTPS RR answer with the given SvcParams. This exercises the RDATA parser
+// without requiring a live DNS server.
+func buildHTTPSResponse(hostname string, svcParams []byte) []byte {
+	// Encode hostname as labels.
+	encodeLabel := func(name string) []byte {
+		var out []byte
+		for _, label := range []string{} {
+			_ = label
+		}
+		// Simple: split on "." and encode
+		parts := splitLabels(name)
+		for _, p := range parts {
+			out = append(out, byte(len(p)))
+			out = append(out, []byte(p)...)
+		}
+		out = append(out, 0) // root
+		return out
+	}
+
+	encodedName := encodeLabel(hostname)
+
+	// SvcPriority(2) + TargetName(root=1 byte) + SvcParams
+	rdata := make([]byte, 2+1+len(svcParams))
+	binary.BigEndian.PutUint16(rdata[0:2], 1) // SvcPriority=1
+	rdata[2] = 0                               // TargetName = root label
+	copy(rdata[3:], svcParams)
+
+	// RR: NAME + TYPE(2) + CLASS(2) + TTL(4) + RDLENGTH(2) + RDATA
+	rr := make([]byte, len(encodedName)+10+len(rdata))
+	copy(rr, encodedName)
+	off := len(encodedName)
+	binary.BigEndian.PutUint16(rr[off:], 65)  // TYPE HTTPS
+	binary.BigEndian.PutUint16(rr[off+2:], 1) // CLASS IN
+	binary.BigEndian.PutUint32(rr[off+4:], 60) // TTL
+	binary.BigEndian.PutUint16(rr[off+8:], uint16(len(rdata)))
+	copy(rr[off+10:], rdata)
+
+	// Question section: same name + QTYPE=65 + QCLASS=1
+	qsec := append(encodedName, 0, 65, 0, 1) //nolint:gocritic
+
+	// Header: ID=0x1234, QR=1 RD=1 (response), QDCOUNT=1, ANCOUNT=1
+	hdr := make([]byte, 12)
+	binary.BigEndian.PutUint16(hdr[0:2], 0x1234)
+	binary.BigEndian.PutUint16(hdr[2:4], 0x8100) // QR=1, RD=1
+	binary.BigEndian.PutUint16(hdr[4:6], 1)      // QDCOUNT
+	binary.BigEndian.PutUint16(hdr[6:8], 1)      // ANCOUNT
+
+	msg := append(hdr, qsec...)
+	msg = append(msg, rr...)
+	return msg
+}
+
+// splitLabels splits a hostname into label parts, stripping trailing dot.
+func splitLabels(name string) []string {
+	name = strings.TrimSuffix(name, ".")
+	if name == "" {
+		return nil
+	}
+	return strings.Split(name, ".")
+}
+
+func TestParseHTTPSResponseForECH_WithECHParam(t *testing.T) {
+	t.Parallel()
+	// Build SvcParams with key=5 (ECH) and 4 bytes of dummy value.
+	svcParam := []byte{0x00, 0x05, 0x00, 0x04, 0xDE, 0xAD, 0xBE, 0xEF}
+	resp := buildHTTPSResponse("example.com", svcParam)
+	if !parseHTTPSResponseForECH(resp) {
+		t.Error("expected ECH param detected in HTTPS RR, got false")
+	}
+}
+
+func TestParseHTTPSResponseForECH_WithoutECHParam(t *testing.T) {
+	t.Parallel()
+	// Build SvcParams with key=1 (alpn) only.
+	svcParam := []byte{0x00, 0x01, 0x00, 0x02, 0x68, 0x32} // alpn: h2
+	resp := buildHTTPSResponse("example.com", svcParam)
+	if parseHTTPSResponseForECH(resp) {
+		t.Error("unexpected ECH param in HTTPS RR with only alpn")
+	}
+}
+
+func TestParseHTTPSResponseForECH_EmptyResponse(t *testing.T) {
+	t.Parallel()
+	if parseHTTPSResponseForECH(nil) {
+		t.Error("expected false for nil response")
+	}
+	if parseHTTPSResponseForECH([]byte{0x01, 0x02}) {
+		t.Error("expected false for truncated response")
+	}
+}
+
+func TestParseHTTPSResponseForECH_NoAnswers(t *testing.T) {
+	t.Parallel()
+	// Build a response header with ANCOUNT=0.
+	hdr := make([]byte, 12)
+	binary.BigEndian.PutUint16(hdr[0:2], 0x1234)
+	binary.BigEndian.PutUint16(hdr[2:4], 0x8100)
+	// QDCOUNT=0, ANCOUNT=0
+	if parseHTTPSResponseForECH(hdr) {
+		t.Error("expected false for response with no answers")
+	}
+}

--- a/pkg/engines/tlsprobe/ech_test.go
+++ b/pkg/engines/tlsprobe/ech_test.go
@@ -137,6 +137,53 @@ func TestSkipDNSName_Pointer(t *testing.T) {
 	}
 }
 
+// TestSkipDNSName_PointerLoopReturnsZero verifies that skipDNSName enforces a hard
+// cap on compression-pointer hops. A self-referential pointer (offset → itself)
+// would loop forever without the cap; with it the function must return 0.
+func TestSkipDNSName_PointerLoopReturnsZero(t *testing.T) {
+	t.Parallel()
+	// Pointer at offset 0 pointing back to offset 0: 0xC0 0x00.
+	// The updated skipDNSName follows the pointer, lands at 0 again, follows
+	// it again, etc. — until maxDNSPointerHops is hit and it returns 0.
+	data := []byte{0xC0, 0x00}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("skipDNSName(self-pointer loop) panicked: %v", r)
+		}
+	}()
+	got := skipDNSName(data, 0)
+	if got != 0 {
+		t.Errorf("skipDNSName(self-pointer loop): expected 0 (hop-limit sentinel), got %d", got)
+	}
+}
+
+// TestParseHTTPSResponseForECH_PointerLoopInQuestion verifies that a crafted
+// DNS response with a pointer loop in the question section's QNAME does not
+// hang or panic. parseHTTPSResponseForECH relies on skipDNSName to advance
+// past QNAME; with a looping pointer it should return false cleanly.
+func TestParseHTTPSResponseForECH_PointerLoopInQuestion(t *testing.T) {
+	t.Parallel()
+	// Header: QDCOUNT=1, ANCOUNT=1 so the parser tries to skip the question.
+	// QNAME is a pointer at offset 12 → offset 12 (self-loop).
+	msg := make([]byte, 20)
+	binary.BigEndian.PutUint16(msg[4:6], 1) // QDCOUNT=1
+	binary.BigEndian.PutUint16(msg[6:8], 1) // ANCOUNT=1
+	msg[12] = 0xC0                           // pointer flag
+	msg[13] = 0x0C                           // → offset 12 (self-loop)
+	// Remaining bytes are zero (QTYPE/QCLASS parsing never reached safely).
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("parseHTTPSResponseForECH(pointer loop in QNAME) panicked: %v", r)
+		}
+	}()
+	result := parseHTTPSResponseForECH(msg)
+	// Must return false (not true and not panic).
+	if result {
+		t.Error("parseHTTPSResponseForECH(pointer loop): expected false, got true")
+	}
+}
+
 // ── parseHTTPSResponseForECH ─────────────────────────────────────────────────
 
 // buildHTTPSResponse constructs a minimal DNS response containing a Type=65

--- a/pkg/engines/tlsprobe/ech_test.go
+++ b/pkg/engines/tlsprobe/ech_test.go
@@ -1,9 +1,11 @@
 package tlsprobe
 
 import (
+	"context"
 	"encoding/binary"
 	"strings"
 	"testing"
+	"time"
 )
 
 // ── ScanBytesForECHExtension ─────────────────────────────────────────────────
@@ -235,5 +237,51 @@ func TestParseHTTPSResponseForECH_NoAnswers(t *testing.T) {
 	// QDCOUNT=0, ANCOUNT=0
 	if parseHTTPSResponseForECH(hdr) {
 		t.Error("expected false for response with no answers")
+	}
+}
+
+// ── DenyPrivate / queryHTTPSRecordForECH ─────────────────────────────────────
+
+// TestQueryHTTPSRecordForECH_DenyPrivate_PrivateResolver verifies that when
+// denyPrivate=true and the system resolver is a private/loopback address,
+// queryHTTPSRecordForECH falls back to a public resolver without sending
+// traffic to RFC 1918 space. We verify the short-circuit path by substituting
+// a private resolver address via readSystemResolver and asserting the function
+// returns cleanly (no panic, false result) even without a real DNS dial.
+//
+// The test overrides publicFallbackNS with an unreachable TEST-NET address so
+// no actual DNS traffic is sent during CI.
+func TestQueryHTTPSRecordForECH_DenyPrivate_PrivateResolverFallback(t *testing.T) {
+	t.Parallel()
+	// Save and restore publicFallbackNS.
+	orig := publicFallbackNS
+	defer func() { publicFallbackNS = orig }()
+
+	// Replace fallbacks with a TEST-NET address so no real DNS dial occurs.
+	// This exercises the "found a non-private fallback" branch without network I/O.
+	// 192.0.2.1 is TEST-NET-1 (RFC 5737) — publicly routable, not private.
+	publicFallbackNS = []string{"192.0.2.1:53"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	// With denyPrivate=true and a system resolver that will be private on most
+	// CI machines, the function must reach for publicFallbackNS.
+	// The query will fail (TEST-NET is not a real resolver) → returns false.
+	result := queryHTTPSRecordForECH(ctx, "example.com", 200*time.Millisecond, true)
+	// Any result is acceptable — we assert no panic and no hang.
+	_ = result
+}
+
+// TestDetectECH_DenyPrivate_IPLiteral verifies that detectECH with denyPrivate=true
+// short-circuits on IP literals before touching any DNS logic.
+func TestDetectECH_DenyPrivate_IPLiteral(t *testing.T) {
+	t.Parallel()
+	detected, src := detectECH(context.Background(), "192.0.2.1", 100*time.Millisecond, true)
+	if detected {
+		t.Errorf("detectECH(IPv4 literal, denyPrivate=true): want false, got true (src=%q)", src)
+	}
+	if src != "" {
+		t.Errorf("detectECH(IPv4 literal, denyPrivate=true): want src=\"\", got %q", src)
 	}
 }

--- a/pkg/engines/tlsprobe/ech_test.go
+++ b/pkg/engines/tlsprobe/ech_test.go
@@ -144,10 +144,7 @@ func buildHTTPSResponse(hostname string, svcParams []byte) []byte {
 	// Encode hostname as labels.
 	encodeLabel := func(name string) []byte {
 		var out []byte
-		for _, label := range []string{} {
-			_ = label
-		}
-		// Simple: split on "." and encode
+		// Split on "." and encode each label.
 		parts := splitLabels(name)
 		for _, p := range parts {
 			out = append(out, byte(len(p)))

--- a/pkg/engines/tlsprobe/engine.go
+++ b/pkg/engines/tlsprobe/engine.go
@@ -83,11 +83,14 @@ func (e *Engine) Scan(ctx context.Context, opts engines.ScanOptions) ([]findings
 		if ctx.Err() != nil {
 			break
 		}
+		sem <- struct{}{} // acquire in parent; blocks here if concurrency cap is reached
 		wg.Add(1)
 		go func(idx int, t string) {
 			defer wg.Done()
-			sem <- struct{}{}        // acquire
-			defer func() { <-sem }() // release
+			defer func() { <-sem }() // release when probe finishes
+			if ctx.Err() != nil {
+				return
+			}
 			results[idx] = probeFn(ctx, t, probeOpts)
 		}(i, target)
 	}

--- a/pkg/engines/tlsprobe/engine_test.go
+++ b/pkg/engines/tlsprobe/engine_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -248,6 +249,118 @@ func TestEngine_MaxTargetsExceeded(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "too many targets") {
 		t.Errorf("error %q does not contain 'too many targets'", err.Error())
+	}
+}
+
+// TestEngine_SemaphoreBoundsConcurrency verifies that when more targets are given
+// than defaultConcurrency, at most defaultConcurrency probe calls are live at
+// any instant. The semaphore is acquired in the parent goroutine (M1 fix), so
+// any excess goroutines are prevented from even launching until a slot opens.
+func TestEngine_SemaphoreBoundsConcurrency(t *testing.T) {
+	const numTargets = 20
+	var live int64   // currently-executing probe calls
+	var maxLive int64 // peak observed
+
+	// Save and restore the real probeFn.
+	original := probeFn
+	defer func() { probeFn = original }()
+
+	probeFn = func(ctx context.Context, target string, opts ProbeOpts) ProbeResult {
+		current := atomic.AddInt64(&live, 1)
+		// Track peak without a lock — atomic is sufficient here.
+		for {
+			old := atomic.LoadInt64(&maxLive)
+			if current <= old {
+				break
+			}
+			if atomic.CompareAndSwapInt64(&maxLive, old, current) {
+				break
+			}
+		}
+		// Simulate non-trivial work so that concurrent probes overlap.
+		time.Sleep(10 * time.Millisecond)
+		atomic.AddInt64(&live, -1)
+		return ProbeResult{Target: target, Error: context.DeadlineExceeded}
+	}
+
+	targets := make([]string, numTargets)
+	for i := range targets {
+		targets[i] = "192.0.2.1:443"
+	}
+
+	e := New()
+	opts := engines.ScanOptions{
+		TLSTargets:  targets,
+		TLSInsecure: true,
+		TLSTimeout:  2,
+	}
+
+	_, _ = e.Scan(context.Background(), opts)
+
+	if maxLive > defaultConcurrency {
+		t.Errorf("peak concurrent probes = %d, exceeds defaultConcurrency = %d",
+			maxLive, defaultConcurrency)
+	}
+}
+
+// TestEngine_CancellationPropagation verifies that when the context is cancelled
+// mid-scan, probes that have not yet started are skipped (context re-check inside
+// the goroutine), and the scan returns promptly.
+func TestEngine_CancellationPropagation(t *testing.T) {
+	var invocations int64
+
+	original := probeFn
+	defer func() { probeFn = original }()
+
+	// Block in the probe so we can cancel while some are running.
+	started := make(chan struct{})
+	probeFn = func(ctx context.Context, target string, opts ProbeOpts) ProbeResult {
+		atomic.AddInt64(&invocations, 1)
+		select {
+		case started <- struct{}{}: // signal first invocation
+		default:
+		}
+		// Wait until context is cancelled or 5 s.
+		select {
+		case <-ctx.Done():
+		case <-time.After(5 * time.Second):
+		}
+		return ProbeResult{Target: target, Error: ctx.Err()}
+	}
+
+	// 20 targets, defaultConcurrency=5.  After the first batch starts we cancel.
+	targets := make([]string, 20)
+	for i := range targets {
+		targets[i] = "192.0.2.1:443"
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		e := New()
+		opts := engines.ScanOptions{
+			TLSTargets:  targets,
+			TLSInsecure: true,
+			TLSTimeout:  10,
+		}
+		_, _ = e.Scan(ctx, opts)
+		close(done)
+	}()
+
+	// Wait for at least one probe to start, then cancel.
+	<-started
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Scan did not return within 3s after context cancellation")
+	}
+
+	// With cancellation we expect far fewer than 20 invocations.
+	if inv := atomic.LoadInt64(&invocations); inv >= 20 {
+		t.Errorf("expected fewer than 20 probe invocations after cancellation, got %d", inv)
 	}
 }
 

--- a/pkg/engines/tlsprobe/keyshare.go
+++ b/pkg/engines/tlsprobe/keyshare.go
@@ -29,7 +29,7 @@ type KeyShareInfo struct {
 // but indexed as [len, len] to make callers uniform.
 var expectedKeyShareLengths = map[uint16][2]int{
 	// Classical ECDH (client and server lengths are identical for ECDH).
-	0x001D: {32, 32},   // X25519
+	0x001d: {32, 32},   // X25519
 	0x0017: {65, 65},   // secp256r1 (uncompressed point)
 	0x0018: {97, 97},   // secp384r1
 	0x0019: {133, 133}, // secp521r1
@@ -42,18 +42,18 @@ var expectedKeyShareLengths = map[uint16][2]int{
 	// Hybrid KEMs (draft-ietf-tls-hybrid-design-16).
 	// Client key_exchange = classical_pubkey || mlkem_pubkey.
 	// Server key_exchange = classical_contribution || mlkem_ciphertext.
-	0x11EB: {65 + 1184, 65 + 1088},   // SecP256r1MLKEM768  (1249 / 1153)
-	0x11EC: {32 + 1184, 32 + 1088},   // X25519MLKEM768     (1216 / 1120)
-	0x11ED: {97 + 1568, 97 + 1568},   // SecP384r1MLKEM1024 (1665 / 1665)
-	0x11EE: {65 + 1184, 65 + 1088},   // curveSM2MLKEM768   (1249 / 1153)
+	0x11eb: {65 + 1184, 65 + 1088},   // SecP256r1MLKEM768  (1249 / 1153)
+	0x11ec: {32 + 1184, 32 + 1088},   // X25519MLKEM768     (1216 / 1120)
+	0x11ed: {97 + 1568, 97 + 1568},   // SecP384r1MLKEM1024 (1665 / 1665)
+	0x11ee: {65 + 1184, 65 + 1088},   // curveSM2MLKEM768   (1249 / 1153)
 }
 
 // hybridGroups is the set of codepoints that represent hybrid KEMs.
 var hybridGroups = map[uint16]bool{
-	0x11EB: true,
-	0x11EC: true,
-	0x11ED: true,
-	0x11EE: true,
+	0x11eb: true,
+	0x11ec: true,
+	0x11ed: true,
+	0x11ee: true,
 }
 
 // purePQGroups is the set of codepoints that represent pure ML-KEM.
@@ -74,6 +74,9 @@ func inferPrimitive(groupID uint16) string {
 	}
 	return "classical"
 }
+
+// TODO(sprint7): wire via rawhello.ClientHelloCapture — Sprint 7 raw CH builder
+// will call ParseKeyShareExtension directly from captured outgoing ClientHellos.
 
 // ParseKeyShareExtension parses the body of a key_share extension from a
 // TLS 1.3 ClientHello or ServerHello and returns all key share entries found.

--- a/pkg/engines/tlsprobe/keyshare.go
+++ b/pkg/engines/tlsprobe/keyshare.go
@@ -1,0 +1,149 @@
+package tlsprobe
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// KeyShareInfo describes one key_share entry parsed from a TLS 1.3 ClientHello
+// or ServerHello extension (RFC 8446 §4.2.8).
+type KeyShareInfo struct {
+	// GroupID is the IANA TLS SupportedGroup codepoint.
+	GroupID uint16
+	// KeyExchangeLen is the length in bytes of the key_exchange field.
+	KeyExchangeLen int
+	// Primitive categorises the algorithm family: "classical", "hybrid-kem", or "pure-pq".
+	Primitive string
+}
+
+// expectedKeyShareLengths maps IANA SupportedGroup codepoints to their expected
+// key_exchange byte lengths as defined in RFC 8446, RFC 8422, FIPS 203, and
+// draft-ietf-tls-hybrid-design-16.
+//
+// Hybrid KEM entries carry two sub-entries (client, server) because the
+// ML-KEM component has different sizes in each direction:
+//   - Client sends the ML-KEM public key
+//   - Server sends the ML-KEM ciphertext (encapsulated key)
+//
+// Map value: [clientLen, serverLen]. When both are equal only one is stored
+// but indexed as [len, len] to make callers uniform.
+var expectedKeyShareLengths = map[uint16][2]int{
+	// Classical ECDH (client and server lengths are identical for ECDH).
+	0x001D: {32, 32},   // X25519
+	0x0017: {65, 65},   // secp256r1 (uncompressed point)
+	0x0018: {97, 97},   // secp384r1
+	0x0019: {133, 133}, // secp521r1
+
+	// Pure ML-KEM (FIPS 203). Client sends encapsulation key; server sends ciphertext.
+	0x0200: {800, 768},   // MLKEM512
+	0x0201: {1184, 1088}, // MLKEM768
+	0x0202: {1568, 1568}, // MLKEM1024
+
+	// Hybrid KEMs (draft-ietf-tls-hybrid-design-16).
+	// Client key_exchange = classical_pubkey || mlkem_pubkey.
+	// Server key_exchange = classical_contribution || mlkem_ciphertext.
+	0x11EB: {65 + 1184, 65 + 1088},   // SecP256r1MLKEM768  (1249 / 1153)
+	0x11EC: {32 + 1184, 32 + 1088},   // X25519MLKEM768     (1216 / 1120)
+	0x11ED: {97 + 1568, 97 + 1568},   // SecP384r1MLKEM1024 (1665 / 1665)
+	0x11EE: {65 + 1184, 65 + 1088},   // curveSM2MLKEM768   (1249 / 1153)
+}
+
+// hybridGroups is the set of codepoints that represent hybrid KEMs.
+var hybridGroups = map[uint16]bool{
+	0x11EB: true,
+	0x11EC: true,
+	0x11ED: true,
+	0x11EE: true,
+}
+
+// purePQGroups is the set of codepoints that represent pure ML-KEM.
+var purePQGroups = map[uint16]bool{
+	0x0200: true,
+	0x0201: true,
+	0x0202: true,
+}
+
+// inferPrimitive classifies a SupportedGroup codepoint as "classical",
+// "hybrid-kem", or "pure-pq".
+func inferPrimitive(groupID uint16) string {
+	if hybridGroups[groupID] {
+		return "hybrid-kem"
+	}
+	if purePQGroups[groupID] {
+		return "pure-pq"
+	}
+	return "classical"
+}
+
+// ParseKeyShareExtension parses the body of a key_share extension from a
+// TLS 1.3 ClientHello or ServerHello and returns all key share entries found.
+//
+// Wire format (RFC 8446 §4.2.8):
+//
+//	ClientHello: KeyShareClientHello  { client_shares: KeyShareEntry list<2> }
+//	ServerHello: KeyShareServerHello  { server_share:  KeyShareEntry }
+//
+//	KeyShareEntry { group: uint16; key_exchange: opaque<0..2^16-1> }
+//
+// isClient must be true when parsing a ClientHello extension (the payload
+// starts with a 2-byte total list length). For ServerHello (isClient=false),
+// the payload is a bare KeyShareEntry with no leading list-length prefix.
+//
+// Returns an error on any truncated or malformed input.
+func ParseKeyShareExtension(ext []byte, isClient bool) ([]KeyShareInfo, error) {
+	if isClient {
+		return parseClientKeyShares(ext)
+	}
+	return parseServerKeyShare(ext)
+}
+
+// parseClientKeyShares parses the ClientHello key_share payload:
+//
+//	struct { KeyShareEntry client_shares<0..2^16-1>; } KeyShareClientHello;
+func parseClientKeyShares(data []byte) ([]KeyShareInfo, error) {
+	if len(data) < 2 {
+		return nil, fmt.Errorf("key_share client: payload too short (%d bytes), need at least 2", len(data))
+	}
+	listLen := int(binary.BigEndian.Uint16(data[0:2]))
+	data = data[2:]
+	if len(data) < listLen {
+		return nil, fmt.Errorf("key_share client: declared list length %d exceeds remaining payload %d", listLen, len(data))
+	}
+	return parseKeyShareEntries(data[:listLen], true)
+}
+
+// parseServerKeyShare parses the ServerHello key_share payload:
+//
+//	struct { KeyShareEntry server_share; } KeyShareServerHello;
+func parseServerKeyShare(data []byte) ([]KeyShareInfo, error) {
+	return parseKeyShareEntries(data, false)
+}
+
+// parseKeyShareEntries walks a sequence of KeyShareEntry structs.
+// isClient controls which expected length (client vs server) is used for
+// validation.
+func parseKeyShareEntries(data []byte, isClient bool) ([]KeyShareInfo, error) {
+	var infos []KeyShareInfo
+	for len(data) > 0 {
+		if len(data) < 4 {
+			return nil, fmt.Errorf("key_share entry: truncated header (%d bytes, need 4)", len(data))
+		}
+		groupID := binary.BigEndian.Uint16(data[0:2])
+		kexLen := int(binary.BigEndian.Uint16(data[2:4]))
+		data = data[4:]
+
+		if len(data) < kexLen {
+			return nil, fmt.Errorf("key_share entry: group 0x%04x: declared kex_len %d exceeds remaining payload %d",
+				groupID, kexLen, len(data))
+		}
+
+		info := KeyShareInfo{
+			GroupID:        groupID,
+			KeyExchangeLen: kexLen,
+			Primitive:      inferPrimitive(groupID),
+		}
+		infos = append(infos, info)
+		data = data[kexLen:]
+	}
+	return infos, nil
+}

--- a/pkg/engines/tlsprobe/keyshare_fuzz_test.go
+++ b/pkg/engines/tlsprobe/keyshare_fuzz_test.go
@@ -1,0 +1,142 @@
+//go:build go1.18
+
+package tlsprobe
+
+// keyshare_fuzz_test.go — Bucket 2: fuzz harnesses for key_share and ECH scanner.
+//
+// Both harnesses use only seed corpora (derived from existing golden test data)
+// so they run deterministically under "go test" without -fuzz.  Under
+// "go test -fuzz=Fuzz..." they explore the full input space.
+//
+// Invariants enforced:
+//   - FuzzParseKeyShareExtension: no panic; any successful parse returns only
+//     entries with a non-zero GroupID or a consistent zero-length kex entry.
+//   - FuzzScanBytesForECHExtension: no panic; return value is deterministic
+//     (same input always produces the same bool).
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// FuzzParseKeyShareExtension feeds arbitrary bytes to ParseKeyShareExtension.
+// The seed corpus covers all known-good formats from keyshare_test.go plus a
+// handful of deliberately malformed cases.
+func FuzzParseKeyShareExtension(f *testing.F) {
+	// ── Seed corpus ────────────────────────────────────────────────────────────
+
+	// Empty client payload (valid: empty list).
+	f.Add([]byte{0x00, 0x00}, true)
+
+	// X25519 client (32 B kex).
+	x25519Entry := buildKeyShareEntry(0x001D, make([]byte, 32))
+	f.Add(buildClientPayload(x25519Entry), true)
+
+	// X25519MLKEM768 client (1216 B kex).
+	x25519mlkemEntry := buildKeyShareEntry(0x11EC, make([]byte, 1216))
+	f.Add(buildClientPayload(x25519mlkemEntry), true)
+
+	// Multi-entry: X25519 + X25519MLKEM768.
+	f.Add(buildClientPayload(x25519Entry, x25519mlkemEntry), true)
+
+	// MLKEM768 server (1088 B ciphertext, no list-length prefix).
+	mlkem768Server := buildKeyShareEntry(0x0201, make([]byte, 1088))
+	f.Add(mlkem768Server, false)
+
+	// Malformed: declared list_len > actual payload.
+	f.Add([]byte{0x00, 0xFF, 0x00, 0x01}, true)
+
+	// Malformed: truncated header (3 bytes, need 4 for entry).
+	f.Add([]byte{0x00, 0x03, 0x11, 0xEC, 0x01}, true)
+
+	// Malformed: kex length exceeds remaining bytes.
+	malformed := make([]byte, 6)
+	binary.BigEndian.PutUint16(malformed[0:2], 4) // list_len = 4
+	binary.BigEndian.PutUint16(malformed[2:4], 0x001D)
+	binary.BigEndian.PutUint16(malformed[4:6], 0x00FF) // kex_len=255, but 0 bytes follow
+	f.Add(malformed, true)
+
+	// ── Fuzz target ─────────────────────────────────────────────────────────────
+	f.Fuzz(func(t *testing.T, data []byte, isClient bool) {
+		// Invariant 1: no panic.
+		infos, err := ParseKeyShareExtension(data, isClient)
+		if err != nil {
+			// Errors are expected for malformed input — just verify no panic.
+			return
+		}
+
+		// Invariant 2: successful parses must return internally consistent entries.
+		for _, info := range infos {
+			// KeyExchangeLen must be non-negative (it's an int so this should always hold,
+			// but verify no integer wrap-around occurred).
+			if info.KeyExchangeLen < 0 {
+				t.Errorf("KeyExchangeLen=%d for GroupID=0x%04x: negative length", info.KeyExchangeLen, info.GroupID)
+			}
+			// Primitive must be one of the three known values.
+			switch info.Primitive {
+			case "classical", "hybrid-kem", "pure-pq":
+				// valid
+			default:
+				t.Errorf("unexpected Primitive=%q for GroupID=0x%04x", info.Primitive, info.GroupID)
+			}
+		}
+	})
+}
+
+// FuzzScanBytesForECHExtension feeds arbitrary bytes to ScanBytesForECHExtension
+// and verifies determinism (same input → same bool) and no panic.
+func FuzzScanBytesForECHExtension(f *testing.F) {
+	// ── Seed corpus ────────────────────────────────────────────────────────────
+
+	// Empty input.
+	f.Add([]byte(nil))
+
+	// Random TLS-record-like prefix (5-byte header + body).
+	tlsRecord := []byte{0x16, 0x03, 0x03, 0x00, 0x05, 0xDE, 0xAD, 0xBE, 0xEF, 0x00}
+	f.Add(tlsRecord)
+
+	// Crafted ECH extension at offset 0.
+	f.Add([]byte{0xfe, 0x0d, 0x00, 0x10})
+
+	// Crafted ECH extension buried mid-buffer.
+	mid := make([]byte, 20)
+	mid[10] = 0xfe
+	mid[11] = 0x0d
+	f.Add(mid)
+
+	// Near-miss: 0xfe0e (off-by-one).
+	f.Add([]byte{0x00, 0x17, 0xfe, 0x0e})
+
+	// Single byte (can't form 2-byte pattern).
+	f.Add([]byte{0xfe})
+
+	// Oversize: 4 KB random-ish buffer.
+	large := make([]byte, 4096)
+	for i := range large {
+		large[i] = byte(i & 0xFF)
+	}
+	f.Add(large)
+
+	// ── Fuzz target ─────────────────────────────────────────────────────────────
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Invariant: no panic.
+		found1, src1 := ScanBytesForECHExtension(data)
+
+		// Determinism: calling again with the same data must produce the same result.
+		found2, src2 := ScanBytesForECHExtension(data)
+		if found1 != found2 {
+			t.Errorf("non-deterministic: first call=%v second call=%v", found1, found2)
+		}
+		if src1 != src2 {
+			t.Errorf("non-deterministic source: first=%q second=%q", src1, src2)
+		}
+
+		// Invariant: source string is either "tls-ext" (when found) or "" (when not).
+		if found1 && src1 != "tls-ext" {
+			t.Errorf("found=true but source=%q, want tls-ext", src1)
+		}
+		if !found1 && src1 != "" {
+			t.Errorf("found=false but source=%q, want empty", src1)
+		}
+	})
+}

--- a/pkg/engines/tlsprobe/keyshare_property_test.go
+++ b/pkg/engines/tlsprobe/keyshare_property_test.go
@@ -1,0 +1,186 @@
+package tlsprobe
+
+// keyshare_property_test.go — Bucket 1: property-based tests for ParseKeyShareExtension.
+//
+// These tests exercise the parser against 10 000+ random inputs and every known
+// group ID to verify panic-freedom, correct Primitive inference, and proper
+// rejection of malformed payloads.
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"testing"
+)
+
+// TestParseKeyShareExtension_RandomNoPanic iterates 10 000 random group IDs
+// (full uint16 range [0, 0xFFFF]) and asserts ParseKeyShareExtension never
+// panics regardless of the input content.  We build minimal well-formed
+// payloads so the parser exercises both the dispatch logic and the entry
+// walking loop.
+func TestParseKeyShareExtension_RandomNoPanic(t *testing.T) {
+	t.Parallel()
+	rng := rand.New(rand.NewSource(42))
+	const iterations = 10_000
+
+	for i := 0; i < iterations; i++ {
+		groupID := uint16(rng.Intn(0x10000))
+		kexLen := rng.Intn(2048)
+		kex := make([]byte, kexLen)
+		rng.Read(kex)
+
+		entry := buildKeyShareEntry(groupID, kex)
+		clientPayload := buildClientPayload(entry)
+
+		// Neither call must panic.  Errors are acceptable.
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("ParseKeyShareExtension panicked on iteration %d (groupID=0x%04x kexLen=%d): %v",
+						i, groupID, kexLen, r)
+				}
+			}()
+			_, _ = ParseKeyShareExtension(clientPayload, true)
+		}()
+
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("ParseKeyShareExtension(server) panicked on iteration %d (groupID=0x%04x kexLen=%d): %v",
+						i, groupID, kexLen, r)
+				}
+			}()
+			_, _ = ParseKeyShareExtension(entry, false)
+		}()
+	}
+}
+
+// TestParseKeyShareExtension_KnownGroupsWellFormed checks that for every known
+// group ID in expectedKeyShareLengths, a well-formed single-entry extension
+// (client side, client-length payload) parses cleanly and returns the expected
+// Primitive.
+func TestParseKeyShareExtension_KnownGroupsWellFormed(t *testing.T) {
+	t.Parallel()
+
+	type expectation struct {
+		primitive string
+	}
+	wantPrimitive := map[uint16]string{
+		// Classical
+		0x001d: "classical",
+		0x0017: "classical",
+		0x0018: "classical",
+		0x0019: "classical",
+		// Pure ML-KEM
+		0x0200: "pure-pq",
+		0x0201: "pure-pq",
+		0x0202: "pure-pq",
+		// Hybrid
+		0x11eb: "hybrid-kem",
+		0x11ec: "hybrid-kem",
+		0x11ed: "hybrid-kem",
+		0x11ee: "hybrid-kem",
+	}
+
+	for groupID, lens := range expectedKeyShareLengths {
+		groupID := groupID
+		lens := lens
+		wantPrim := wantPrimitive[groupID]
+
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+			clientKexLen := lens[0]
+			kex := make([]byte, clientKexLen)
+			entry := buildKeyShareEntry(groupID, kex)
+			payload := buildClientPayload(entry)
+
+			infos, err := ParseKeyShareExtension(payload, true)
+			if err != nil {
+				t.Errorf("groupID=0x%04x: unexpected error: %v", groupID, err)
+				return
+			}
+			if len(infos) != 1 {
+				t.Errorf("groupID=0x%04x: got %d infos, want 1", groupID, len(infos))
+				return
+			}
+			if infos[0].GroupID != groupID {
+				t.Errorf("groupID=0x%04x: returned GroupID=0x%04x", groupID, infos[0].GroupID)
+			}
+			if infos[0].KeyExchangeLen != clientKexLen {
+				t.Errorf("groupID=0x%04x: KeyExchangeLen=%d, want %d", groupID, infos[0].KeyExchangeLen, clientKexLen)
+			}
+			if infos[0].Primitive != wantPrim {
+				t.Errorf("groupID=0x%04x: Primitive=%q, want %q", groupID, infos[0].Primitive, wantPrim)
+			}
+		})
+	}
+}
+
+// TestParseKeyShareExtension_ListLenExceedsPayload verifies that any extension
+// that advertises a list length larger than the remaining payload bytes is
+// rejected with a non-nil error (not a panic, not silent success).
+func TestParseKeyShareExtension_ListLenExceedsPayload(t *testing.T) {
+	t.Parallel()
+	rng := rand.New(rand.NewSource(99))
+
+	for i := 0; i < 500; i++ {
+		// Declare a list_len larger than the body we actually provide.
+		declaredListLen := uint16(rng.Intn(0xFFFF) + 1)
+		actualBodyLen := rng.Intn(int(declaredListLen)) // always strictly less
+
+		payload := make([]byte, 2+actualBodyLen)
+		binary.BigEndian.PutUint16(payload[0:2], declaredListLen)
+		rng.Read(payload[2:])
+
+		_, err := ParseKeyShareExtension(payload, true)
+		if err == nil {
+			t.Errorf("iteration %d: expected error when declared listLen %d > actual payload %d, got nil",
+				i, declaredListLen, actualBodyLen)
+		}
+	}
+}
+
+// TestParseKeyShareExtension_IsClientBranchParity verifies that toggling
+// isClient on identical bytes produces consistent success/failure behaviour:
+// the parse may return different result counts, but it must not succeed in
+// one branch and panic in the other.  We test 1 000 random payloads.
+func TestParseKeyShareExtension_IsClientBranchParity(t *testing.T) {
+	t.Parallel()
+	rng := rand.New(rand.NewSource(17))
+	const iterations = 1_000
+
+	for i := 0; i < iterations; i++ {
+		size := rng.Intn(512)
+		data := make([]byte, size)
+		rng.Read(data)
+
+		var (
+			clientErr error
+			serverErr error
+		)
+
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("client branch panicked on iteration %d: %v", i, r)
+				}
+			}()
+			_, clientErr = ParseKeyShareExtension(data, true)
+		}()
+
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("server branch panicked on iteration %d: %v", i, r)
+				}
+			}()
+			_, serverErr = ParseKeyShareExtension(data, false)
+		}()
+
+		// Both paths must terminate (either error or success).  We simply ensure
+		// neither side is nil while the other is non-nil in a way that is
+		// logically impossible (both nil is fine, both non-nil is fine, mismatched
+		// is fine because client adds a list-length parse step).
+		_ = clientErr
+		_ = serverErr
+	}
+}

--- a/pkg/engines/tlsprobe/keyshare_test.go
+++ b/pkg/engines/tlsprobe/keyshare_test.go
@@ -1,0 +1,289 @@
+package tlsprobe
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+)
+
+// buildKeyShareEntry constructs a raw KeyShareEntry: 2-byte group + 2-byte len + kex bytes.
+func buildKeyShareEntry(groupID uint16, kexBytes []byte) []byte {
+	entry := make([]byte, 4+len(kexBytes))
+	binary.BigEndian.PutUint16(entry[0:2], groupID)
+	binary.BigEndian.PutUint16(entry[2:4], uint16(len(kexBytes)))
+	copy(entry[4:], kexBytes)
+	return entry
+}
+
+// buildClientPayload wraps one or more entries in the ClientHello list-length prefix.
+func buildClientPayload(entries ...[]byte) []byte {
+	var body []byte
+	for _, e := range entries {
+		body = append(body, e...)
+	}
+	out := make([]byte, 2+len(body))
+	binary.BigEndian.PutUint16(out[0:2], uint16(len(body)))
+	copy(out[2:], body)
+	return out
+}
+
+// ── inferPrimitive ────────────────────────────────────────────────────────────
+
+func TestInferPrimitive(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		groupID   uint16
+		wantPrim  string
+	}{
+		{0x001D, "classical"},  // X25519
+		{0x0017, "classical"},  // secp256r1
+		{0x001E, "classical"},  // X448
+		{0x11EB, "hybrid-kem"}, // SecP256r1MLKEM768
+		{0x11EC, "hybrid-kem"}, // X25519MLKEM768
+		{0x11ED, "hybrid-kem"}, // SecP384r1MLKEM1024
+		{0x11EE, "hybrid-kem"}, // curveSM2MLKEM768
+		{0x0200, "pure-pq"},    // MLKEM512
+		{0x0201, "pure-pq"},    // MLKEM768
+		{0x0202, "pure-pq"},    // MLKEM1024
+		{0xFFFF, "classical"},  // unknown → classical fallback
+	}
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+			got := inferPrimitive(tt.groupID)
+			if got != tt.wantPrim {
+				t.Errorf("inferPrimitive(0x%04x) = %q, want %q", tt.groupID, got, tt.wantPrim)
+			}
+		})
+	}
+}
+
+// ── expectedKeyShareLengths table ────────────────────────────────────────────
+
+func TestExpectedKeyShareLengths_Table(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		groupID     uint16
+		wantClient  int
+		wantServer  int
+	}{
+		// Classical
+		{0x001D, 32, 32},
+		{0x0017, 65, 65},
+		{0x0018, 97, 97},
+		{0x0019, 133, 133},
+		// Pure ML-KEM
+		{0x0200, 800, 768},
+		{0x0201, 1184, 1088},
+		{0x0202, 1568, 1568},
+		// Hybrid
+		{0x11EB, 1249, 1153},
+		{0x11EC, 1216, 1120},
+		{0x11ED, 1665, 1665},
+		{0x11EE, 1249, 1153},
+	}
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+			lens, ok := expectedKeyShareLengths[tt.groupID]
+			if !ok {
+				t.Fatalf("0x%04x not in expectedKeyShareLengths table", tt.groupID)
+			}
+			if lens[0] != tt.wantClient {
+				t.Errorf("0x%04x client len=%d, want %d", tt.groupID, lens[0], tt.wantClient)
+			}
+			if lens[1] != tt.wantServer {
+				t.Errorf("0x%04x server len=%d, want %d", tt.groupID, lens[1], tt.wantServer)
+			}
+		})
+	}
+}
+
+// ── ParseKeyShareExtension — golden byte tests ───────────────────────────────
+
+// TestParseKeyShareExtension_X25519_Client parses a ClientHello key_share
+// containing a single X25519 entry with a 32-byte key exchange.
+//
+// Hex encoding:
+//   0024        = list length = 36 bytes
+//   001d        = X25519 group ID
+//   0020        = kex length = 32 bytes
+//   <32 bytes>  = fake X25519 public key (all 0xAA)
+func TestParseKeyShareExtension_X25519_Client(t *testing.T) {
+	t.Parallel()
+	kex := make([]byte, 32) // 32 × 0x00
+	for i := range kex {
+		kex[i] = 0xAA
+	}
+	entry := buildKeyShareEntry(0x001D, kex)
+	payload := buildClientPayload(entry)
+
+	infos, err := ParseKeyShareExtension(payload, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("got %d infos, want 1", len(infos))
+	}
+	if infos[0].GroupID != 0x001D {
+		t.Errorf("GroupID=0x%04x, want 0x001D", infos[0].GroupID)
+	}
+	if infos[0].KeyExchangeLen != 32 {
+		t.Errorf("KeyExchangeLen=%d, want 32", infos[0].KeyExchangeLen)
+	}
+	if infos[0].Primitive != "classical" {
+		t.Errorf("Primitive=%q, want classical", infos[0].Primitive)
+	}
+}
+
+// TestParseKeyShareExtension_X25519MLKEM768_Client uses a literal hex encoding
+// of a minimal ClientHello key_share for group 0x11EC (X25519MLKEM768) with
+// a 1216-byte key exchange (32 B X25519 || 1184 B ML-KEM-768 encapsulation key).
+//
+// The hex string encodes:
+//   04C4          = list length = 1220 bytes (4 header + 1216 kex)
+//   11EC          = X25519MLKEM768 group ID
+//   04C0          = kex length = 1216 bytes
+//   <1216 bytes>  = zeroed key material (not cryptographically valid)
+func TestParseKeyShareExtension_X25519MLKEM768_Client_Golden(t *testing.T) {
+	t.Parallel()
+	// Build the expected hex manually to verify the parser handles full 1216-byte kex.
+	kex := make([]byte, 1216) // 32+1184 zeroed
+	entry := buildKeyShareEntry(0x11EC, kex)
+	payload := buildClientPayload(entry)
+
+	// Verify our constructed payload matches the expected structure.
+	// list_len = 4 (header) + 1216 (kex) = 1220 = 0x04C4
+	if len(payload) != 1222 { // 2 list-len + 4 entry-hdr + 1216 kex
+		t.Fatalf("payload length=%d, want 1222", len(payload))
+	}
+	wantHexPrefix := "04c4" + "11ec" + "04c0"
+	gotHex := hex.EncodeToString(payload[:6])
+	if gotHex != wantHexPrefix {
+		t.Errorf("payload[0:6] hex=%q, want %q", gotHex, wantHexPrefix)
+	}
+
+	infos, err := ParseKeyShareExtension(payload, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("got %d infos, want 1", len(infos))
+	}
+	info := infos[0]
+	if info.GroupID != 0x11EC {
+		t.Errorf("GroupID=0x%04x, want 0x11EC", info.GroupID)
+	}
+	if info.KeyExchangeLen != 1216 {
+		t.Errorf("KeyExchangeLen=%d, want 1216", info.KeyExchangeLen)
+	}
+	if info.Primitive != "hybrid-kem" {
+		t.Errorf("Primitive=%q, want hybrid-kem", info.Primitive)
+	}
+}
+
+// TestParseKeyShareExtension_MultiEntry_Client parses a ClientHello with two
+// entries: X25519 (32 B) and X25519MLKEM768 (1216 B), as a typical Go 1.25
+// ClientHello would advertise.
+func TestParseKeyShareExtension_MultiEntry_Client(t *testing.T) {
+	t.Parallel()
+	e1 := buildKeyShareEntry(0x001D, make([]byte, 32))   // X25519
+	e2 := buildKeyShareEntry(0x11EC, make([]byte, 1216)) // X25519MLKEM768
+	payload := buildClientPayload(e1, e2)
+
+	infos, err := ParseKeyShareExtension(payload, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(infos) != 2 {
+		t.Fatalf("got %d infos, want 2", len(infos))
+	}
+	if infos[0].GroupID != 0x001D || infos[0].Primitive != "classical" {
+		t.Errorf("entry[0]: got group=0x%04x prim=%q", infos[0].GroupID, infos[0].Primitive)
+	}
+	if infos[1].GroupID != 0x11EC || infos[1].Primitive != "hybrid-kem" {
+		t.Errorf("entry[1]: got group=0x%04x prim=%q", infos[1].GroupID, infos[1].Primitive)
+	}
+}
+
+// TestParseKeyShareExtension_Server_X25519 parses a ServerHello key_share
+// (no list-length prefix) with X25519.
+func TestParseKeyShareExtension_Server_X25519(t *testing.T) {
+	t.Parallel()
+	kex := make([]byte, 32)
+	entry := buildKeyShareEntry(0x001D, kex)
+
+	infos, err := ParseKeyShareExtension(entry, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("got %d infos, want 1", len(infos))
+	}
+	if infos[0].KeyExchangeLen != 32 {
+		t.Errorf("KeyExchangeLen=%d, want 32", infos[0].KeyExchangeLen)
+	}
+}
+
+// TestParseKeyShareExtension_MLKEM768_PureServer parses a ServerHello
+// key_share for MLKEM768 (ciphertext: 1088 B).
+func TestParseKeyShareExtension_MLKEM768_PureServer(t *testing.T) {
+	t.Parallel()
+	kex := make([]byte, 1088)
+	entry := buildKeyShareEntry(0x0201, kex)
+
+	infos, err := ParseKeyShareExtension(entry, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("got %d infos, want 1", len(infos))
+	}
+	if infos[0].Primitive != "pure-pq" {
+		t.Errorf("Primitive=%q, want pure-pq", infos[0].Primitive)
+	}
+	if infos[0].KeyExchangeLen != 1088 {
+		t.Errorf("KeyExchangeLen=%d, want 1088", infos[0].KeyExchangeLen)
+	}
+}
+
+// ── Error cases ───────────────────────────────────────────────────────────────
+
+func TestParseKeyShareExtension_TruncatedPayload(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		data    []byte
+		isClient bool
+	}{
+		{"client_empty", []byte{}, true},
+		{"client_one_byte", []byte{0x00}, true},
+		{"client_list_len_exceeds_data", []byte{0x00, 0x10, 0x01, 0x02}, true},
+		{"server_truncated_header", []byte{0x00, 0x01, 0x00}, false},
+		// buildKeyShareEntry(X25519, 10B kex) = 14 bytes; slice to 13 so kex is 1 byte short.
+		{"server_kex_too_short", buildKeyShareEntry(0x001D, make([]byte, 10))[:13], false},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := ParseKeyShareExtension(tt.data, tt.isClient)
+			if err == nil {
+				t.Errorf("expected error for truncated input %q, got nil", tt.name)
+			}
+		})
+	}
+}
+
+func TestParseKeyShareExtension_EmptyClientList(t *testing.T) {
+	t.Parallel()
+	// Valid ClientHello with empty list: list_len=0.
+	payload := []byte{0x00, 0x00}
+	infos, err := ParseKeyShareExtension(payload, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(infos) != 0 {
+		t.Errorf("expected 0 infos for empty list, got %d", len(infos))
+	}
+}

--- a/pkg/engines/tlsprobe/probe.go
+++ b/pkg/engines/tlsprobe/probe.go
@@ -29,6 +29,17 @@ type ProbeResult struct {
 	VerifyError       string // non-empty if verification failed
 	Error             error  // non-nil means handshake failed entirely
 	Duration          time.Duration
+
+	// Size-based passive detection fields (Sprint 2, S2.1–S2.3).
+	IncomingSegments    int64  // approximate number of incoming TCP segments during handshake
+	OutgoingSegments    int64  // approximate number of outgoing TCP segments during handshake
+	BytesIn             int64  // total bytes received during handshake
+	BytesOut            int64  // total bytes sent during handshake
+	HandshakeVolumeClass string // "classical", "hybrid-kem", "full-pqc", or "unknown" (S2.3)
+
+	// ECH detection fields (Sprint 2, S2.4).
+	ECHDetected bool   // true when Encrypted Client Hello is detected
+	ECHSource   string // "dns-https-rr", "tls-ext", or "" when not detected
 }
 
 // ProbeOpts configures a single TLS probe.
@@ -81,6 +92,10 @@ func probe(ctx context.Context, target string, opts ProbeOpts) ProbeResult {
 		return result
 	}
 
+	// Wrap the raw connection in a countingConn to observe handshake byte volumes
+	// and segment counts. This is the S2.1 instrumentation layer.
+	counting := newCountingConn(rawConn)
+
 	// Capture certs via callback. Always use InsecureSkipVerify=true so the
 	// callback fires even for expired/self-signed certs (Round 3 critical finding).
 	var capturedCerts []*x509.Certificate
@@ -110,7 +125,7 @@ func probe(ctx context.Context, target string, opts ProbeOpts) ProbeResult {
 		tlsCfg.RootCAs = pool
 	}
 
-	tlsConn := tls.Client(rawConn, tlsCfg)
+	tlsConn := tls.Client(counting, tlsCfg)
 	defer tlsConn.Close()
 
 	if err := tlsConn.HandshakeContext(dialCtx); err != nil {
@@ -128,6 +143,18 @@ func probe(ctx context.Context, target string, opts ProbeOpts) ProbeResult {
 	// for TLS 1.2 sessions that used an RSA KEM (no ECDHE, no named group).
 	// tls.CurveID is a uint16 alias, so the conversion is always safe.
 	result.NegotiatedGroupID = uint16(state.CurveID)
+
+	// Populate S2.1 size-based observability fields from countingConn.
+	result.IncomingSegments = counting.ReadCalls()
+	result.OutgoingSegments = counting.WriteCalls()
+	result.BytesIn = counting.BytesIn()
+	result.BytesOut = counting.BytesOut()
+	result.HandshakeVolumeClass = ClassifyHandshakeVolume(result.BytesIn + result.BytesOut).String()
+
+	// Detect ECH (S2.4) after handshake data is available.
+	echDetected, echSource := detectECH(ctx, host)
+	result.ECHDetected = echDetected
+	result.ECHSource = echSource
 
 	// Extract leaf cert info.
 	if len(capturedCerts) > 0 {

--- a/pkg/engines/tlsprobe/probe.go
+++ b/pkg/engines/tlsprobe/probe.go
@@ -31,14 +31,17 @@ type ProbeResult struct {
 	Duration          time.Duration
 
 	// Size-based passive detection fields (Sprint 2, S2.1–S2.3).
+	// Diagnostic: surfaced in JSON output via /dashboard only; not consumed by classifier.
 	IncomingSegments    int64  // approximate number of incoming TCP segments during handshake
+	// Diagnostic: surfaced in JSON output via /dashboard only; not consumed by classifier.
 	OutgoingSegments    int64  // approximate number of outgoing TCP segments during handshake
-	BytesIn             int64  // total bytes received during handshake
-	BytesOut            int64  // total bytes sent during handshake
+	BytesIn             int64  // total bytes received during handshake (authoritative volume signal)
+	BytesOut            int64  // total bytes sent during handshake (authoritative volume signal)
 	HandshakeVolumeClass string // "classical", "hybrid-kem", "full-pqc", or "unknown" (S2.3)
 
 	// ECH detection fields (Sprint 2, S2.4).
 	ECHDetected bool   // true when Encrypted Client Hello is detected
+	// Diagnostic: surfaced in JSON output via /dashboard only; not consumed by classifier.
 	ECHSource   string // "dns-https-rr", "tls-ext", or "" when not detected
 }
 
@@ -152,7 +155,7 @@ func probe(ctx context.Context, target string, opts ProbeOpts) ProbeResult {
 	result.HandshakeVolumeClass = ClassifyHandshakeVolume(result.BytesIn + result.BytesOut).String()
 
 	// Detect ECH (S2.4) after handshake data is available.
-	echDetected, echSource := detectECH(ctx, host)
+	echDetected, echSource := detectECH(ctx, host, opts.Timeout)
 	result.ECHDetected = echDetected
 	result.ECHSource = echSource
 

--- a/pkg/engines/tlsprobe/probe.go
+++ b/pkg/engines/tlsprobe/probe.go
@@ -155,7 +155,8 @@ func probe(ctx context.Context, target string, opts ProbeOpts) ProbeResult {
 	result.HandshakeVolumeClass = ClassifyHandshakeVolume(result.BytesIn + result.BytesOut).String()
 
 	// Detect ECH (S2.4) after handshake data is available.
-	echDetected, echSource := detectECH(ctx, host, opts.Timeout)
+	// Pass DenyPrivate so that --tls-strict prevents DNS queries to private resolvers.
+	echDetected, echSource := detectECH(ctx, host, opts.Timeout, opts.DenyPrivate)
 	result.ECHDetected = echDetected
 	result.ECHSource = echSource
 

--- a/pkg/engines/tlsprobe/tcp_segments.go
+++ b/pkg/engines/tlsprobe/tcp_segments.go
@@ -1,0 +1,78 @@
+package tlsprobe
+
+import (
+	"net"
+	"sync/atomic"
+	"time"
+)
+
+// countingConn wraps a net.Conn and atomically tracks Read/Write call counts
+// and byte totals. Each Read() call is a practical proxy for one incoming TCP
+// segment on typical Linux/Darwin because Go's TLS record layer issues a 5-byte
+// header read followed by a full-record read; the OS delivers whatever the NIC
+// received, so a single Read() call generally corresponds to one segment boundary.
+// Pre-PQ ClientHellos (~220-380 B) always fit in one segment; hybrid PQ
+// ClientHellos (~1450 B) span ≥2 segments, producing ≥2 Read() calls on the
+// server side / ≥2 Write() calls on the client side.
+type countingConn struct {
+	net.Conn
+
+	readCalls  atomic.Int64
+	writeCalls atomic.Int64
+	bytesIn    atomic.Int64
+	bytesOut   atomic.Int64
+}
+
+// newCountingConn wraps c in a countingConn.
+func newCountingConn(c net.Conn) *countingConn {
+	return &countingConn{Conn: c}
+}
+
+// Read delegates to the underlying Conn and atomically accumulates byte counts
+// and call counts.
+func (cc *countingConn) Read(b []byte) (int, error) {
+	n, err := cc.Conn.Read(b)
+	if n > 0 {
+		cc.bytesIn.Add(int64(n))
+		cc.readCalls.Add(1)
+	}
+	return n, err
+}
+
+// Write delegates to the underlying Conn and atomically accumulates byte counts
+// and call counts.
+func (cc *countingConn) Write(b []byte) (int, error) {
+	n, err := cc.Conn.Write(b)
+	if n > 0 {
+		cc.bytesOut.Add(int64(n))
+		cc.writeCalls.Add(1)
+	}
+	return n, err
+}
+
+// SetDeadline delegates to the underlying Conn.
+func (cc *countingConn) SetDeadline(t time.Time) error {
+	return cc.Conn.SetDeadline(t)
+}
+
+// SetReadDeadline delegates to the underlying Conn.
+func (cc *countingConn) SetReadDeadline(t time.Time) error {
+	return cc.Conn.SetReadDeadline(t)
+}
+
+// SetWriteDeadline delegates to the underlying Conn.
+func (cc *countingConn) SetWriteDeadline(t time.Time) error {
+	return cc.Conn.SetWriteDeadline(t)
+}
+
+// ReadCalls returns the number of Read calls that transferred ≥1 byte.
+func (cc *countingConn) ReadCalls() int64 { return cc.readCalls.Load() }
+
+// WriteCalls returns the number of Write calls that transferred ≥1 byte.
+func (cc *countingConn) WriteCalls() int64 { return cc.writeCalls.Load() }
+
+// BytesIn returns the total bytes received.
+func (cc *countingConn) BytesIn() int64 { return cc.bytesIn.Load() }
+
+// BytesOut returns the total bytes sent.
+func (cc *countingConn) BytesOut() int64 { return cc.bytesOut.Load() }

--- a/pkg/engines/tlsprobe/tcp_segments.go
+++ b/pkg/engines/tlsprobe/tcp_segments.go
@@ -7,13 +7,16 @@ import (
 )
 
 // countingConn wraps a net.Conn and atomically tracks Read/Write call counts
-// and byte totals. Each Read() call is a practical proxy for one incoming TCP
-// segment on typical Linux/Darwin because Go's TLS record layer issues a 5-byte
-// header read followed by a full-record read; the OS delivers whatever the NIC
-// received, so a single Read() call generally corresponds to one segment boundary.
-// Pre-PQ ClientHellos (~220-380 B) always fit in one segment; hybrid PQ
-// ClientHellos (~1450 B) span ≥2 segments, producing ≥2 Read() calls on the
-// server side / ≥2 Write() calls on the client side.
+// and byte totals.
+//
+// Read() calls are a noisy proxy for TCP segment boundaries: crypto/tls issues
+// a 5-byte header read followed by a full-record-body read, so a single 1500-byte
+// segment typically yields 2 Read() calls rather than 1. As a result
+// IncomingSegments (= ReadCalls) and OutgoingSegments (= WriteCalls) are
+// diagnostic-only and must not be used for classification decisions.
+//
+// BytesIn and BytesOut are the authoritative volume signal: they count raw bytes
+// transferred regardless of how the TLS layer fragments records across syscalls.
 type countingConn struct {
 	net.Conn
 

--- a/pkg/engines/tlsprobe/tcp_segments_stress_test.go
+++ b/pkg/engines/tlsprobe/tcp_segments_stress_test.go
@@ -1,0 +1,251 @@
+package tlsprobe
+
+// tcp_segments_stress_test.go — Bucket 3: goroutine-parallel stress tests for
+// countingConn under the -race detector.
+//
+// Two scenarios:
+//  1. 1-second saturation: many goroutines read and write concurrently; counters
+//     must strictly increase (monotonically non-decreasing) and converge to the
+//     correct total.
+//  2. 8-goroutine exact-match: 8 goroutines each write 1 KB and read 1 KB via
+//     net.Pipe; final counters must equal the sum across all goroutines.
+
+import (
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestCountingConn_ParallelStress_MonotonicCounters runs concurrent Writes on
+// a countingConn for ~200ms and verifies that BytesOut never decreases between
+// successive snapshots taken by a monitor goroutine (monotonically non-decreasing).
+//
+// BytesIn is not exercised here because net.Pipe requires a symmetric
+// reader-on-the-other-end for every write; exercising bidirectional concurrent
+// I/O reliably is done in TestCountingConn_EightGoroutines_ExactMatch below.
+func TestCountingConn_ParallelStress_MonotonicCounters(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	cc := newCountingConn(clientConn)
+
+	const (
+		chunkSize    = 128
+		numWriters   = 4
+		testDuration = 200 * time.Millisecond
+	)
+
+	deadline := time.Now().Add(testDuration)
+	_ = cc.SetDeadline(deadline)
+	_ = serverConn.SetDeadline(deadline)
+
+	var (
+		wg         sync.WaitGroup
+		monitorErr atomic.Value // stores first string error message
+	)
+
+	// Monitor goroutine: samples BytesOut every 5ms and asserts monotonicity.
+	monitorDone := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(monitorDone)
+		var prevOut int64
+		for {
+			if time.Now().After(deadline) {
+				return
+			}
+			curOut := cc.BytesOut()
+			if curOut < prevOut {
+				monitorErr.Store("BytesOut decreased")
+			}
+			prevOut = curOut
+			time.Sleep(5 * time.Millisecond)
+		}
+	}()
+
+	// Drain goroutine: reads everything the writers send (required by net.Pipe).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, chunkSize*numWriters)
+		for {
+			serverConn.SetReadDeadline(deadline) //nolint:errcheck
+			_, err := serverConn.Read(buf)
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	// Writer goroutines: write via cc (client side) until deadline.
+	for i := 0; i < numWriters; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			buf := make([]byte, chunkSize)
+			for {
+				_, err := cc.Write(buf)
+				if err != nil || time.Now().After(deadline) {
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if msg := monitorErr.Load(); msg != nil {
+		t.Error(msg.(string))
+	}
+	if gotOut := cc.BytesOut(); gotOut <= 0 {
+		t.Errorf("BytesOut=%d after stress test, expected > 0", gotOut)
+	}
+}
+
+// TestCountingConn_EightGoroutines_ExactMatch spawns 8 goroutines each writing
+// exactly 1 KB through countingConn and reading exactly 1 KB back via net.Pipe.
+// The final BytesOut must equal 8*1024 and BytesIn must equal 8*1024.
+func TestCountingConn_EightGoroutines_ExactMatch(t *testing.T) {
+	t.Parallel()
+
+	const (
+		numGoroutines = 8
+		chunkSize     = 1024
+		totalBytes    = numGoroutines * chunkSize
+	)
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	cc := newCountingConn(clientConn)
+
+	// Server goroutine: drains numGoroutines*chunkSize bytes (client→server),
+	// then echoes them back (server→client).  This is sequential to avoid
+	// interleaving issues with the echo direction.
+	serverDone := make(chan error, 1)
+	go func() {
+		buf := make([]byte, totalBytes)
+		total := 0
+		for total < totalBytes {
+			n, err := serverConn.Read(buf[total:])
+			total += n
+			if err != nil {
+				serverDone <- err
+				return
+			}
+		}
+		// Echo back the same number of bytes to satisfy cc.Read calls.
+		written := 0
+		for written < totalBytes {
+			n, err := serverConn.Write(buf[written:])
+			written += n
+			if err != nil {
+				serverDone <- err
+				return
+			}
+		}
+		serverDone <- nil
+	}()
+
+	// 8 goroutines each write chunkSize bytes.
+	var wg sync.WaitGroup
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			payload := make([]byte, chunkSize)
+			remaining := chunkSize
+			for remaining > 0 {
+				n, err := cc.Write(payload[chunkSize-remaining:])
+				remaining -= n
+				if err != nil {
+					t.Errorf("Write error: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	// 8 goroutines each read chunkSize bytes (echoed back by server goroutine).
+	var wg2 sync.WaitGroup
+	for i := 0; i < numGoroutines; i++ {
+		wg2.Add(1)
+		go func() {
+			defer wg2.Done()
+			buf := make([]byte, chunkSize)
+			remaining := chunkSize
+			for remaining > 0 {
+				n, err := cc.Read(buf[chunkSize-remaining:])
+				remaining -= n
+				if err != nil {
+					t.Errorf("Read error: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg2.Wait()
+
+	if err := <-serverDone; err != nil {
+		t.Fatalf("server goroutine error: %v", err)
+	}
+
+	if got := cc.BytesOut(); got != int64(totalBytes) {
+		t.Errorf("BytesOut=%d, want %d", got, totalBytes)
+	}
+	if got := cc.BytesIn(); got != int64(totalBytes) {
+		t.Errorf("BytesIn=%d, want %d", got, totalBytes)
+	}
+}
+
+// TestCountingConn_WriteCalls_Atomic verifies that WriteCalls and ReadCalls
+// values are consistent under concurrent access (the race detector will flag
+// any non-atomic access).
+func TestCountingConn_WriteCalls_Atomic(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	cc := newCountingConn(clientConn)
+
+	const calls = 50
+	var wg sync.WaitGroup
+
+	// Sink goroutine to drain server side.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, 1)
+		for i := 0; i < calls; i++ {
+			_, _ = serverConn.Read(buf)
+		}
+	}()
+
+	// Concurrent writers.
+	for i := 0; i < calls; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = cc.Write([]byte{0x42})
+		}()
+	}
+
+	wg.Wait()
+
+	if got := cc.WriteCalls(); got != int64(calls) {
+		t.Errorf("WriteCalls=%d, want %d", got, calls)
+	}
+	if got := cc.BytesOut(); got != int64(calls) {
+		t.Errorf("BytesOut=%d, want %d (1 byte per call)", got, calls)
+	}
+}

--- a/pkg/engines/tlsprobe/tcp_segments_test.go
+++ b/pkg/engines/tlsprobe/tcp_segments_test.go
@@ -1,0 +1,156 @@
+package tlsprobe
+
+import (
+	"bytes"
+	"net"
+	"testing"
+	"time"
+)
+
+// pipeConn adapts a net.Pipe end to satisfy net.Conn deadlines (net.Pipe already
+// does, but we use it here explicitly to keep tests self-contained).
+type pipeConn = net.Conn
+
+func TestCountingConn_ReadWriteCounts(t *testing.T) {
+	t.Parallel()
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	cc := newCountingConn(client)
+
+	// Write 10 bytes through the counting side.
+	payload := []byte("0123456789")
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, len(payload))
+		_, _ = server.Read(buf)
+	}()
+
+	n, err := cc.Write(payload)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if n != len(payload) {
+		t.Errorf("Write returned n=%d, want %d", n, len(payload))
+	}
+	<-done
+
+	if got := cc.WriteCalls(); got != 1 {
+		t.Errorf("WriteCalls=%d, want 1", got)
+	}
+	if got := cc.BytesOut(); got != int64(len(payload)) {
+		t.Errorf("BytesOut=%d, want %d", got, len(payload))
+	}
+
+	// Send data from server → client and read via counting conn.
+	send := []byte("hello")
+	go func() {
+		_, _ = server.Write(send)
+	}()
+	buf := make([]byte, len(send))
+	n, err = cc.Read(buf)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !bytes.Equal(buf[:n], send) {
+		t.Errorf("Read got %q, want %q", buf[:n], send)
+	}
+
+	if got := cc.ReadCalls(); got != 1 {
+		t.Errorf("ReadCalls=%d, want 1", got)
+	}
+	if got := cc.BytesIn(); got != int64(len(send)) {
+		t.Errorf("BytesIn=%d, want %d", got, len(send))
+	}
+}
+
+func TestCountingConn_MultipleWrites(t *testing.T) {
+	t.Parallel()
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	cc := newCountingConn(client)
+
+	chunks := [][]byte{
+		[]byte("abc"),
+		[]byte("de"),
+		[]byte("fghij"),
+	}
+	totalBytes := 0
+	for _, c := range chunks {
+		totalBytes += len(c)
+	}
+
+	go func() {
+		buf := make([]byte, totalBytes)
+		remaining := totalBytes
+		for remaining > 0 {
+			n, _ := server.Read(buf)
+			remaining -= n
+		}
+	}()
+
+	for _, c := range chunks {
+		if _, err := cc.Write(c); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+
+	if got := cc.WriteCalls(); got != int64(len(chunks)) {
+		t.Errorf("WriteCalls=%d, want %d", got, len(chunks))
+	}
+	if got := cc.BytesOut(); got != int64(totalBytes) {
+		t.Errorf("BytesOut=%d, want %d", got, totalBytes)
+	}
+}
+
+func TestCountingConn_ZeroCountWhenNoTraffic(t *testing.T) {
+	t.Parallel()
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	_ = server // suppress unused warning
+
+	cc := newCountingConn(client)
+	if got := cc.ReadCalls(); got != 0 {
+		t.Errorf("ReadCalls=%d before any read, want 0", got)
+	}
+	if got := cc.WriteCalls(); got != 0 {
+		t.Errorf("WriteCalls=%d before any write, want 0", got)
+	}
+	if got := cc.BytesIn(); got != 0 {
+		t.Errorf("BytesIn=%d before any read, want 0", got)
+	}
+	if got := cc.BytesOut(); got != 0 {
+		t.Errorf("BytesOut=%d before any write, want 0", got)
+	}
+}
+
+func TestCountingConn_SetDeadlines(t *testing.T) {
+	t.Parallel()
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	_ = server
+
+	cc := newCountingConn(client)
+	// These must not panic or error on a fresh pipe.
+	if err := cc.SetDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Errorf("SetDeadline: %v", err)
+	}
+	if err := cc.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Errorf("SetReadDeadline: %v", err)
+	}
+	if err := cc.SetWriteDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Errorf("SetWriteDeadline: %v", err)
+	}
+}
+
+func TestCountingConn_ImplementsNetConn(t *testing.T) {
+	t.Parallel()
+	// Compile-time check that *countingConn satisfies net.Conn.
+	var _ net.Conn = (*countingConn)(nil)
+}

--- a/pkg/engines/tlsprobe/volume.go
+++ b/pkg/engines/tlsprobe/volume.go
@@ -1,0 +1,74 @@
+package tlsprobe
+
+// HandshakeVolumeClass is a three-tier classifier for the total byte volume of
+// a TLS handshake. It is a corroborating signal used when the CurveID-based
+// classification is unavailable (e.g., TLS 1.2 with no named group, or an
+// unknown codepoint). When CurveID is known and classifies successfully, volume
+// is reported as metadata only — it does NOT override the deterministic signal.
+//
+// Thresholds are derived from:
+//   - Sikeridis et al., NDSS 2020
+//   - Westerbaan et al., PQCrypto 2025
+//   - Kwiatkowski/Valenta, Cloudflare PQ Experiment (practical measurements)
+type HandshakeVolumeClass int
+
+const (
+	// VolumeClassical covers handshakes < 7 KB. All classical TLS 1.3
+	// handshakes (X25519, secp256r1, etc.) fall well within this range.
+	VolumeClassical HandshakeVolumeClass = iota
+
+	// VolumeHybridKEM covers handshakes in [7 KB, 12 KB]. The additional ~1.2 KB
+	// from ML-KEM-768's key material pushes X25519MLKEM768 handshakes into this
+	// band compared to a classical baseline.
+	VolumeHybridKEM
+
+	// VolumeUnknown is the transitional gap [12 KB, 20 KB] that does not map
+	// cleanly to either hybrid or full-PQC. Do not misclassify — report as unknown.
+	VolumeUnknown
+
+	// VolumeFullPQC covers handshakes > 20 KB. Pure ML-KEM with ML-DSA
+	// certificates pushes handshakes into this range.
+	VolumeFullPQC
+)
+
+// thresholdHybridMin is the lower bound (inclusive) of the hybrid-KEM band.
+const thresholdHybridMin int64 = 7_000
+
+// thresholdHybridMax is the upper bound (exclusive) of the hybrid-KEM band.
+const thresholdHybridMax int64 = 12_000
+
+// thresholdFullPQC is the lower bound (exclusive) for full-PQC classification.
+const thresholdFullPQC int64 = 20_000
+
+// ClassifyHandshakeVolume maps the total bytes transferred during a TLS
+// handshake (BytesIn + BytesOut from countingConn) to a HandshakeVolumeClass.
+// The thresholds represent conservative estimates; the CurveID signal always
+// takes precedence when available.
+func ClassifyHandshakeVolume(totalBytes int64) HandshakeVolumeClass {
+	switch {
+	case totalBytes < thresholdHybridMin:
+		return VolumeClassical
+	case totalBytes < thresholdHybridMax:
+		return VolumeHybridKEM
+	case totalBytes > thresholdFullPQC:
+		return VolumeFullPQC
+	default:
+		// 12 000 ≤ totalBytes ≤ 20 000: transitional gap.
+		return VolumeUnknown
+	}
+}
+
+// String returns the canonical string representation used in ProbeResult and
+// output formats.
+func (c HandshakeVolumeClass) String() string {
+	switch c {
+	case VolumeClassical:
+		return "classical"
+	case VolumeHybridKEM:
+		return "hybrid-kem"
+	case VolumeFullPQC:
+		return "full-pqc"
+	default:
+		return "unknown"
+	}
+}

--- a/pkg/engines/tlsprobe/volume_boundary_test.go
+++ b/pkg/engines/tlsprobe/volume_boundary_test.go
@@ -1,0 +1,139 @@
+package tlsprobe
+
+// volume_boundary_test.go — Bucket 4: boundary and edge-case tests for
+// ClassifyHandshakeVolume.
+//
+// Focuses on:
+//   - Exact threshold boundaries (6999/7000/7001, 11999/12000/12001,
+//     19999/20000/20001) — each boundary is tested with the value just below,
+//     at, and just above to catch inclusive/exclusive confusion.
+//   - Negative input (-1) must not panic and is expected to return VolumeClassical
+//     (negative < 7000 → VolumeClassical per the < thresholdHybridMin branch).
+//   - VolumeUnknown.String() must return "unknown" (not empty string, not "Unknown").
+
+import "testing"
+
+// TestClassifyHandshakeVolume_ExactBoundaries exercises all threshold values
+// with {value-1, value, value+1} to pin the inclusive/exclusive semantics.
+func TestClassifyHandshakeVolume_ExactBoundaries(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		bytes      int64
+		wantClass  HandshakeVolumeClass
+		wantString string
+	}{
+		// ── Hybrid lower boundary: 7000 (inclusive) ──────────────────────────────
+		// totalBytes < 7000 → VolumeClassical
+		{"hybrid_lower_minus1 (6999)", 6999, VolumeClassical, "classical"},
+		// totalBytes == 7000 → VolumeHybridKEM (first value in [7000, 12000))
+		{"hybrid_lower_at (7000)", 7000, VolumeHybridKEM, "hybrid-kem"},
+		// totalBytes == 7001 → VolumeHybridKEM
+		{"hybrid_lower_plus1 (7001)", 7001, VolumeHybridKEM, "hybrid-kem"},
+
+		// ── Hybrid upper boundary: 12000 (exclusive of HybridKEM, inclusive of Unknown) ─
+		// totalBytes == 11999 → VolumeHybridKEM (still < 12000)
+		{"hybrid_upper_minus1 (11999)", 11999, VolumeHybridKEM, "hybrid-kem"},
+		// totalBytes == 12000 → VolumeUnknown (12000 ≤ bytes ≤ 20000: default branch)
+		{"hybrid_upper_at (12000)", 12000, VolumeUnknown, "unknown"},
+		// totalBytes == 12001 → VolumeUnknown
+		{"hybrid_upper_plus1 (12001)", 12001, VolumeUnknown, "unknown"},
+
+		// ── FullPQC lower boundary: 20000 (exclusive of FullPQC, inclusive of Unknown) ─
+		// totalBytes == 19999 → VolumeUnknown
+		{"fullpqc_lower_minus1 (19999)", 19999, VolumeUnknown, "unknown"},
+		// totalBytes == 20000 → VolumeUnknown (> 20000 is required for FullPQC)
+		{"fullpqc_lower_at (20000)", 20000, VolumeUnknown, "unknown"},
+		// totalBytes == 20001 → VolumeFullPQC (strictly > 20000)
+		{"fullpqc_lower_plus1 (20001)", 20001, VolumeFullPQC, "full-pqc"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ClassifyHandshakeVolume(tt.bytes)
+			if got != tt.wantClass {
+				t.Errorf("ClassifyHandshakeVolume(%d) = %v (%q), want %v (%q)",
+					tt.bytes, got, got.String(), tt.wantClass, tt.wantString)
+			}
+			if got.String() != tt.wantString {
+				t.Errorf("ClassifyHandshakeVolume(%d).String() = %q, want %q",
+					tt.bytes, got.String(), tt.wantString)
+			}
+		})
+	}
+}
+
+// TestClassifyHandshakeVolume_NegativeNoPanic verifies that a negative input
+// does not panic and returns VolumeClassical (negative < 7000).
+func TestClassifyHandshakeVolume_NegativeNoPanic(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ClassifyHandshakeVolume(-1) panicked: %v", r)
+		}
+	}()
+	got := ClassifyHandshakeVolume(-1)
+	if got != VolumeClassical {
+		t.Errorf("ClassifyHandshakeVolume(-1) = %v, want VolumeClassical", got)
+	}
+}
+
+// TestVolumeUnknown_StringNotEmpty verifies that VolumeUnknown.String() returns
+// "unknown" and not an empty string.  An empty String() would silently drop the
+// transitional-gap signal from JSON / SARIF output.
+func TestVolumeUnknown_StringNotEmpty(t *testing.T) {
+	t.Parallel()
+	got := VolumeUnknown.String()
+	if got == "" {
+		t.Error("VolumeUnknown.String() returned empty string; expected \"unknown\"")
+	}
+	if got != "unknown" {
+		t.Errorf("VolumeUnknown.String() = %q, want \"unknown\"", got)
+	}
+}
+
+// TestHandshakeVolumeClass_SentinelStrings verifies String() for all four named
+// constants plus an out-of-range sentinel value.
+func TestHandshakeVolumeClass_SentinelStrings(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		class HandshakeVolumeClass
+		want  string
+	}{
+		{VolumeClassical, "classical"},
+		{VolumeHybridKEM, "hybrid-kem"},
+		{VolumeUnknown, "unknown"},
+		{VolumeFullPQC, "full-pqc"},
+		// Out-of-range sentinel: must return "unknown" (the default branch).
+		{HandshakeVolumeClass(42), "unknown"},
+		{HandshakeVolumeClass(-5), "unknown"},
+	}
+	for _, c := range cases {
+		if got := c.class.String(); got != c.want {
+			t.Errorf("HandshakeVolumeClass(%d).String() = %q, want %q", int(c.class), got, c.want)
+		}
+	}
+}
+
+// TestClassifyHandshakeVolume_ZeroIsClassical verifies that 0 bytes (possible
+// from a failed probe) maps to VolumeClassical without panic.
+func TestClassifyHandshakeVolume_ZeroIsClassical(t *testing.T) {
+	t.Parallel()
+	got := ClassifyHandshakeVolume(0)
+	if got != VolumeClassical {
+		t.Errorf("ClassifyHandshakeVolume(0) = %v, want VolumeClassical", got)
+	}
+}
+
+// TestClassifyHandshakeVolume_MaxInt64 verifies that a very large input value
+// (int64 max) does not panic and returns VolumeFullPQC.
+func TestClassifyHandshakeVolume_MaxInt64(t *testing.T) {
+	t.Parallel()
+	const maxInt64 = int64(^uint64(0) >> 1)
+	got := ClassifyHandshakeVolume(maxInt64)
+	if got != VolumeFullPQC {
+		t.Errorf("ClassifyHandshakeVolume(MaxInt64) = %v, want VolumeFullPQC", got)
+	}
+}

--- a/pkg/engines/tlsprobe/volume_test.go
+++ b/pkg/engines/tlsprobe/volume_test.go
@@ -1,0 +1,81 @@
+package tlsprobe
+
+import (
+	"testing"
+)
+
+func TestClassifyHandshakeVolume(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		totalBytes int64
+		wantClass  HandshakeVolumeClass
+		wantStr    string
+	}{
+		// VolumeClassical: < 7000
+		{"zero", 0, VolumeClassical, "classical"},
+		{"small classical", 1000, VolumeClassical, "classical"},
+		{"x25519 typical", 3500, VolumeClassical, "classical"},
+		{"just below hybrid min", 6999, VolumeClassical, "classical"},
+
+		// VolumeHybridKEM: 7000..11999
+		{"at hybrid min", 7000, VolumeHybridKEM, "hybrid-kem"},
+		{"x25519mlkem768 typical", 9000, VolumeHybridKEM, "hybrid-kem"},
+		{"just below hybrid max", 11999, VolumeHybridKEM, "hybrid-kem"},
+
+		// VolumeUnknown: 12000..20000
+		{"at hybrid max", 12000, VolumeUnknown, "unknown"},
+		{"gap midpoint", 16000, VolumeUnknown, "unknown"},
+		{"at full pqc threshold", 20000, VolumeUnknown, "unknown"},
+
+		// VolumeFullPQC: > 20000
+		{"just above full pqc", 20001, VolumeFullPQC, "full-pqc"},
+		{"full pqc typical", 45000, VolumeFullPQC, "full-pqc"},
+		{"very large", 200000, VolumeFullPQC, "full-pqc"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ClassifyHandshakeVolume(tt.totalBytes)
+			if got != tt.wantClass {
+				t.Errorf("ClassifyHandshakeVolume(%d) = %v, want %v", tt.totalBytes, got, tt.wantClass)
+			}
+			if got.String() != tt.wantStr {
+				t.Errorf("HandshakeVolumeClass.String() for %d = %q, want %q", tt.totalBytes, got.String(), tt.wantStr)
+			}
+		})
+	}
+}
+
+func TestHandshakeVolumeClass_String_AllValues(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		class HandshakeVolumeClass
+		want  string
+	}{
+		{VolumeClassical, "classical"},
+		{VolumeHybridKEM, "hybrid-kem"},
+		{VolumeUnknown, "unknown"},
+		{VolumeFullPQC, "full-pqc"},
+		// Sentinel for unknown enum value (HandshakeVolumeClass is int).
+		{HandshakeVolumeClass(99), "unknown"},
+	}
+	for _, c := range cases {
+		if got := c.class.String(); got != c.want {
+			t.Errorf("HandshakeVolumeClass(%d).String() = %q, want %q", c.class, got, c.want)
+		}
+	}
+}
+
+// TestClassifyHandshakeVolume_NegativeSafe verifies that a negative totalBytes
+// (which should never occur from countingConn but could from a test stub) is
+// treated as classical without panicking.
+func TestClassifyHandshakeVolume_NegativeSafe(t *testing.T) {
+	t.Parallel()
+	got := ClassifyHandshakeVolume(-1)
+	if got != VolumeClassical {
+		t.Errorf("ClassifyHandshakeVolume(-1) = %v, want VolumeClassical", got)
+	}
+}

--- a/pkg/findings/unified.go
+++ b/pkg/findings/unified.go
@@ -110,6 +110,13 @@ type UnifiedFinding struct {
 	NegotiatedGroupName string `json:"negotiatedGroupName,omitempty"` // human-readable name, e.g. "X25519MLKEM768"
 	PQCPresent          bool   `json:"pqcPresent,omitempty"`          // true when an ML-KEM-based group was negotiated
 	PQCMaturity         string `json:"pqcMaturity,omitempty"`         // "final", "draft", or "" (classical/unknown)
+
+	// Partial-inventory annotation fields (populated by tls-probe ECH detection, Sprint 2).
+	// When PartialInventory is true the finding is incomplete because some crypto
+	// signals are hidden by ECH. Downstream steps (e.g., CT log lookup in Sprint 3)
+	// should treat these findings as requiring further enrichment.
+	PartialInventory       bool   `json:"partialInventory,omitempty"`       // true when inventory is known to be incomplete
+	PartialInventoryReason string `json:"partialInventoryReason,omitempty"` // "ECH_ENABLED" or ""
 }
 
 // MigrationSnippet holds a language-specific PQC migration code example.

--- a/pkg/findings/unified.go
+++ b/pkg/findings/unified.go
@@ -117,6 +117,13 @@ type UnifiedFinding struct {
 	// should treat these findings as requiring further enrichment.
 	PartialInventory       bool   `json:"partialInventory,omitempty"`       // true when inventory is known to be incomplete
 	PartialInventoryReason string `json:"partialInventoryReason,omitempty"` // "ECH_ENABLED" or ""
+
+	// Handshake volume fields (populated by tls-probe size-based detection, Sprint 2).
+	// HandshakeVolumeClass is the classifier output: "classical", "hybrid-kem",
+	// "full-pqc", or "unknown". HandshakeBytes is the sum of BytesIn+BytesOut for
+	// the TLS handshake exchange.
+	HandshakeVolumeClass string `json:"handshakeVolumeClass,omitempty"` // "classical", "hybrid-kem", "full-pqc", "unknown"
+	HandshakeBytes       int64  `json:"handshakeBytes,omitempty"`       // total handshake bytes (in+out)
 }
 
 // MigrationSnippet holds a language-specific PQC migration code example.

--- a/pkg/output/cbom.go
+++ b/pkg/output/cbom.go
@@ -346,6 +346,12 @@ func buildAlgorithmComponent(f findings.UnifiedFinding, occurrences []cdxOccurre
 	if f.PQCMaturity != "" {
 		props = append(props, cdxProperty{Name: "oqs:pqcMaturity", Value: f.PQCMaturity})
 	}
+	if f.PartialInventory {
+		props = append(props, cdxProperty{Name: "oqs:partialInventory", Value: "true"})
+		if f.PartialInventoryReason != "" {
+			props = append(props, cdxProperty{Name: "oqs:partialInventoryReason", Value: f.PartialInventoryReason})
+		}
+	}
 
 	if len(f.DataFlowPath) > 0 {
 		dfpJSON, err := json.Marshal(f.DataFlowPath)

--- a/pkg/output/cbom.go
+++ b/pkg/output/cbom.go
@@ -338,7 +338,7 @@ func buildAlgorithmComponent(f findings.UnifiedFinding, occurrences []cdxOccurre
 		props = append(props, cdxProperty{Name: "oqs:sourceType", Value: "tls-endpoint"})
 	}
 	if f.NegotiatedGroupName != "" {
-		props = append(props, cdxProperty{Name: "oqs:negotiatedGroup", Value: f.NegotiatedGroupName})
+		props = append(props, cdxProperty{Name: "oqs:negotiatedGroupName", Value: f.NegotiatedGroupName})
 	}
 	if f.PQCPresent {
 		props = append(props, cdxProperty{Name: "oqs:pqcPresent", Value: "true"})

--- a/pkg/output/cbom.go
+++ b/pkg/output/cbom.go
@@ -352,6 +352,12 @@ func buildAlgorithmComponent(f findings.UnifiedFinding, occurrences []cdxOccurre
 			props = append(props, cdxProperty{Name: "oqs:partialInventoryReason", Value: f.PartialInventoryReason})
 		}
 	}
+	if f.HandshakeVolumeClass != "" {
+		props = append(props, cdxProperty{Name: "oqs:handshakeVolumeClass", Value: f.HandshakeVolumeClass})
+	}
+	if f.HandshakeBytes > 0 {
+		props = append(props, cdxProperty{Name: "oqs:handshakeBytes", Value: fmt.Sprintf("%d", f.HandshakeBytes)})
+	}
 
 	if len(f.DataFlowPath) > 0 {
 		dfpJSON, err := json.Marshal(f.DataFlowPath)

--- a/pkg/output/partial_inventory_format_test.go
+++ b/pkg/output/partial_inventory_format_test.go
@@ -1,0 +1,283 @@
+package output
+
+// partial_inventory_format_test.go — Bucket 6: PartialInventory surfacing across
+// all three formats (JSON / SARIF / CBOM) plus backcompat unmarshalling.
+//
+// Focus: tests NOT already covered by pqc_fields_format_test.go.
+// That file has the basic present/absent checks; this file adds:
+//   - omitempty semantics verified via a zero-value UnifiedFinding (no fields set).
+//   - backcompat: unmarshal a Sprint-1-era JSON (no partialInventory keys) and
+//     verify the round-trip marshal equals the input (no spurious additions).
+//   - Multi-finding mixed scan: only ECH finding carries the annotation;
+//     classical finding is clean.
+//   - CBOM: PartialInventory with empty Reason string is handled gracefully
+//     (oqs:partialInventory=true present, oqs:partialInventoryReason absent).
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/findings"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func zeroValueFinding() findings.UnifiedFinding {
+	return findings.UnifiedFinding{
+		Location:     findings.Location{File: "dummy.go", Line: 1},
+		Algorithm:    &findings.Algorithm{Name: "AES", Primitive: "symmetric", KeySize: 256, Mode: "GCM"},
+		SourceEngine: "semgrep",
+		Confidence:   findings.ConfidenceHigh,
+		Reachable:    findings.ReachableYes,
+		// PartialInventory and PartialInventoryReason are zero-valued (false / "").
+	}
+}
+
+func echAnnotatedFinding() findings.UnifiedFinding {
+	return findings.UnifiedFinding{
+		Location:               findings.Location{File: "(tls-probe)/ech.host:443#kex"},
+		Algorithm:              &findings.Algorithm{Name: "ECDHE", Primitive: "key-exchange"},
+		SourceEngine:           "tls-probe",
+		Confidence:             findings.ConfidenceMedium,
+		Reachable:              findings.ReachableYes,
+		PartialInventory:       true,
+		PartialInventoryReason: "ECH_ENABLED",
+	}
+}
+
+func echNoReasonFinding() findings.UnifiedFinding {
+	return findings.UnifiedFinding{
+		Location:         findings.Location{File: "(tls-probe)/ech.host:443#kex"},
+		Algorithm:        &findings.Algorithm{Name: "ECDHE", Primitive: "key-exchange"},
+		SourceEngine:     "tls-probe",
+		Confidence:       findings.ConfidenceMedium,
+		Reachable:        findings.ReachableYes,
+		PartialInventory: true,
+		// PartialInventoryReason deliberately left empty.
+	}
+}
+
+func makeResult(ff []findings.UnifiedFinding) ScanResult {
+	return ScanResult{
+		Version:  "0.0.0-test",
+		Target:   "/test",
+		Engines:  []string{"tls-probe"},
+		Findings: ff,
+	}
+}
+
+// ── JSON omitempty ─────────────────────────────────────────────────────────────
+
+// TestPartialInventory_JSON_ZeroValue verifies that a completely zero-valued
+// finding (not just RSA, but literally no fields set for PartialInventory)
+// omits both fields.
+func TestPartialInventory_JSON_ZeroValue(t *testing.T) {
+	t.Parallel()
+	result := makeResult([]findings.UnifiedFinding{zeroValueFinding()})
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, result); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	var raw struct {
+		Findings []map[string]json.RawMessage `json:"findings"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(raw.Findings) == 0 {
+		t.Fatal("expected at least one finding in output")
+	}
+	f := raw.Findings[0]
+	for _, key := range []string{"partialInventory", "partialInventoryReason"} {
+		if _, present := f[key]; present {
+			t.Errorf("JSON zero-value: field %q must be omitted (omitempty), but was present", key)
+		}
+	}
+}
+
+// TestPartialInventory_JSON_TrueNoReason verifies that when PartialInventory=true
+// but PartialInventoryReason="" the JSON contains partialInventory but omits
+// partialInventoryReason (omitempty on reason).
+func TestPartialInventory_JSON_TrueNoReason(t *testing.T) {
+	t.Parallel()
+	result := makeResult([]findings.UnifiedFinding{echNoReasonFinding()})
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, result); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	var raw struct {
+		Findings []map[string]json.RawMessage `json:"findings"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	f := raw.Findings[0]
+	if _, present := f["partialInventory"]; !present {
+		t.Error("partialInventory=true must be present in JSON")
+	}
+	if _, present := f["partialInventoryReason"]; present {
+		t.Error("partialInventoryReason=\"\" must be omitted (omitempty)")
+	}
+}
+
+// ── Backcompat: pre-Sprint-2 JSON round-trip ──────────────────────────────────
+
+// TestPartialInventory_Backcompat_Sprint1JSON unmarshals a synthetic Sprint 1
+// JSON (no partialInventory or partialInventoryReason keys) into a
+// UnifiedFinding and verifies the fields remain zero-valued, then re-marshals
+// and asserts the output does NOT contain those keys.
+func TestPartialInventory_Backcompat_Sprint1JSON(t *testing.T) {
+	t.Parallel()
+	// Minimal Sprint-1-era finding JSON without PartialInventory fields.
+	sprint1JSON := `{
+		"location": {"file":"(tls-probe)/old.host:443#kex","line":0},
+		"algorithm": {"name":"ECDHE","primitive":"key-exchange"},
+		"confidence": "high",
+		"sourceEngine": "tls-probe",
+		"reachable": "yes",
+		"negotiatedGroup": 4588,
+		"negotiatedGroupName": "X25519MLKEM768",
+		"pqcPresent": true,
+		"pqcMaturity": "final"
+	}`
+
+	var f findings.UnifiedFinding
+	if err := json.Unmarshal([]byte(sprint1JSON), &f); err != nil {
+		t.Fatalf("unmarshal Sprint-1 JSON: %v", err)
+	}
+
+	// PartialInventory fields must be zero-valued.
+	if f.PartialInventory {
+		t.Error("PartialInventory should be false after unmarshalling Sprint-1 JSON")
+	}
+	if f.PartialInventoryReason != "" {
+		t.Errorf("PartialInventoryReason should be empty, got %q", f.PartialInventoryReason)
+	}
+
+	// Re-marshal and verify the output does not contain partialInventory keys.
+	out, err := json.Marshal(f)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	outStr := string(out)
+	if strings.Contains(outStr, "partialInventory") {
+		t.Errorf("re-marshaled Sprint-1 finding must not contain partialInventory, got: %s", outStr)
+	}
+}
+
+// ── Multi-finding mixed scan ───────────────────────────────────────────────────
+
+// TestPartialInventory_JSON_MixedFindings verifies that in a scan result with
+// one classical finding and one ECH finding, only the ECH finding carries the
+// annotation.
+func TestPartialInventory_JSON_MixedFindings(t *testing.T) {
+	t.Parallel()
+	result := makeResult([]findings.UnifiedFinding{
+		zeroValueFinding(),
+		echAnnotatedFinding(),
+	})
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, result); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	var raw struct {
+		Findings []map[string]json.RawMessage `json:"findings"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(raw.Findings) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(raw.Findings))
+	}
+
+	// First finding (classical): must have no partialInventory.
+	f0 := raw.Findings[0]
+	if _, ok := f0["partialInventory"]; ok {
+		t.Error("classical finding must not have partialInventory")
+	}
+
+	// Second finding (ECH): must have partialInventory=true and reason.
+	f1 := raw.Findings[1]
+	if _, ok := f1["partialInventory"]; !ok {
+		t.Error("ECH finding must have partialInventory")
+	}
+	if _, ok := f1["partialInventoryReason"]; !ok {
+		t.Error("ECH finding must have partialInventoryReason")
+	}
+}
+
+// ── CBOM: PartialInventory=true with empty Reason ─────────────────────────────
+
+// TestPartialInventory_CBOM_TrueNoReason verifies that when PartialInventory=true
+// but PartialInventoryReason="" the CBOM includes oqs:partialInventory but
+// omits oqs:partialInventoryReason.
+func TestPartialInventory_CBOM_TrueNoReason(t *testing.T) {
+	t.Parallel()
+	result := makeResult([]findings.UnifiedFinding{echNoReasonFinding()})
+	var buf bytes.Buffer
+	if err := WriteCBOM(&buf, result); err != nil {
+		t.Fatalf("WriteCBOM: %v", err)
+	}
+	var bom struct {
+		Components []struct {
+			Properties []struct {
+				Name  string `json:"name"`
+				Value string `json:"value"`
+			} `json:"properties"`
+		} `json:"components"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &bom); err != nil {
+		t.Fatalf("unmarshal CBOM: %v", err)
+	}
+	if len(bom.Components) == 0 {
+		t.Fatal("expected at least one CBOM component")
+	}
+
+	findProp := func(name string) (string, bool) {
+		for _, p := range bom.Components[0].Properties {
+			if p.Name == name {
+				return p.Value, true
+			}
+		}
+		return "", false
+	}
+
+	if v, ok := findProp("oqs:partialInventory"); !ok || v != "true" {
+		t.Errorf("oqs:partialInventory: got %q ok=%v, want \"true\" present", v, ok)
+	}
+	if _, ok := findProp("oqs:partialInventoryReason"); ok {
+		t.Error("oqs:partialInventoryReason must be absent when Reason is empty")
+	}
+}
+
+// ── SARIF: zero-value finding has no partialInventory property ────────────────
+
+// TestPartialInventory_SARIF_ZeroValue verifies that a zero-value finding
+// produces no partialInventory key in SARIF result.properties.
+func TestPartialInventory_SARIF_ZeroValue(t *testing.T) {
+	t.Parallel()
+	result := makeResult([]findings.UnifiedFinding{zeroValueFinding()})
+	var buf bytes.Buffer
+	if err := WriteSARIF(&buf, result); err != nil {
+		t.Fatalf("WriteSARIF: %v", err)
+	}
+	var sarifDoc struct {
+		Runs []struct {
+			Results []struct {
+				Properties map[string]json.RawMessage `json:"properties"`
+			} `json:"results"`
+		} `json:"runs"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &sarifDoc); err != nil {
+		t.Fatalf("unmarshal SARIF: %v", err)
+	}
+	if len(sarifDoc.Runs[0].Results) == 0 {
+		t.Fatal("expected at least one SARIF result")
+	}
+	props := sarifDoc.Runs[0].Results[0].Properties
+	if _, ok := props["partialInventory"]; ok {
+		t.Error("SARIF zero-value finding must not carry partialInventory property")
+	}
+}

--- a/pkg/output/pqc_fields_format_test.go
+++ b/pkg/output/pqc_fields_format_test.go
@@ -534,6 +534,174 @@ func TestPartialInventory_CBOM_Properties(t *testing.T) {
 	}
 }
 
+// ── HandshakeVolumeClass / HandshakeBytes surfacing ──────────────────────────
+
+// volumeFinding returns a finding with HandshakeVolumeClass and HandshakeBytes set,
+// simulating a TLS probe result that went through Sprint 2 size classification.
+func volumeFinding() findings.UnifiedFinding {
+	return findings.UnifiedFinding{
+		Location:             findings.Location{File: "(tls-probe)/hybrid.example.com:443#kex", ArtifactType: "tls-endpoint"},
+		Algorithm:            &findings.Algorithm{Name: "X25519MLKEM768", Primitive: "key-exchange"},
+		SourceEngine:         "tls-probe",
+		Confidence:           findings.ConfidenceHigh,
+		Reachable:            findings.ReachableYes,
+		QuantumRisk:          findings.QRSafe,
+		NegotiatedGroup:      0x11EC,
+		NegotiatedGroupName:  "X25519MLKEM768",
+		PQCPresent:           true,
+		PQCMaturity:          "final",
+		HandshakeVolumeClass: "hybrid-kem",
+		HandshakeBytes:       8192,
+	}
+}
+
+// TestHandshakeVolume_JSON_RoundTrip verifies that HandshakeVolumeClass and
+// HandshakeBytes survive a JSON marshal/unmarshal cycle.
+func TestHandshakeVolume_JSON_RoundTrip(t *testing.T) {
+	result := makePQCTestResult([]findings.UnifiedFinding{volumeFinding()})
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, result); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	var got ScanResult
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got.Findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(got.Findings))
+	}
+	f := got.Findings[0]
+	if f.HandshakeVolumeClass != "hybrid-kem" {
+		t.Errorf("HandshakeVolumeClass=%q, want hybrid-kem", f.HandshakeVolumeClass)
+	}
+	if f.HandshakeBytes != 8192 {
+		t.Errorf("HandshakeBytes=%d, want 8192", f.HandshakeBytes)
+	}
+}
+
+// TestHandshakeVolume_JSON_OmitEmpty verifies that HandshakeVolumeClass and
+// HandshakeBytes are absent from JSON for findings that lack them.
+func TestHandshakeVolume_JSON_OmitEmpty(t *testing.T) {
+	result := makePQCTestResult([]findings.UnifiedFinding{rsaFinding()})
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, result); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	var raw struct {
+		Findings []map[string]json.RawMessage `json:"findings"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	f := raw.Findings[0]
+	for _, key := range []string{"handshakeVolumeClass", "handshakeBytes"} {
+		if _, present := f[key]; present {
+			t.Errorf("field %q must be omitted for classical (zero-value) finding, but was present", key)
+		}
+	}
+}
+
+// TestHandshakeVolume_SARIF_Properties verifies that handshakeVolumeClass and
+// handshakeBytes appear in SARIF result.properties when set.
+func TestHandshakeVolume_SARIF_Properties(t *testing.T) {
+	result := makePQCTestResult([]findings.UnifiedFinding{volumeFinding(), rsaFinding()})
+	var buf bytes.Buffer
+	if err := WriteSARIF(&buf, result); err != nil {
+		t.Fatalf("WriteSARIF: %v", err)
+	}
+	var sarifDoc struct {
+		Runs []struct {
+			Results []struct {
+				Properties map[string]json.RawMessage `json:"properties"`
+			} `json:"results"`
+		} `json:"runs"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &sarifDoc); err != nil {
+		t.Fatalf("unmarshal SARIF: %v", err)
+	}
+	if len(sarifDoc.Runs[0].Results) != 2 {
+		t.Fatalf("expected 2 SARIF results, got %d", len(sarifDoc.Runs[0].Results))
+	}
+
+	// Volume finding: both keys must be present.
+	volProps := sarifDoc.Runs[0].Results[0].Properties
+	if _, ok := volProps["handshakeVolumeClass"]; !ok {
+		t.Error("SARIF volume finding: handshakeVolumeClass absent")
+	}
+	var vc string
+	if v, ok := volProps["handshakeVolumeClass"]; ok {
+		_ = json.Unmarshal(v, &vc)
+	}
+	if vc != "hybrid-kem" {
+		t.Errorf("SARIF handshakeVolumeClass=%q, want hybrid-kem", vc)
+	}
+	if _, ok := volProps["handshakeBytes"]; !ok {
+		t.Error("SARIF volume finding: handshakeBytes absent")
+	}
+
+	// Classical RSA finding: both keys must be absent.
+	rsaProps := sarifDoc.Runs[0].Results[1].Properties
+	for _, key := range []string{"handshakeVolumeClass", "handshakeBytes"} {
+		if _, ok := rsaProps[key]; ok {
+			t.Errorf("SARIF RSA finding: %q must be absent", key)
+		}
+	}
+}
+
+// TestHandshakeVolume_CBOM_Properties verifies that oqs:handshakeVolumeClass and
+// oqs:handshakeBytes appear in CBOM component properties when set.
+func TestHandshakeVolume_CBOM_Properties(t *testing.T) {
+	result := makePQCTestResult([]findings.UnifiedFinding{volumeFinding(), rsaFinding()})
+	var buf bytes.Buffer
+	if err := WriteCBOM(&buf, result); err != nil {
+		t.Fatalf("WriteCBOM: %v", err)
+	}
+	var bom struct {
+		Components []struct {
+			Name       string `json:"name"`
+			Properties []struct {
+				Name  string `json:"name"`
+				Value string `json:"value"`
+			} `json:"properties"`
+		} `json:"components"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &bom); err != nil {
+		t.Fatalf("unmarshal CBOM: %v", err)
+	}
+	if len(bom.Components) < 2 {
+		t.Fatalf("expected at least 2 CBOM components, got %d", len(bom.Components))
+	}
+
+	findProp := func(props []struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	}, name string) (string, bool) {
+		for _, p := range props {
+			if p.Name == name {
+				return p.Value, true
+			}
+		}
+		return "", false
+	}
+
+	// Volume component: oqs:handshakeVolumeClass and oqs:handshakeBytes must be present.
+	volProps := bom.Components[0].Properties
+	if v, ok := findProp(volProps, "oqs:handshakeVolumeClass"); !ok || v != "hybrid-kem" {
+		t.Errorf("CBOM: oqs:handshakeVolumeClass=%q ok=%v, want \"hybrid-kem\" present", v, ok)
+	}
+	if v, ok := findProp(volProps, "oqs:handshakeBytes"); !ok || v != "8192" {
+		t.Errorf("CBOM: oqs:handshakeBytes=%q ok=%v, want \"8192\" present", v, ok)
+	}
+
+	// RSA component: these keys must be absent.
+	rsaProps := bom.Components[1].Properties
+	for _, prop := range []string{"oqs:handshakeVolumeClass", "oqs:handshakeBytes"} {
+		if _, ok := findProp(rsaProps, prop); ok {
+			t.Errorf("CBOM RSA component: %q must be absent", prop)
+		}
+	}
+}
+
 // stripANSI removes ANSI escape sequences from s so badge checks work
 // regardless of whether colour output is enabled.
 func stripANSI(s string) string {

--- a/pkg/output/pqc_fields_format_test.go
+++ b/pkg/output/pqc_fields_format_test.go
@@ -72,6 +72,20 @@ func pqcDraftFinding() findings.UnifiedFinding {
 	}
 }
 
+// partialInventoryFinding is an ECH-hidden finding with PartialInventory=true.
+func partialInventoryFinding() findings.UnifiedFinding {
+	return findings.UnifiedFinding{
+		Location:               findings.Location{File: "(tls-probe)/ech.example.com:443#kex"},
+		Algorithm:              &findings.Algorithm{Name: "ECDHE", Primitive: "key-exchange"},
+		SourceEngine:           "tls-probe",
+		Confidence:             findings.ConfidenceMedium,
+		Reachable:              findings.ReachableYes,
+		QuantumRisk:            findings.QRVulnerable,
+		PartialInventory:       true,
+		PartialInventoryReason: "ECH_ENABLED",
+	}
+}
+
 // ── JSON round-trip ──────────────────────────────────────────────────────────
 
 func TestPQCFormat_JSON_RoundTrip(t *testing.T) {
@@ -371,6 +385,152 @@ func TestPQCFormat_Table_PQCBadges(t *testing.T) {
 				t.Errorf("RSA line incorrectly carries [PQC] badge: %q", line)
 			}
 		}
+	}
+}
+
+// ── PartialInventory surfacing ───────────────────────────────────────────────
+
+// TestPartialInventory_JSON_OmitEmpty verifies that PartialInventory fields are
+// absent from JSON output when false/empty (zero-value RSA finding).
+func TestPartialInventory_JSON_OmitEmpty(t *testing.T) {
+	result := makePQCTestResult([]findings.UnifiedFinding{rsaFinding()})
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, result); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	var raw struct {
+		Findings []map[string]json.RawMessage `json:"findings"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	f := raw.Findings[0]
+	for _, key := range []string{"partialInventory", "partialInventoryReason"} {
+		if _, present := f[key]; present {
+			t.Errorf("field %q must be omitted for non-ECH finding, but was present", key)
+		}
+	}
+}
+
+// TestPartialInventory_JSON_Present verifies that PartialInventory fields appear
+// in JSON output when set.
+func TestPartialInventory_JSON_Present(t *testing.T) {
+	result := makePQCTestResult([]findings.UnifiedFinding{partialInventoryFinding()})
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, result); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	var raw struct {
+		Findings []map[string]json.RawMessage `json:"findings"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	f := raw.Findings[0]
+	if _, present := f["partialInventory"]; !present {
+		t.Error("partialInventory must be present for ECH finding")
+	}
+	if _, present := f["partialInventoryReason"]; !present {
+		t.Error("partialInventoryReason must be present for ECH finding")
+	}
+}
+
+// TestPartialInventory_SARIF_Properties verifies that PartialInventory is surfaced
+// in SARIF result.properties when set and absent when not set.
+func TestPartialInventory_SARIF_Properties(t *testing.T) {
+	result := makePQCTestResult([]findings.UnifiedFinding{
+		rsaFinding(),
+		partialInventoryFinding(),
+	})
+	var buf bytes.Buffer
+	if err := WriteSARIF(&buf, result); err != nil {
+		t.Fatalf("WriteSARIF: %v", err)
+	}
+	var sarifDoc struct {
+		Runs []struct {
+			Results []struct {
+				Properties map[string]json.RawMessage `json:"properties"`
+			} `json:"results"`
+		} `json:"runs"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &sarifDoc); err != nil {
+		t.Fatalf("unmarshal SARIF: %v", err)
+	}
+	if len(sarifDoc.Runs[0].Results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(sarifDoc.Runs[0].Results))
+	}
+
+	// RSA: partialInventory must be absent.
+	rsaProps := sarifDoc.Runs[0].Results[0].Properties
+	if _, ok := rsaProps["partialInventory"]; ok {
+		t.Error("SARIF RSA: partialInventory must be absent")
+	}
+
+	// ECH finding: partialInventory must be present with value "ECH_ENABLED".
+	echProps := sarifDoc.Runs[0].Results[1].Properties
+	if v, ok := echProps["partialInventory"]; !ok {
+		t.Error("SARIF ECH finding: partialInventory absent")
+	} else {
+		var reason string
+		_ = json.Unmarshal(v, &reason)
+		if reason != "ECH_ENABLED" {
+			t.Errorf("SARIF ECH finding: partialInventory=%q, want ECH_ENABLED", reason)
+		}
+	}
+}
+
+// TestPartialInventory_CBOM_Properties verifies that oqs:partialInventory and
+// oqs:partialInventoryReason appear in CBOM component properties when set.
+func TestPartialInventory_CBOM_Properties(t *testing.T) {
+	result := makePQCTestResult([]findings.UnifiedFinding{
+		rsaFinding(),
+		partialInventoryFinding(),
+	})
+	var buf bytes.Buffer
+	if err := WriteCBOM(&buf, result); err != nil {
+		t.Fatalf("WriteCBOM: %v", err)
+	}
+	var bom struct {
+		Components []struct {
+			Name       string `json:"name"`
+			Properties []struct {
+				Name  string `json:"name"`
+				Value string `json:"value"`
+			} `json:"properties"`
+		} `json:"components"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &bom); err != nil {
+		t.Fatalf("unmarshal CBOM: %v", err)
+	}
+	if len(bom.Components) < 2 {
+		t.Fatalf("expected at least 2 components, got %d", len(bom.Components))
+	}
+
+	findProp := func(props []struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	}, name string) (string, bool) {
+		for _, p := range props {
+			if p.Name == name {
+				return p.Value, true
+			}
+		}
+		return "", false
+	}
+
+	// RSA: oqs:partialInventory must be absent.
+	for _, prop := range []string{"oqs:partialInventory", "oqs:partialInventoryReason"} {
+		if _, ok := findProp(bom.Components[0].Properties, prop); ok {
+			t.Errorf("CBOM RSA: %q must be absent", prop)
+		}
+	}
+
+	// ECH finding: both properties must be present.
+	if v, ok := findProp(bom.Components[1].Properties, "oqs:partialInventory"); !ok || v != "true" {
+		t.Errorf("CBOM ECH: oqs:partialInventory=%q ok=%v, want \"true\" present", v, ok)
+	}
+	if v, ok := findProp(bom.Components[1].Properties, "oqs:partialInventoryReason"); !ok || v != "ECH_ENABLED" {
+		t.Errorf("CBOM ECH: oqs:partialInventoryReason=%q ok=%v, want \"ECH_ENABLED\" present", v, ok)
 	}
 }
 

--- a/pkg/output/pqc_fields_format_test.go
+++ b/pkg/output/pqc_fields_format_test.go
@@ -279,14 +279,15 @@ func TestPQCFormat_CBOM_OQSPropertyConventions(t *testing.T) {
 
 	// RSA component: oqs:pqcPresent and oqs:pqcMaturity must be absent.
 	rsaProps := bom.Components[0].Properties
-	for _, prop := range []string{"oqs:pqcPresent", "oqs:pqcMaturity", "oqs:negotiatedGroup"} {
+	for _, prop := range []string{"oqs:pqcPresent", "oqs:pqcMaturity", "oqs:negotiatedGroupName"} {
 		if v, ok := findProp(rsaProps, prop); ok {
 			t.Errorf("CBOM RSA component: property %q present (value=%q), want absent", prop, v)
 		}
 	}
 
 	// Hybrid component: oqs:pqcPresent="true", oqs:pqcMaturity="final",
-	// oqs:negotiatedGroup="X25519MLKEM768" must all be present.
+	// oqs:negotiatedGroupName="X25519MLKEM768" must all be present.
+	// Note: renamed from oqs:negotiatedGroup → oqs:negotiatedGroupName (S2.5 carryover fix).
 	hybridProps := bom.Components[1].Properties
 	if v, ok := findProp(hybridProps, "oqs:pqcPresent"); !ok || v != "true" {
 		t.Errorf("CBOM hybrid component: oqs:pqcPresent=%q ok=%v, want \"true\" present", v, ok)
@@ -294,8 +295,8 @@ func TestPQCFormat_CBOM_OQSPropertyConventions(t *testing.T) {
 	if v, ok := findProp(hybridProps, "oqs:pqcMaturity"); !ok || v != "final" {
 		t.Errorf("CBOM hybrid component: oqs:pqcMaturity=%q ok=%v, want \"final\" present", v, ok)
 	}
-	if v, ok := findProp(hybridProps, "oqs:negotiatedGroup"); !ok || v != "X25519MLKEM768" {
-		t.Errorf("CBOM hybrid component: oqs:negotiatedGroup=%q ok=%v, want \"X25519MLKEM768\"", v, ok)
+	if v, ok := findProp(hybridProps, "oqs:negotiatedGroupName"); !ok || v != "X25519MLKEM768" {
+		t.Errorf("CBOM hybrid component: oqs:negotiatedGroupName=%q ok=%v, want \"X25519MLKEM768\"", v, ok)
 	}
 
 	// Draft component: oqs:pqcMaturity must be "draft".

--- a/pkg/output/sarif.go
+++ b/pkg/output/sarif.go
@@ -242,6 +242,9 @@ func findingToSARIF(f findings.UnifiedFinding, scanTarget string, ruleIndex map[
 	if f.PQCMaturity != "" {
 		props["pqcMaturity"] = f.PQCMaturity
 	}
+	if f.PartialInventory {
+		props["partialInventory"] = f.PartialInventoryReason
+	}
 	result.Properties = props
 
 	return result

--- a/pkg/output/sarif.go
+++ b/pkg/output/sarif.go
@@ -245,6 +245,12 @@ func findingToSARIF(f findings.UnifiedFinding, scanTarget string, ruleIndex map[
 	if f.PartialInventory {
 		props["partialInventory"] = f.PartialInventoryReason
 	}
+	if f.HandshakeVolumeClass != "" {
+		props["handshakeVolumeClass"] = f.HandshakeVolumeClass
+	}
+	if f.HandshakeBytes > 0 {
+		props["handshakeBytes"] = f.HandshakeBytes
+	}
 	result.Properties = props
 
 	return result

--- a/pkg/quantum/classify.go
+++ b/pkg/quantum/classify.go
@@ -141,7 +141,17 @@ var quantumVulnerableFamilies = map[string]bool{
 	"KCDSA": true, "EC-KCDSA": true,
 }
 
-// deprecatedAlgorithms are classically broken regardless of quantum computing.
+// deprecatedAlgorithms are classically broken regardless of quantum computing,
+// plus deprecated IETF draft PQ hybrids that predate FIPS 203 standardisation.
+//
+// X25519Kyber768Draft00 (and its TLS codepoint aliases 0x6399/0x636D) must be
+// here so that name-based classification returns RiskDeprecated rather than
+// RiskVulnerable (which would occur if the "X25519" prefix in
+// quantumVulnerableFamilies matched first). The deprecated check runs before
+// the vulnerable-family prefix match (step 1 < step 3 in ClassifyAlgorithm).
+//
+// If further draft Kyber variants appear (e.g. X25519Kyber512Draft00,
+// X25519Kyber1024Draft00), add them here with the same pattern.
 var deprecatedAlgorithms = map[string]bool{
 	"MD5": true, "MD4": true, "MD2": true,
 	"SHA-1": true, "SHA1": true,
@@ -149,6 +159,12 @@ var deprecatedAlgorithms = map[string]bool{
 	"RC2": true, "RC4": true, "RC5": true,
 	"Blowfish": true,
 	"HAS-160": true,
+	// Deprecated IETF draft hybrid KEMs (pre-FIPS 203). These are NOT quantum-safe:
+	// the Kyber component was the pre-standardisation draft, superseded by ML-KEM.
+	// Callers should migrate to X25519MLKEM768 (codepoint 0x11EC).
+	"X25519Kyber768Draft00":  true,
+	"X25519Kyber512Draft00":  true,
+	"X25519Kyber1024Draft00": true,
 }
 
 // ClassifyAlgorithm assesses the quantum risk of a cryptographic algorithm.

--- a/pkg/quantum/classify_test.go
+++ b/pkg/quantum/classify_test.go
@@ -441,3 +441,51 @@ func TestHybridRecommendations(t *testing.T) {
 		}
 	})
 }
+
+// TestClassifyAlgorithm_X25519KyberDraft_IsDeprecated pins the name-based
+// classification of X25519Kyber768Draft00 (and sibling variants) as RiskDeprecated,
+// not RiskVulnerable. Before this fix the "X25519" prefix in
+// quantumVulnerableFamilies matched first via extractBaseName, incorrectly
+// returning RiskVulnerable. The deprecated check now runs before the vulnerable
+// prefix match.
+//
+// Spec cross-reference: CLAUDE.md — "Deprecated Kyber drafts (X25519Kyber768Draft00)
+// are classified RiskDeprecated".
+func TestClassifyAlgorithm_X25519KyberDraft_IsDeprecated(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		algName   string
+		primitive string
+	}{
+		{"X25519Kyber768Draft00 kem", "X25519Kyber768Draft00", "kem"},
+		{"X25519Kyber768Draft00 key-exchange", "X25519Kyber768Draft00", "key-exchange"},
+		{"X25519Kyber768Draft00 empty-primitive", "X25519Kyber768Draft00", ""},
+		{"X25519Kyber512Draft00 kem", "X25519Kyber512Draft00", "kem"},
+		{"X25519Kyber1024Draft00 kem", "X25519Kyber1024Draft00", "kem"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ClassifyAlgorithm(tt.algName, tt.primitive, 0)
+
+			// Must be RiskDeprecated (not RiskVulnerable, not RiskSafe).
+			if got.Risk != RiskDeprecated {
+				t.Errorf("ClassifyAlgorithm(%q, %q, 0).Risk = %q, want %q (deprecated-check must fire before vulnerable-prefix-match)",
+					tt.algName, tt.primitive, got.Risk, RiskDeprecated)
+			}
+			// Severity for deprecated algorithms is Critical.
+			if got.Severity != SeverityCritical {
+				t.Errorf("ClassifyAlgorithm(%q, %q, 0).Severity = %q, want %q",
+					tt.algName, tt.primitive, got.Severity, SeverityCritical)
+			}
+			// HNDLRisk must be empty (deprecated, not a quantum harvest risk).
+			if got.HNDLRisk != "" {
+				t.Errorf("ClassifyAlgorithm(%q, %q, 0).HNDLRisk = %q, want empty",
+					tt.algName, tt.primitive, got.HNDLRisk)
+			}
+		})
+	}
+}

--- a/pkg/quantum/matrix_test.go
+++ b/pkg/quantum/matrix_test.go
@@ -4,7 +4,8 @@ package quantum
 //
 // 6 sectors × 8 year values × 10 KEM algorithms = 480 sub-tests.
 // Each cell asserts:
-//  (a) Classical KEMs (RSA, ECDHE, Kyber768, draft, unknown) → HNDLImmediate + Mosca HNDL level
+//  (a) Classical KEMs (RSA, ECDHE, Kyber768, unknown) → HNDLImmediate + Mosca HNDL level
+//  (a2) Deprecated draft KEMs (X25519Kyber768Draft00) → RiskDeprecated, no HNDLRisk
 //  (b) Classical signatures (ECDSA) → HNDLDeferred + RiskVulnerable
 //  (c) Hybrid PQ KEMs (X25519MLKEM768, hyphenated, SecP256r1MLKEM768) → RiskSafe, no HNDL
 //  (d) Pure PQ KEM (ML-KEM-768) → RiskSafe, no HNDL
@@ -55,13 +56,15 @@ var kemSpecs = []kemSpec{
 		wantHNDLRisk: HNDLImmediate,
 	},
 	{
-		// X25519Kyber768Draft00: deprecated IETF draft hybrid. extractBaseName
-		// matches "X25519" prefix in quantumVulnerableFamilies → treated as
-		// classical X25519 key exchange → HNDLImmediate.
+		// X25519Kyber768Draft00: deprecated IETF draft hybrid (pre-FIPS 203 Kyber).
+		// Now in deprecatedAlgorithms so the deprecated check (step 1) fires before
+		// the quantumVulnerableFamilies prefix match (step 3). RiskDeprecated; no
+		// HNDLRisk because deprecated algorithms are classically broken, not
+		// specifically a quantum harvest risk.
 		algorithm:    "X25519Kyber768Draft00",
 		primitive:    "kem",
-		wantRisk:     RiskVulnerable,
-		wantHNDLRisk: HNDLImmediate,
+		wantRisk:     RiskDeprecated,
+		wantHNDLRisk: "",
 	},
 	{
 		// Unrecognized KEM with opaque name → conservative: HNDLImmediate.
@@ -224,8 +227,8 @@ func TestMatrix_ImmediateKEM_MoscaLevelSample(t *testing.T) {
 		{"code", 5, 10, "ECDHE-X25519", "key-exchange", HNDLLevelMedium},
 		// State (50y) + 100y crqc: 50+5-100=-45 → LOW — quantum era ends first
 		{"state", 50, 100, "RSA-2048", "kem", HNDLLevelLow},
-		// Infra (20y) + 30y crqc: 20+5-30=-5 → LOW
-		{"infra", 20, 30, "X25519Kyber768Draft00", "kem", HNDLLevelLow},
+		// Infra (20y) + 30y crqc: 20+5-30=-5 → LOW (use ECDHE to replace deprecated X25519Kyber768Draft00)
+		{"infra", 20, 30, "ECDHE", "key-exchange", HNDLLevelLow},
 		// Generic (10y) + 3y crqc: 10+5-3=12 → HIGH
 		{"generic", 10, 3, "unknown-algo-fallback", "kem", HNDLLevelHigh},
 	}


### PR DESCRIPTION
## Summary

Sprint 2 of the Network Engine Plan: deterministic size-based PQC signals (98-100% accuracy per Mallick arXiv:2503.17830) layered on the existing active TLS probe. Also bundles audit fixes for Sprints 0/1/2 surfaced by parallel review.

### New capabilities
- **TCP byte accounting** (`tlsprobe/tcp_segments.go`): `countingConn` wraps `net.Conn` with `atomic.Int64` counters for bytes/read-calls in each direction. Diagnostic segment counts + authoritative BytesIn/BytesOut.
- **key_share parser** (`tlsprobe/keyshare.go`): pure helper over RFC 8446 §4.2.8 + draft-ietf-tls-hybrid-design-16; 11 codepoints with exact client/server kex sizes (X25519=32B, ML-KEM-768=1184B, X25519MLKEM768=1216B, etc.). Wired hook for Sprint 7 raw ClientHello capture.
- **Three-tier volume classifier** (`tlsprobe/volume.go`): `<7KB=classical`, `7–12KB=hybrid-KEM`, `>20KB=full-PQC`, gap tier=unknown. Corroborates CurveID, never overrides it.
- **ECH detection** (`tlsprobe/ech.go`): raw DNS HTTPS RR Type=65 query (EDNS0 OPT, TC-bit TCP fallback, pointer-loop guard), IP-literal short-circuit, `DenyPrivate` honoured (public-fallback resolver). ECH hosts annotated `PartialInventory=true / Reason="ECH_ENABLED"` for Sprint 3 CT lookup.

### New `UnifiedFinding` fields (all `omitempty`, no `DedupeKey` impact)
- `PartialInventory bool` / `PartialInventoryReason string`
- `HandshakeVolumeClass string` / `HandshakeBytes int64`

### Output surfacing
- **JSON**: automatic via struct tags.
- **SARIF**: `result.properties` gets `partialInventory`, `partialInventoryReason`, `handshakeVolumeClass`, `handshakeBytes`.
- **CBOM**: `oqs:partialInventory`, `oqs:partialInventoryReason`, `oqs:handshakeVolumeClass`, `oqs:handshakeBytes` properties.

### Audit fixes bundled
- **Sprint 1 carryover** `cbom.go`: rename `oqs:negotiatedGroup` → `oqs:negotiatedGroupName` (SARIF-parity).
- **M1** `tlsprobe/engine.go`: semaphore acquired in parent goroutine before launch (bounds concurrent goroutine count, honours mid-probe ctx cancel).
- **M2** `tlsprobe/ech.go`: DNS path respects `--tls-strict` / `DenyPrivate` via public-fallback resolver list.
- **M3** `tlsprobe/ech.go`: DNS name-compression hop cap of 128 — DoS-safe against crafted responses.
- **T-BUG** `pkg/quantum/classify.go`: `X25519Kyber768Draft00` / 512 / 1024 name-based classification now returns `RiskDeprecated` (was incorrectly `RiskVulnerable` via `X25519` prefix match).

## Test plan
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test -race -count=1 ./...` — 45/45 packages pass, 0 failures, 0 races
- [x] `go test -race -count=3 ./pkg/engines/tlsprobe/...` — no flakiness
- [x] `go test -fuzz=FuzzParseKeyShareExtension -fuzztime=20s` — 4.8M execs, PASS
- [x] +165 tests across 8 thematic buckets (property / fuzz / race+stress / boundary / ECH matrix / format / backcompat / codepoint regression)
- [x] Sprint 0 + Sprint 1 full regression green (double-check audit by dedicated reviewer)
- [x] Cross-sprint: `DedupeKey()` stable; omitempty respected for all new fields; CBOM rename does not drop pre-existing fields