### PR TITLE
Sprint 4: SSH PQC probe engine

### DIFF
--- a/cmd/oqs-scanner/main.go
+++ b/cmd/oqs-scanner/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/jimbo111/open-quantum-secure/pkg/engines/cbomkit"
 	"github.com/jimbo111/open-quantum-secure/pkg/engines/configscanner"
 	"github.com/jimbo111/open-quantum-secure/pkg/engines/ctlookup"
+	"github.com/jimbo111/open-quantum-secure/pkg/engines/sshprobe"
 	"github.com/jimbo111/open-quantum-secure/pkg/engines/tlsprobe"
 	"github.com/jimbo111/open-quantum-secure/pkg/engines/cdxgen"
 	"github.com/jimbo111/open-quantum-secure/pkg/engines/cipherscope"
@@ -134,7 +135,10 @@ func buildOrchestrator() *orchestrator.Orchestrator {
 	// runs tls-probe first and can enrich ct-lookup with ECH hostnames.
 	ct := ctlookup.New()
 
-	return orchestrator.New(cs, cscan, ag, sg, cdeps, cdx, sy, cbk, bs, cfgs, tlsp, ct)
+	// Tier 5: SSH probe engine (pure Go, always available; Sprint 4).
+	sshp := sshprobe.New()
+
+	return orchestrator.New(cs, cscan, ag, sg, cdeps, cdx, sy, cbk, bs, cfgs, tlsp, ct, sshp)
 }
 
 // engineVersionsHash computes a stable SHA-256 hex digest over the
@@ -356,6 +360,7 @@ func scanCmd() *cobra.Command {
 		ctLookupTargets   []string
 		ctLookupFromECH   bool
 		noNetwork         bool
+		sshTargets        []string
 	)
 
 	cmd := &cobra.Command{
@@ -506,6 +511,7 @@ Example with data lifetime adjustment for healthcare:
 				NoNetwork:       noNetwork,
 				CTLookupTargets: ctLookupTargets,
 				CTLookupFromECH: ctLookupFromECH,
+				SSHTargets:      sshTargets,
 			}
 
 			if incremental && noCache {
@@ -698,6 +704,9 @@ Overrides --sector when both are provided.`)
 	cmd.Flags().BoolVar(&noNetwork, "no-network", false, "Disable all outbound network calls (TLS probe + CT lookup)")
 	cmd.Flags().BoolVar(&noNetwork, "offline", false, "Disable all outbound network calls (alias for --no-network)")
 
+	// SSH probe flags (Sprint 4)
+	cmd.Flags().StringSliceVar(&sshTargets, "ssh-targets", nil, "SSH endpoints to probe for quantum-vulnerable KEX methods (comma-separated host:port)")
+
 	// HNDL Mosca sector preset flag
 	cmd.Flags().StringVar(&sector, "sector", "",
 		`Industry sector preset for Mosca HNDL shelf-life (case-insensitive).
@@ -735,6 +744,7 @@ func diffCmd() *cobra.Command {
 		ctLookupTargets   []string
 		ctLookupFromECH   bool
 		noNetwork         bool
+		sshTargets        []string
 	)
 
 	cmd := &cobra.Command{
@@ -875,6 +885,7 @@ Example:
 				NoNetwork:       noNetwork,
 				CTLookupTargets: ctLookupTargets,
 				CTLookupFromECH: ctLookupFromECH,
+				SSHTargets:      sshTargets,
 			}
 
 			selected := orch.EffectiveEngines(opts)
@@ -1023,6 +1034,9 @@ financial/banking=7, legal/contracts=10, web sessions/ephemeral=1.
 	cmd.Flags().BoolVar(&ctLookupFromECH, "ct-lookup-from-ech", false, "Auto-query CT logs for ECH-enabled findings detected by the TLS probe")
 	cmd.Flags().BoolVar(&noNetwork, "no-network", false, "Disable all outbound network calls (TLS probe + CT lookup)")
 	cmd.Flags().BoolVar(&noNetwork, "offline", false, "Disable all outbound network calls (alias for --no-network)")
+
+	// SSH probe flags (Sprint 4)
+	cmd.Flags().StringSliceVar(&sshTargets, "ssh-targets", nil, "SSH endpoints to probe for quantum-vulnerable KEX methods (comma-separated host:port)")
 
 	return cmd
 }

--- a/cmd/oqs-scanner/main.go
+++ b/cmd/oqs-scanner/main.go
@@ -11,9 +11,11 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"net"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"text/tabwriter"
@@ -361,6 +363,7 @@ func scanCmd() *cobra.Command {
 		ctLookupFromECH   bool
 		noNetwork         bool
 		sshTargets        []string
+		sshStrict         bool
 	)
 
 	cmd := &cobra.Command{
@@ -475,6 +478,13 @@ Example with data lifetime adjustment for healthcare:
 				}
 			}
 
+			// Validate --ssh-targets: must be host:port with valid hostname/IP syntax.
+			for _, t := range sshTargets {
+				if err := validateSSHTarget(t); err != nil {
+					return fmt.Errorf("invalid --ssh-targets value %q: %w", t, err)
+				}
+			}
+
 			orch := buildOrchestrator()
 
 			ctx := context.Background()
@@ -512,6 +522,7 @@ Example with data lifetime adjustment for healthcare:
 				CTLookupTargets: ctLookupTargets,
 				CTLookupFromECH: ctLookupFromECH,
 				SSHTargets:      sshTargets,
+				SSHDenyPrivate:  sshStrict,
 			}
 
 			if incremental && noCache {
@@ -706,6 +717,7 @@ Overrides --sector when both are provided.`)
 
 	// SSH probe flags (Sprint 4)
 	cmd.Flags().StringSliceVar(&sshTargets, "ssh-targets", nil, "SSH endpoints to probe for quantum-vulnerable KEX methods (comma-separated host:port)")
+	cmd.Flags().BoolVar(&sshStrict, "ssh-strict", false, "Deny SSH probe connections to private/loopback IPs (SSRF guard; analogous to --tls-strict)")
 
 	// HNDL Mosca sector preset flag
 	cmd.Flags().StringVar(&sector, "sector", "",
@@ -745,6 +757,7 @@ func diffCmd() *cobra.Command {
 		ctLookupFromECH   bool
 		noNetwork         bool
 		sshTargets        []string
+		sshStrict         bool
 	)
 
 	cmd := &cobra.Command{
@@ -866,6 +879,13 @@ Example:
 				}
 			}
 
+			// Validate --ssh-targets: must be host:port with valid hostname/IP syntax.
+			for _, t := range sshTargets {
+				if err := validateSSHTarget(t); err != nil {
+					return fmt.Errorf("invalid --ssh-targets value %q: %w", t, err)
+				}
+			}
+
 			opts := engines.ScanOptions{
 				TargetPath:      absPath,
 				Timeout:         timeout,
@@ -886,6 +906,7 @@ Example:
 				CTLookupTargets: ctLookupTargets,
 				CTLookupFromECH: ctLookupFromECH,
 				SSHTargets:      sshTargets,
+				SSHDenyPrivate:  sshStrict,
 			}
 
 			selected := orch.EffectiveEngines(opts)
@@ -1037,8 +1058,31 @@ financial/banking=7, legal/contracts=10, web sessions/ephemeral=1.
 
 	// SSH probe flags (Sprint 4)
 	cmd.Flags().StringSliceVar(&sshTargets, "ssh-targets", nil, "SSH endpoints to probe for quantum-vulnerable KEX methods (comma-separated host:port)")
+	cmd.Flags().BoolVar(&sshStrict, "ssh-strict", false, "Deny SSH probe connections to private/loopback IPs (SSRF guard; analogous to --tls-strict)")
 
 	return cmd
+}
+
+// validateSSHTarget validates a single --ssh-targets entry. It must be in
+// "host:port" form with a valid port number (1–65535) and either a valid
+// hostname (RFC 1123 DNS labels) or an IP literal.
+func validateSSHTarget(target string) error {
+	host, portStr, err := net.SplitHostPort(target)
+	if err != nil {
+		return fmt.Errorf("must be in host:port format: %w", err)
+	}
+	if host == "" {
+		return fmt.Errorf("empty host")
+	}
+	portNum, convErr := strconv.Atoi(portStr)
+	if convErr != nil || portNum < 1 || portNum > 65535 {
+		return fmt.Errorf("invalid port %q (must be 1-65535)", portStr)
+	}
+	// IP literals are valid SSH targets; skip hostname validation for them.
+	if net.ParseIP(host) != nil {
+		return nil
+	}
+	return ctlookup.ValidateHostname(host)
 }
 
 // writeOutput writes the scan result in the specified format to the given destination.

--- a/pkg/engines/engine.go
+++ b/pkg/engines/engine.go
@@ -89,6 +89,10 @@ type ScanOptions struct {
 	// CT log lookup options (Sprint 3).
 	CTLookupTargets []string // hostnames to query CT logs for cert algorithm discovery
 	CTLookupFromECH bool     // auto-query CT logs for hostnames found via ECH partial-inventory findings
+
+	// SSH probe options (Sprint 4).
+	SSHTargets []string // host:port targets to probe SSH KEX advertisement (empty = skip ssh-probe)
+	SSHTimeout int      // per-target dial+KEXINIT timeout in seconds (0 = default 10s)
 }
 
 // Engine is the interface every scanner engine must implement.

--- a/pkg/engines/engine.go
+++ b/pkg/engines/engine.go
@@ -91,8 +91,9 @@ type ScanOptions struct {
 	CTLookupFromECH bool     // auto-query CT logs for hostnames found via ECH partial-inventory findings
 
 	// SSH probe options (Sprint 4).
-	SSHTargets []string // host:port targets to probe SSH KEX advertisement (empty = skip ssh-probe)
-	SSHTimeout int      // per-target dial+KEXINIT timeout in seconds (0 = default 10s)
+	SSHTargets     []string // host:port targets to probe SSH KEX advertisement (empty = skip ssh-probe)
+	SSHTimeout     int      // per-target dial+KEXINIT timeout in seconds (0 = default 10s)
+	SSHDenyPrivate bool     // reject RFC 1918 / loopback / link-local target IPs (--ssh-strict)
 }
 
 // Engine is the interface every scanner engine must implement.

--- a/pkg/engines/netutil/validate.go
+++ b/pkg/engines/netutil/validate.go
@@ -1,0 +1,80 @@
+// Package netutil provides shared network validation helpers used by Tier 5
+// network engines. Centralising here avoids duplicating the private-IP and
+// DNS-resolution logic across tlsprobe, sshprobe, and future network engines.
+package netutil
+
+import (
+	"context"
+	"fmt"
+	"net"
+)
+
+var privateRanges []*net.IPNet
+
+func init() {
+	cidrs := []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"127.0.0.0/8",
+		"169.254.0.0/16",
+		"0.0.0.0/8",          // "This" network (includes 0.0.0.0)
+		"100.64.0.0/10",      // CGNAT (RFC 6598)
+		"198.18.0.0/15",      // Benchmark testing (RFC 2544)
+		"224.0.0.0/4",        // IPv4 multicast
+		"255.255.255.255/32", // IPv4 limited broadcast
+		"::1/128",
+		"::/128",
+		"fc00::/7",
+		"fe80::/10",
+		"ff00::/8", // IPv6 multicast
+	}
+	for _, cidr := range cidrs {
+		_, ipNet, _ := net.ParseCIDR(cidr)
+		privateRanges = append(privateRanges, ipNet)
+	}
+}
+
+// IsPrivateIP reports whether ip falls within a private, loopback, or link-local range.
+func IsPrivateIP(ip net.IP) bool {
+	for _, r := range privateRanges {
+		if r.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// ResolveAndValidate resolves hostname to IPs, validates all resolved addresses
+// against private/loopback/link-local ranges (when denyPrivate is set), and
+// returns the first valid IP string for DNS-pinned connection establishment.
+//
+// When host is already an IP literal, DNS resolution is skipped and the IP is
+// validated directly. The denyPrivate flag maps to --ssh-strict on the CLI.
+func ResolveAndValidate(ctx context.Context, host string, denyPrivate bool) (string, error) {
+	if ip := net.ParseIP(host); ip != nil {
+		if denyPrivate && IsPrivateIP(ip) {
+			return "", fmt.Errorf("target %s is a private IP (blocked by --ssh-strict)", host)
+		}
+		return host, nil
+	}
+
+	ips, err := net.DefaultResolver.LookupHost(ctx, host)
+	if err != nil {
+		return "", fmt.Errorf("DNS resolution failed for %s: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return "", fmt.Errorf("DNS resolution returned no addresses for %s", host)
+	}
+
+	if denyPrivate {
+		for _, ipStr := range ips {
+			ip := net.ParseIP(ipStr)
+			if ip != nil && IsPrivateIP(ip) {
+				return "", fmt.Errorf("target %s resolves to private IP %s (blocked by --ssh-strict)", host, ipStr)
+			}
+		}
+	}
+
+	return ips[0], nil
+}

--- a/pkg/engines/netutil/validate_test.go
+++ b/pkg/engines/netutil/validate_test.go
@@ -1,0 +1,80 @@
+package netutil
+
+import (
+	"context"
+	"net"
+	"testing"
+)
+
+func TestIsPrivateIP(t *testing.T) {
+	cases := []struct {
+		ip      string
+		private bool
+	}{
+		{"10.0.0.1", true},
+		{"172.16.0.1", true},
+		{"172.31.255.255", true},
+		{"192.168.1.1", true},
+		{"127.0.0.1", true},
+		{"169.254.0.1", true},
+		{"::1", true},
+		{"fe80::1", true},
+		{"fc00::1", true},
+		{"8.8.8.8", false},
+		{"1.1.1.1", false},
+		{"198.51.100.1", false}, // TEST-NET-2 — not in privateRanges
+		{"2001:db8::1", false},  // documentation range — not in privateRanges
+	}
+	for _, tc := range cases {
+		ip := net.ParseIP(tc.ip)
+		if ip == nil {
+			t.Fatalf("failed to parse IP %q", tc.ip)
+		}
+		got := IsPrivateIP(ip)
+		if got != tc.private {
+			t.Errorf("IsPrivateIP(%q) = %v; want %v", tc.ip, got, tc.private)
+		}
+	}
+}
+
+func TestResolveAndValidate_IPLiteral_Public(t *testing.T) {
+	ip, err := ResolveAndValidate(context.Background(), "8.8.8.8", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ip != "8.8.8.8" {
+		t.Errorf("got %q; want 8.8.8.8", ip)
+	}
+}
+
+func TestResolveAndValidate_IPLiteral_Private_NotDenied(t *testing.T) {
+	ip, err := ResolveAndValidate(context.Background(), "192.168.1.1", false)
+	if err != nil {
+		t.Fatalf("unexpected error when denyPrivate=false: %v", err)
+	}
+	if ip != "192.168.1.1" {
+		t.Errorf("got %q; want 192.168.1.1", ip)
+	}
+}
+
+func TestResolveAndValidate_IPLiteral_Private_Denied(t *testing.T) {
+	_, err := ResolveAndValidate(context.Background(), "192.168.1.1", true)
+	if err == nil {
+		t.Fatal("expected error for private IP with denyPrivate=true, got nil")
+	}
+}
+
+func TestResolveAndValidate_IPLiteral_Loopback_Denied(t *testing.T) {
+	_, err := ResolveAndValidate(context.Background(), "127.0.0.1", true)
+	if err == nil {
+		t.Fatal("expected error for loopback with denyPrivate=true, got nil")
+	}
+}
+
+func TestResolveAndValidate_Localhost_Denied(t *testing.T) {
+	// localhost resolves to 127.0.0.1 — should be blocked by denyPrivate=true.
+	_, err := ResolveAndValidate(context.Background(), "localhost", true)
+	if err == nil {
+		t.Fatal("expected error for localhost (resolves to loopback) with denyPrivate=true, got nil")
+	}
+}

--- a/pkg/engines/sshprobe/adversarial_server_test.go
+++ b/pkg/engines/sshprobe/adversarial_server_test.go
@@ -27,7 +27,7 @@ import (
 // if the dial itself fails (separate from probe error expectations).
 func dialAndProbe(t *testing.T, addr string) ProbeResult {
 	t.Helper()
-	return probeSSH(t.Context(), addr, 3*time.Second)
+	return probeSSH(t.Context(), addr, 3*time.Second, false)
 }
 
 // serveOnce starts a TCP listener, accepts exactly one connection, runs handler,
@@ -193,7 +193,7 @@ func TestAdversarial_TLSClientHelloOnSSHPort(t *testing.T) {
 }
 
 // TestAdversarial_SixNonKEXINITPackets — server sends 6 non-KEXINIT packets,
-// exceeding the 5-packet skip tolerance (maxSkip=5). The probe must error.
+// exceeding the 2-packet skip tolerance (B3: maxSkip=2). The probe must error.
 func TestAdversarial_SixNonKEXINITPackets(t *testing.T) {
 	// SSH_MSG_IGNORE = 2 (a valid non-KEXINIT packet type).
 	ignorePayload := []byte{2, 0, 0, 0, 0}
@@ -209,7 +209,7 @@ func TestAdversarial_SixNonKEXINITPackets(t *testing.T) {
 
 	result := dialAndProbe(t, addr)
 	if result.Error == nil {
-		t.Error("expected error after 6 non-KEXINIT packets (exceeds maxSkip=5)")
+		t.Error("expected error after 6 non-KEXINIT packets (exceeds maxSkip=2)")
 	}
 }
 
@@ -238,10 +238,10 @@ func TestAdversarial_BillionNonASCIIBannerPreamble(t *testing.T) {
 	}
 }
 
-// TestAdversarial_FiveNonKEXINITThenKEXINIT — server sends exactly 5 non-KEXINIT
-// packets then a valid KEXINIT. The probe must succeed (5 = maxSkip-1, which is
-// still within tolerance since the loop iterates for skip 0..4).
-func TestAdversarial_FiveNonKEXINITThenKEXINIT(t *testing.T) {
+// TestAdversarial_OneNonKEXINITThenKEXINIT — B3 regression: server sends exactly
+// 1 non-KEXINIT packet then a valid KEXINIT. With maxSkip=2 the probe must succeed
+// (KEXINIT arrives on the second read, i.e. skip=1 which is within the loop bound).
+func TestAdversarial_OneNonKEXINITThenKEXINIT(t *testing.T) {
 	ignorePayload := []byte{2, 0, 0, 0, 0} // SSH_MSG_IGNORE
 
 	methods := []string{"mlkem768x25519-sha256", "curve25519-sha256"}
@@ -250,19 +250,37 @@ func TestAdversarial_FiveNonKEXINITThenKEXINIT(t *testing.T) {
 		_, _ = conn.Write([]byte("SSH-2.0-Tolerant_1.0\r\n"))
 		buf := make([]byte, 512)
 		_, _ = conn.Read(buf)
-		// Send 4 non-KEXINIT packets (skip values 0..3), then KEXINIT on skip=4.
-		for i := 0; i < 4; i++ {
-			_, _ = conn.Write(buildSSHPacket(ignorePayload))
-		}
+		// Send 1 non-KEXINIT packet (skip=0), then KEXINIT (skip=1).
+		_, _ = conn.Write(buildSSHPacket(ignorePayload))
 		_, _ = conn.Write(buildKEXInitPacket(methods))
 	})
 
 	result := dialAndProbe(t, addr)
 	if result.Error != nil {
-		t.Errorf("expected success with 4 non-KEXINIT then KEXINIT, got: %v", result.Error)
+		t.Errorf("expected success with 1 non-KEXINIT then KEXINIT (within maxSkip=2), got: %v", result.Error)
 	}
 	if len(result.KEXMethods) != len(methods) {
 		t.Errorf("KEXMethods len=%d; want %d", len(result.KEXMethods), len(methods))
+	}
+}
+
+// TestAdversarial_TwoNonKEXINITNoKEXINIT — B3 regression: server sends exactly
+// 2 non-KEXINIT packets with no KEXINIT. With maxSkip=2 this must error.
+func TestAdversarial_TwoNonKEXINITNoKEXINIT(t *testing.T) {
+	ignorePayload := []byte{2, 0, 0, 0, 0} // SSH_MSG_IGNORE
+
+	addr := serveOnce(t, func(conn net.Conn) {
+		_, _ = conn.Write([]byte("SSH-2.0-NoKEX_1.0\r\n"))
+		buf := make([]byte, 512)
+		_, _ = conn.Read(buf)
+		for i := 0; i < 2; i++ {
+			_, _ = conn.Write(buildSSHPacket(ignorePayload))
+		}
+	})
+
+	result := dialAndProbe(t, addr)
+	if result.Error == nil {
+		t.Error("expected error after 2 non-KEXINIT packets with no KEXINIT (maxSkip=2)")
 	}
 }
 

--- a/pkg/engines/sshprobe/adversarial_server_test.go
+++ b/pkg/engines/sshprobe/adversarial_server_test.go
@@ -1,0 +1,291 @@
+// adversarial_server_test.go — adversarial TCP server scenarios for the SSH probe.
+//
+// Purpose: verify that the probe handles pathological server behaviour safely —
+// no panics, no goroutine leaks, and appropriate error returns. Each sub-test
+// starts a local TCP listener that exhibits one specific hostile pattern.
+//
+// Scenarios covered:
+//   (a) 1 MiB banner in a single write (exceeds maxBannerLen)
+//   (b) Byte-by-byte banner with 100ms delays (slowloris-style)
+//   (c) Oversized packet_length field (4 GiB claimed)
+//   (d) Name-list with 64 KB of commas (max-length comma explosion)
+//   (e) SSH_MSG_DISCONNECT immediately after banner
+//   (f) TLS ClientHello bytes on the SSH port (protocol confusion)
+//   (g) 6 non-KEXINIT packets (exceeds the 5-packet tolerance)
+//   (h) 1 billion non-ASCII bytes as banner preamble (must be limited by cap)
+package sshprobe
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+)
+
+// dialWithTimeout connects to addr and returns the connection, failing the test
+// if the dial itself fails (separate from probe error expectations).
+func dialAndProbe(t *testing.T, addr string) ProbeResult {
+	t.Helper()
+	return probeSSH(t.Context(), addr, 3*time.Second)
+}
+
+// serveOnce starts a TCP listener, accepts exactly one connection, runs handler,
+// and closes. Returns the listener address.
+func serveOnce(t *testing.T, handler func(net.Conn)) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	addr := ln.Addr().String()
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+		defer conn.Close()
+		handler(conn)
+	}()
+	return addr
+}
+
+// TestAdversarial_1MiBBannerInOneWrite — server sends a 1 MiB banner in one
+// Write call. The probe must reject it (exceed maxBannerLen) and return an error.
+func TestAdversarial_1MiBBannerInOneWrite(t *testing.T) {
+	bigBanner := bytes.Repeat([]byte("X"), 1<<20) // 1 MiB, no newline
+	addr := serveOnce(t, func(conn net.Conn) {
+		_, _ = conn.Write(bigBanner)
+	})
+
+	result := dialAndProbe(t, addr)
+	if result.Error == nil {
+		t.Error("expected error for 1 MiB banner, got nil")
+	}
+}
+
+// TestAdversarial_BannerByteByByte_Slowloris — server dribbles the banner one
+// byte at a time with 100ms pauses between each byte. The 3-second deadline on
+// the probe must cut it off before the full banner would arrive.
+func TestAdversarial_BannerByteByByte_Slowloris(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slowloris test skipped in short mode")
+	}
+	// Send 40 bytes at 100ms each → 4 seconds, longer than the probe timeout.
+	data := []byte("SSH-2.0-Slowloris_1.0\r\n")
+	addr := serveOnce(t, func(conn net.Conn) {
+		for _, b := range data {
+			_, _ = conn.Write([]byte{b})
+			time.Sleep(100 * time.Millisecond)
+		}
+	})
+
+	start := time.Now()
+	result := dialAndProbe(t, addr)
+	elapsed := time.Since(start)
+
+	// The probe must have timed out within its 3s deadline, not blocked for
+	// the full transmission time (>2.3s for 23 bytes at 100ms each).
+	// We don't assert an exact time — just that it completed < 4s.
+	if elapsed > 4*time.Second {
+		t.Errorf("probe took %v; expected to time out within 3s deadline", elapsed)
+	}
+	_ = result // error or not — either is acceptable; what matters is liveness
+}
+
+// TestAdversarial_OversizedPacketLength — server sends a banner then a packet
+// with claimed packet_length = 0xFFFFFFFF (4 GiB). The probe must reject it.
+func TestAdversarial_OversizedPacketLength(t *testing.T) {
+	addr := serveOnce(t, func(conn net.Conn) {
+		// Valid banner first.
+		_, _ = conn.Write([]byte("SSH-2.0-Evil_1.0\r\n"))
+		// Read client banner (don't block on it — use short deadline).
+		buf := make([]byte, 512)
+		_, _ = conn.Read(buf)
+		// Send packet with 0xFFFFFFFF packet_length.
+		hdr := make([]byte, 4)
+		binary.BigEndian.PutUint32(hdr, 0xFFFFFFFF)
+		_, _ = conn.Write(hdr)
+		// Don't send the body — the length check must reject before reading.
+	})
+
+	result := dialAndProbe(t, addr)
+	if result.Error == nil {
+		t.Error("expected error for packet_length=0xFFFFFFFF, got nil")
+	}
+}
+
+// TestAdversarial_NameListCommaExplosion — server sends a valid banner then a
+// KEXINIT packet whose kex_algorithms name-list is filled with 64 KB of commas,
+// producing thousands of empty name segments. The probe must handle it without
+// crashing or consuming excessive memory.
+func TestAdversarial_NameListCommaExplosion(t *testing.T) {
+	// Build a KEXINIT packet with a name-list payload of maxNameListLen commas.
+	commas := bytes.Repeat([]byte(","), maxNameListLen)
+	kexPayload := buildKEXInitPayloadRaw(commas)
+	pkt := buildSSHPacket(kexPayload)
+
+	addr := serveOnce(t, func(conn net.Conn) {
+		_, _ = conn.Write([]byte("SSH-2.0-Evil_1.0\r\n"))
+		buf := make([]byte, 512)
+		_, _ = conn.Read(buf)
+		_, _ = conn.Write(pkt)
+	})
+
+	result := dialAndProbe(t, addr)
+	// The comma-explosion may succeed (returning many empty method names) or
+	// error — both are acceptable. What we assert is: no panic.
+	_ = result
+}
+
+// TestAdversarial_SSHMsgDisconnectAfterBanner — server sends banner + DISCONNECT
+// (SSH_MSG_DISCONNECT = 1) instead of KEXINIT. The probe should exhaust its
+// 5-packet skip budget and return an error.
+func TestAdversarial_SSHMsgDisconnectAfterBanner(t *testing.T) {
+	// SSH_MSG_DISCONNECT = 1. Build a dummy disconnect payload.
+	disconnectPayload := make([]byte, 5)
+	disconnectPayload[0] = 1 // SSH_MSG_DISCONNECT type
+
+	addr := serveOnce(t, func(conn net.Conn) {
+		_, _ = conn.Write([]byte("SSH-2.0-Disconnect_1.0\r\n"))
+		buf := make([]byte, 512)
+		_, _ = conn.Read(buf)
+		// Send 6 DISCONNECT packets to exceed the 5-packet tolerance.
+		for i := 0; i < 6; i++ {
+			_, _ = conn.Write(buildSSHPacket(disconnectPayload))
+		}
+	})
+
+	result := dialAndProbe(t, addr)
+	if result.Error == nil {
+		t.Error("expected error: server sent only non-KEXINIT packets, but probe succeeded")
+	}
+}
+
+// TestAdversarial_TLSClientHelloOnSSHPort — server receives a connection and
+// immediately sends TLS ClientHello-looking bytes instead of SSH banner.
+// The probe must reject the non-SSH banner and return an error.
+func TestAdversarial_TLSClientHelloOnSSHPort(t *testing.T) {
+	// Minimal TLS ClientHello bytes (not a complete handshake — just the prefix).
+	// TLS record header: ContentType=22 (Handshake), Version=0x0303 (TLS 1.2),
+	// Length=arbitrary. The SSH probe checks for "SSH-" prefix.
+	tlsHello := []byte{
+		0x16, 0x03, 0x03, 0x00, 0x50, // TLS record header (handshake, TLS 1.2, length 80)
+		0x01, 0x00, 0x00, 0x4c, 0x03, 0x03, // ClientHello header
+		// 32-byte random
+		0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
+		0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
+		0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
+		0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
+		'\n', // terminate the "line" so readBanner completes
+	}
+
+	addr := serveOnce(t, func(conn net.Conn) {
+		_, _ = conn.Write(tlsHello)
+	})
+
+	result := dialAndProbe(t, addr)
+	if result.Error == nil {
+		t.Error("expected error: TLS ClientHello is not a valid SSH banner")
+	}
+}
+
+// TestAdversarial_SixNonKEXINITPackets — server sends 6 non-KEXINIT packets,
+// exceeding the 5-packet skip tolerance (maxSkip=5). The probe must error.
+func TestAdversarial_SixNonKEXINITPackets(t *testing.T) {
+	// SSH_MSG_IGNORE = 2 (a valid non-KEXINIT packet type).
+	ignorePayload := []byte{2, 0, 0, 0, 0}
+
+	addr := serveOnce(t, func(conn net.Conn) {
+		_, _ = conn.Write([]byte("SSH-2.0-NoKEX_1.0\r\n"))
+		buf := make([]byte, 512)
+		_, _ = conn.Read(buf)
+		for i := 0; i < 6; i++ {
+			_, _ = conn.Write(buildSSHPacket(ignorePayload))
+		}
+	})
+
+	result := dialAndProbe(t, addr)
+	if result.Error == nil {
+		t.Error("expected error after 6 non-KEXINIT packets (exceeds maxSkip=5)")
+	}
+}
+
+// TestAdversarial_BillionNonASCIIBannerPreamble — server sends a large block of
+// non-ASCII bytes before the SSH banner line. The probe caps reads at
+// maxBannerLen+2 bytes, so it must error long before reading 1 billion bytes.
+func TestAdversarial_BillionNonASCIIBannerPreamble(t *testing.T) {
+	// We can't actually send 1 billion bytes in a unit test. Instead, we send
+	// maxBannerLen*2 non-ASCII bytes without a newline, verifying the probe
+	// caps out promptly. The server closes after sending to avoid blocking.
+	nonASCII := bytes.Repeat([]byte{0xFF}, maxBannerLen*2+100)
+	addr := serveOnce(t, func(conn net.Conn) {
+		_, _ = conn.Write(nonASCII)
+	})
+
+	start := time.Now()
+	result := dialAndProbe(t, addr)
+	elapsed := time.Since(start)
+
+	if result.Error == nil {
+		t.Error("expected error for non-ASCII preamble (no newline within cap), got nil")
+	}
+	// Must complete promptly — the cap limits how much data is read.
+	if elapsed > 3*time.Second {
+		t.Errorf("probe took %v reading non-ASCII preamble; should cap immediately", elapsed)
+	}
+}
+
+// TestAdversarial_FiveNonKEXINITThenKEXINIT — server sends exactly 5 non-KEXINIT
+// packets then a valid KEXINIT. The probe must succeed (5 = maxSkip-1, which is
+// still within tolerance since the loop iterates for skip 0..4).
+func TestAdversarial_FiveNonKEXINITThenKEXINIT(t *testing.T) {
+	ignorePayload := []byte{2, 0, 0, 0, 0} // SSH_MSG_IGNORE
+
+	methods := []string{"mlkem768x25519-sha256", "curve25519-sha256"}
+
+	addr := serveOnce(t, func(conn net.Conn) {
+		_, _ = conn.Write([]byte("SSH-2.0-Tolerant_1.0\r\n"))
+		buf := make([]byte, 512)
+		_, _ = conn.Read(buf)
+		// Send 4 non-KEXINIT packets (skip values 0..3), then KEXINIT on skip=4.
+		for i := 0; i < 4; i++ {
+			_, _ = conn.Write(buildSSHPacket(ignorePayload))
+		}
+		_, _ = conn.Write(buildKEXInitPacket(methods))
+	})
+
+	result := dialAndProbe(t, addr)
+	if result.Error != nil {
+		t.Errorf("expected success with 4 non-KEXINIT then KEXINIT, got: %v", result.Error)
+	}
+	if len(result.KEXMethods) != len(methods) {
+		t.Errorf("KEXMethods len=%d; want %d", len(result.KEXMethods), len(methods))
+	}
+}
+
+// buildKEXInitPayloadRaw builds a KEXINIT payload with a raw name-list content
+// bytes (not comma-joined from a []string). Used for adversarial inputs.
+func buildKEXInitPayloadRaw(kexBytes []byte) []byte {
+	var buf []byte
+	buf = append(buf, sshMsgKexInit)
+	buf = append(buf, make([]byte, kexinitCookieLen)...)
+
+	// Name-list length prefix + raw bytes.
+	lenBuf := make([]byte, 4)
+	binary.BigEndian.PutUint32(lenBuf, uint32(len(kexBytes)))
+	buf = append(buf, lenBuf...)
+	buf = append(buf, kexBytes...)
+
+	// 9 empty name-lists.
+	emptyList := encodeNameList(nil)
+	for i := 0; i < kexinitNameListCount-1; i++ {
+		buf = append(buf, emptyList...)
+	}
+
+	// first_kex_packet_follows + reserved.
+	buf = append(buf, 0, 0, 0, 0, 0)
+	return buf
+}

--- a/pkg/engines/sshprobe/backcompat_test.go
+++ b/pkg/engines/sshprobe/backcompat_test.go
@@ -1,0 +1,353 @@
+// backcompat_test.go — backward-compatibility tests across Sprint 0–4.
+//
+// Purpose: verify that adding Sprint 4 ssh-probe findings to a ScanResult does
+// not break serialization of Sprint 0/1/2/3 fields. Specifically:
+//   - Sprint 0: HNDLRisk, Severity, QuantumRisk (Mosca/QRS fields)
+//   - Sprint 1: PQCPresent, PQCMaturity, NegotiatedGroup, NegotiatedGroupName (TLS probe)
+//   - Sprint 2: PartialInventory, PartialInventoryReason, HandshakeVolumeClass,
+//               HandshakeBytes (ECH + volume classification)
+//   - Sprint 3: no new UnifiedFinding fields (CT lookup output is findings too)
+//   - Sprint 4: PQCPresent, PQCMaturity (SSH probe reuses Sprint 1 fields — no
+//               new fields added, pure additive via SourceEngine="ssh-probe")
+//
+// These tests ensure the json struct tags and omitempty annotations on
+// UnifiedFinding have not regressed as Sprint 4 code landed.
+package sshprobe
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/findings"
+)
+
+// TestBackcompat_Sprint0_HNDLAndSeverityFields verifies that HNDLRisk, Severity,
+// and QuantumRisk (Sprint 0 scoring fields) round-trip correctly through JSON.
+func TestBackcompat_Sprint0_HNDLAndSeverityFields(t *testing.T) {
+	f := findings.UnifiedFinding{
+		Location:    findings.Location{File: "/src/rsa.go", Line: 10},
+		Algorithm:   &findings.Algorithm{Name: "RSA-2048", Primitive: "asymmetric", KeySize: 2048},
+		SourceEngine: "cipherscope",
+		Confidence:  findings.ConfidenceHigh,
+		Reachable:   findings.ReachableYes,
+		QuantumRisk: findings.QRVulnerable,
+		Severity:    findings.SevCritical,
+		HNDLRisk:    "immediate",
+	}
+
+	b, err := json.Marshal(f)
+	if err != nil {
+		t.Fatalf("json.Marshal Sprint 0 finding: %v", err)
+	}
+
+	var got findings.UnifiedFinding
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("json.Unmarshal Sprint 0 finding: %v", err)
+	}
+
+	if got.QuantumRisk != findings.QRVulnerable {
+		t.Errorf("Sprint 0 QuantumRisk=%q, want %q", got.QuantumRisk, findings.QRVulnerable)
+	}
+	if got.Severity != findings.SevCritical {
+		t.Errorf("Sprint 0 Severity=%q, want %q", got.Severity, findings.SevCritical)
+	}
+	if got.HNDLRisk != "immediate" {
+		t.Errorf("Sprint 0 HNDLRisk=%q, want immediate", got.HNDLRisk)
+	}
+}
+
+// TestBackcompat_Sprint1_TLSProbeFields verifies that Sprint 1 TLS probe fields
+// (NegotiatedGroup, NegotiatedGroupName, PQCPresent, PQCMaturity) survive JSON
+// round-trip when co-located with Sprint 4 SSH probe findings in the same output.
+func TestBackcompat_Sprint1_TLSProbeFields(t *testing.T) {
+	tlsFinding := findings.UnifiedFinding{
+		Location:            findings.Location{File: "(tls-probe)/example.com:443#kex", ArtifactType: "tls-endpoint"},
+		Algorithm:           &findings.Algorithm{Name: "X25519MLKEM768", Primitive: "key-exchange"},
+		SourceEngine:        "tls-probe",
+		Confidence:          findings.ConfidenceHigh,
+		Reachable:           findings.ReachableYes,
+		QuantumRisk:         findings.QRSafe,
+		NegotiatedGroup:     0x11EC,
+		NegotiatedGroupName: "X25519MLKEM768",
+		PQCPresent:          true,
+		PQCMaturity:         "final",
+	}
+	sshFinding := findings.UnifiedFinding{
+		Location:    findings.Location{File: "(ssh-probe)/example.com:22#kex", ArtifactType: "ssh-endpoint"},
+		Algorithm:   &findings.Algorithm{Name: "mlkem768x25519-sha256", Primitive: "kex"},
+		SourceEngine: "ssh-probe",
+		Confidence:  findings.ConfidenceHigh,
+		Reachable:   findings.ReachableYes,
+		QuantumRisk: findings.QRSafe,
+		PQCPresent:  true,
+		PQCMaturity: "final",
+		// NegotiatedGroup intentionally 0 — SSH probe does not populate this field.
+	}
+
+	pair := []findings.UnifiedFinding{tlsFinding, sshFinding}
+	b, err := json.Marshal(pair)
+	if err != nil {
+		t.Fatalf("json.Marshal Sprint 1+4 findings: %v", err)
+	}
+
+	var got []findings.UnifiedFinding
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("json.Unmarshal Sprint 1+4 findings: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(got))
+	}
+
+	// TLS finding: NegotiatedGroup must still be set.
+	if got[0].NegotiatedGroup != 0x11EC {
+		t.Errorf("Sprint 1 NegotiatedGroup=0x%04x, want 0x11EC", got[0].NegotiatedGroup)
+	}
+	if got[0].NegotiatedGroupName != "X25519MLKEM768" {
+		t.Errorf("Sprint 1 NegotiatedGroupName=%q, want X25519MLKEM768", got[0].NegotiatedGroupName)
+	}
+	if !got[0].PQCPresent {
+		t.Error("Sprint 1 PQCPresent=false after round-trip, want true")
+	}
+	if got[0].PQCMaturity != "final" {
+		t.Errorf("Sprint 1 PQCMaturity=%q, want final", got[0].PQCMaturity)
+	}
+
+	// SSH finding: NegotiatedGroup must remain 0 (not set by SSH probe).
+	if got[1].NegotiatedGroup != 0 {
+		t.Errorf("Sprint 4 SSH finding NegotiatedGroup=0x%04x, want 0", got[1].NegotiatedGroup)
+	}
+	if !got[1].PQCPresent {
+		t.Error("Sprint 4 SSH finding PQCPresent=false after round-trip, want true")
+	}
+}
+
+// TestBackcompat_Sprint2_ECHAndVolumeFields verifies that Sprint 2 partial-inventory
+// and handshake-volume fields survive JSON round-trip.
+func TestBackcompat_Sprint2_ECHAndVolumeFields(t *testing.T) {
+	f := findings.UnifiedFinding{
+		Location:               findings.Location{File: "(tls-probe)/ech.example.com:443#kex", ArtifactType: "tls-endpoint"},
+		Algorithm:              &findings.Algorithm{Name: "ECDHE", Primitive: "key-exchange"},
+		SourceEngine:           "tls-probe",
+		Confidence:             findings.ConfidenceMedium,
+		Reachable:              findings.ReachableYes,
+		QuantumRisk:            findings.QRVulnerable,
+		PartialInventory:       true,
+		PartialInventoryReason: "ECH_ENABLED",
+		HandshakeVolumeClass:   "hybrid-kem",
+		HandshakeBytes:         8500,
+	}
+
+	b, err := json.Marshal(f)
+	if err != nil {
+		t.Fatalf("json.Marshal Sprint 2 finding: %v", err)
+	}
+
+	var got findings.UnifiedFinding
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("json.Unmarshal Sprint 2 finding: %v", err)
+	}
+
+	if !got.PartialInventory {
+		t.Error("Sprint 2 PartialInventory=false after round-trip, want true")
+	}
+	if got.PartialInventoryReason != "ECH_ENABLED" {
+		t.Errorf("Sprint 2 PartialInventoryReason=%q, want ECH_ENABLED", got.PartialInventoryReason)
+	}
+	if got.HandshakeVolumeClass != "hybrid-kem" {
+		t.Errorf("Sprint 2 HandshakeVolumeClass=%q, want hybrid-kem", got.HandshakeVolumeClass)
+	}
+	if got.HandshakeBytes != 8500 {
+		t.Errorf("Sprint 2 HandshakeBytes=%d, want 8500", got.HandshakeBytes)
+	}
+}
+
+// TestBackcompat_Sprint4_AdditiveOnly verifies that Sprint 4 ssh-probe findings
+// use no new JSON fields beyond what was already defined in Sprints 0–3.
+// Concretely: marshal a Sprint 4 SSH finding and assert the raw JSON keys are a
+// strict subset of the known UnifiedFinding schema.
+func TestBackcompat_Sprint4_AdditiveOnly(t *testing.T) {
+	sshFinding := findings.UnifiedFinding{
+		Location:    findings.Location{File: "(ssh-probe)/203.0.113.1:22#kex", ArtifactType: "ssh-endpoint"},
+		Algorithm:   &findings.Algorithm{Name: "mlkem768x25519-sha256", Primitive: "kex"},
+		SourceEngine: "ssh-probe",
+		Confidence:  findings.ConfidenceHigh,
+		Reachable:   findings.ReachableYes,
+		QuantumRisk: findings.QRSafe,
+		Severity:    findings.SevInfo,
+		PQCPresent:  true,
+		PQCMaturity: "final",
+		Recommendation: "PQC-capable KEX method advertised. No migration required.",
+		RawIdentifier:  "ssh-kex:mlkem768x25519-sha256|203.0.113.1:22",
+	}
+
+	b, err := json.Marshal(sshFinding)
+	if err != nil {
+		t.Fatalf("json.Marshal Sprint 4 finding: %v", err)
+	}
+
+	// Unmarshal into a raw map to inspect keys.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		t.Fatalf("json.Unmarshal to map: %v", err)
+	}
+
+	// All field names must match the documented UnifiedFinding schema.
+	// Sprint 4 must not introduce any new top-level JSON keys.
+	knownKeys := map[string]bool{
+		"location":               true,
+		"algorithm":              true,
+		"dependency":             true,
+		"confidence":             true,
+		"sourceEngine":           true,
+		"corroboratedBy":         true,
+		"reachable":              true,
+		"rawIdentifier":          true,
+		"quantumRisk":            true,
+		"severity":               true,
+		"recommendation":         true,
+		"dataFlowPath":           true,
+		"hndlRisk":               true,
+		"priority":               true,
+		"blastRadius":            true,
+		"testFile":               true,
+		"generatedFile":          true,
+		"migrationEffort":        true,
+		"targetAlgorithm":        true,
+		"targetStandard":         true,
+		"migrationSnippet":       true,
+		"negotiatedGroup":        true, // Sprint 1 TLS
+		"negotiatedGroupName":    true, // Sprint 1 TLS
+		"pqcPresent":             true, // Sprint 1 TLS; reused by Sprint 4 SSH
+		"pqcMaturity":            true, // Sprint 1 TLS; reused by Sprint 4 SSH
+		"partialInventory":       true, // Sprint 2
+		"partialInventoryReason": true, // Sprint 2
+		"handshakeVolumeClass":   true, // Sprint 2
+		"handshakeBytes":         true, // Sprint 2
+	}
+
+	for key := range raw {
+		if !knownKeys[key] {
+			t.Errorf("Sprint 4 SSH finding introduces unknown JSON key %q — "+
+				"Sprint 4 must be purely additive with no new top-level fields", key)
+		}
+	}
+}
+
+// TestBackcompat_AllSprints_FullRoundTrip performs a joint round-trip across
+// all sprint fields in a single JSON array, asserting no cross-sprint interference.
+func TestBackcompat_AllSprints_FullRoundTrip(t *testing.T) {
+	all := []findings.UnifiedFinding{
+		// Sprint 0: classical vulnerable with HNDL risk
+		{
+			Location:    findings.Location{File: "/src/rsa.go", Line: 5},
+			Algorithm:   &findings.Algorithm{Name: "RSA-2048", Primitive: "asymmetric", KeySize: 2048},
+			SourceEngine: "cipherscope",
+			Confidence:  findings.ConfidenceHigh,
+			Reachable:   findings.ReachableYes,
+			QuantumRisk: findings.QRVulnerable,
+			Severity:    findings.SevCritical,
+			HNDLRisk:    "immediate",
+		},
+		// Sprint 1: TLS hybrid KEX
+		{
+			Location:            findings.Location{File: "(tls-probe)/example.com:443#kex", ArtifactType: "tls-endpoint"},
+			Algorithm:           &findings.Algorithm{Name: "X25519MLKEM768", Primitive: "key-exchange"},
+			SourceEngine:        "tls-probe",
+			Confidence:          findings.ConfidenceHigh,
+			Reachable:           findings.ReachableYes,
+			QuantumRisk:         findings.QRSafe,
+			NegotiatedGroup:     0x11EC,
+			NegotiatedGroupName: "X25519MLKEM768",
+			PQCPresent:          true,
+			PQCMaturity:         "final",
+		},
+		// Sprint 2: ECH partial inventory
+		{
+			Location:               findings.Location{File: "(tls-probe)/ech.example.com:443#kex", ArtifactType: "tls-endpoint"},
+			Algorithm:              &findings.Algorithm{Name: "ECDHE", Primitive: "key-exchange"},
+			SourceEngine:           "tls-probe",
+			Confidence:             findings.ConfidenceMedium,
+			Reachable:              findings.ReachableYes,
+			QuantumRisk:            findings.QRVulnerable,
+			PartialInventory:       true,
+			PartialInventoryReason: "ECH_ENABLED",
+			HandshakeVolumeClass:   "classical",
+			HandshakeBytes:         6200,
+		},
+		// Sprint 4: SSH PQC KEX
+		{
+			Location:    findings.Location{File: "(ssh-probe)/203.0.113.1:22#kex", ArtifactType: "ssh-endpoint"},
+			Algorithm:   &findings.Algorithm{Name: "mlkem768x25519-sha256", Primitive: "kex"},
+			SourceEngine: "ssh-probe",
+			Confidence:  findings.ConfidenceHigh,
+			Reachable:   findings.ReachableYes,
+			QuantumRisk: findings.QRSafe,
+			PQCPresent:  true,
+			PQCMaturity: "final",
+		},
+		// Sprint 4: SSH classical KEX
+		{
+			Location:    findings.Location{File: "(ssh-probe)/203.0.113.1:22#kex", ArtifactType: "ssh-endpoint"},
+			Algorithm:   &findings.Algorithm{Name: "diffie-hellman-group14-sha256", Primitive: "kex"},
+			SourceEngine: "ssh-probe",
+			Confidence:  findings.ConfidenceHigh,
+			Reachable:   findings.ReachableYes,
+			QuantumRisk: findings.QRVulnerable,
+			Severity:    findings.SevHigh,
+			PQCPresent:  false,
+		},
+	}
+
+	b, err := json.Marshal(all)
+	if err != nil {
+		t.Fatalf("json.Marshal all-sprint findings: %v", err)
+	}
+	var got []findings.UnifiedFinding
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("json.Unmarshal all-sprint findings: %v", err)
+	}
+	if len(got) != len(all) {
+		t.Fatalf("expected %d findings, got %d", len(all), len(got))
+	}
+
+	// Sprint 0 — HNDL risk preserved.
+	if got[0].HNDLRisk != "immediate" {
+		t.Errorf("Sprint 0 HNDLRisk=%q, want immediate", got[0].HNDLRisk)
+	}
+
+	// Sprint 1 — TLS group preserved.
+	if got[1].NegotiatedGroup != 0x11EC {
+		t.Errorf("Sprint 1 NegotiatedGroup=0x%04x, want 0x11EC", got[1].NegotiatedGroup)
+	}
+	if got[1].NegotiatedGroupName != "X25519MLKEM768" {
+		t.Errorf("Sprint 1 NegotiatedGroupName=%q, want X25519MLKEM768", got[1].NegotiatedGroupName)
+	}
+
+	// Sprint 2 — ECH fields preserved.
+	if !got[2].PartialInventory {
+		t.Error("Sprint 2 PartialInventory=false after round-trip")
+	}
+	if got[2].HandshakeBytes != 6200 {
+		t.Errorf("Sprint 2 HandshakeBytes=%d, want 6200", got[2].HandshakeBytes)
+	}
+
+	// Sprint 4 SSH PQC — reuses Sprint 1 PQC fields, NegotiatedGroup must be 0.
+	if !got[3].PQCPresent {
+		t.Error("Sprint 4 SSH PQCPresent=false after round-trip, want true")
+	}
+	if got[3].NegotiatedGroup != 0 {
+		t.Errorf("Sprint 4 SSH NegotiatedGroup=0x%04x, want 0", got[3].NegotiatedGroup)
+	}
+	if got[3].SourceEngine != "ssh-probe" {
+		t.Errorf("Sprint 4 SSH SourceEngine=%q, want ssh-probe", got[3].SourceEngine)
+	}
+
+	// Sprint 4 SSH classical — PQCPresent=false, no NegotiatedGroup.
+	if got[4].PQCPresent {
+		t.Error("Sprint 4 classical SSH PQCPresent=true after round-trip, want false")
+	}
+	if !strings.Contains(got[4].Algorithm.Name, "diffie-hellman") {
+		t.Errorf("Sprint 4 classical method name=%q", got[4].Algorithm.Name)
+	}
+}

--- a/pkg/engines/sshprobe/classify.go
+++ b/pkg/engines/sshprobe/classify.go
@@ -1,0 +1,85 @@
+package sshprobe
+
+import (
+	"fmt"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/findings"
+	"github.com/jimbo111/open-quantum-secure/pkg/quantum"
+)
+
+const engineName = "ssh-probe"
+
+// kexInitToFindings converts a ProbeResult into one UnifiedFinding per KEX method
+// advertised by the server in its SSH_MSG_KEXINIT. Each finding carries the quantum
+// risk classification derived from the method name.
+func kexInitToFindings(result ProbeResult) []findings.UnifiedFinding {
+	if result.Error != nil {
+		return nil
+	}
+
+	basePath := fmt.Sprintf("(ssh-probe)/%s", result.Target)
+	var ff []findings.UnifiedFinding
+
+	for _, method := range result.KEXMethods {
+		if method == "" {
+			continue
+		}
+
+		info := classifyKex(method)
+
+		// For PQC-safe SSH KEX methods (e.g. mlkem768x25519-sha256) ClassifyAlgorithm
+		// returns RiskUnknown because it has no SSH-specific entry — kex.go is the
+		// authoritative source. We use ClassifyAlgorithm only for classical method
+		// names that map to quantum-vulnerable families (DH, ECDH, X25519, etc.).
+		c := quantum.ClassifyAlgorithm(method, "kex", 0)
+
+		// Override: if our kex table marks the method as PQC-present, trust it over
+		// the generic classifier which may not know SSH-specific name formats.
+		if info.pqcPresent {
+			c.Risk = quantum.RiskSafe
+			c.Severity = quantum.SeverityInfo
+			c.Recommendation = "PQC-capable KEX method advertised. No migration required."
+			c.HNDLRisk = ""
+		}
+
+		f := findings.UnifiedFinding{
+			Location: findings.Location{
+				File:         basePath + "#kex",
+				Line:         0,
+				ArtifactType: "ssh-endpoint",
+			},
+			Algorithm: &findings.Algorithm{
+				Name:      method,
+				Primitive: "kex",
+			},
+			Confidence:   findings.ConfidenceHigh,
+			SourceEngine: engineName,
+			Reachable:    findings.ReachableYes,
+			RawIdentifier: fmt.Sprintf("ssh-kex:%s|%s", method, result.Target),
+			QuantumRisk:  findings.QuantumRisk(c.Risk),
+			Severity:     findings.Severity(c.Severity),
+			PQCPresent:   info.pqcPresent,
+			PQCMaturity:  info.maturity,
+		}
+
+		if c.Recommendation != "" {
+			f.Recommendation = c.Recommendation
+		}
+		if c.HNDLRisk != "" {
+			f.HNDLRisk = c.HNDLRisk
+		}
+		if c.TargetAlgorithm != "" {
+			f.TargetAlgorithm = c.TargetAlgorithm
+		}
+		if c.TargetStandard != "" {
+			f.TargetStandard = c.TargetStandard
+		}
+		if c.MigrationEffort != "" {
+			f.MigrationEffort = c.MigrationEffort
+		}
+
+		ff = append(ff, f)
+	}
+
+	return ff
+}

--- a/pkg/engines/sshprobe/classify_test.go
+++ b/pkg/engines/sshprobe/classify_test.go
@@ -1,0 +1,118 @@
+package sshprobe
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/findings"
+)
+
+func TestKexInitToFindings_NMethodsYieldNFindings(t *testing.T) {
+	methods := []string{
+		"mlkem768x25519-sha256",
+		"sntrup761x25519-sha512@openssh.com",
+		"curve25519-sha256",
+		"diffie-hellman-group14-sha256",
+		"ecdh-sha2-nistp256",
+	}
+	result := ProbeResult{
+		Target:     "198.51.100.1:22",
+		ServerID:   "SSH-2.0-OpenSSH_10.0",
+		KEXMethods: methods,
+	}
+	ff := kexInitToFindings(result)
+	if len(ff) != len(methods) {
+		t.Fatalf("got %d findings; want %d", len(ff), len(methods))
+	}
+	for i, f := range ff {
+		if f.Algorithm == nil {
+			t.Fatalf("finding[%d] has nil Algorithm", i)
+		}
+		if f.Algorithm.Name != methods[i] {
+			t.Errorf("finding[%d].Algorithm.Name = %q; want %q", i, f.Algorithm.Name, methods[i])
+		}
+		if f.Algorithm.Primitive != "kex" {
+			t.Errorf("finding[%d].Primitive = %q; want kex", i, f.Algorithm.Primitive)
+		}
+		if f.SourceEngine != engineName {
+			t.Errorf("finding[%d].SourceEngine = %q; want %q", i, f.SourceEngine, engineName)
+		}
+		if f.Confidence != findings.ConfidenceHigh {
+			t.Errorf("finding[%d].Confidence = %q; want high", i, f.Confidence)
+		}
+		if f.Reachable != findings.ReachableYes {
+			t.Errorf("finding[%d].Reachable = %q; want yes", i, f.Reachable)
+		}
+		if !strings.HasPrefix(f.Location.File, "(ssh-probe)/") {
+			t.Errorf("finding[%d].Location.File = %q; want (ssh-probe)/... prefix", i, f.Location.File)
+		}
+		if f.Location.ArtifactType != "ssh-endpoint" {
+			t.Errorf("finding[%d].ArtifactType = %q; want ssh-endpoint", i, f.Location.ArtifactType)
+		}
+		if !strings.Contains(f.RawIdentifier, methods[i]) {
+			t.Errorf("finding[%d].RawIdentifier does not contain method name", i)
+		}
+	}
+}
+
+func TestKexInitToFindings_QuantumRiskMapping(t *testing.T) {
+	cases := []struct {
+		method      string
+		wantPQC     bool
+		wantSafe    bool
+	}{
+		{"mlkem768x25519-sha256", true, true},
+		{"sntrup761x25519-sha512@openssh.com", true, true},
+		{"curve25519-sha256", false, false},
+		{"diffie-hellman-group14-sha256", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.method, func(t *testing.T) {
+			result := ProbeResult{
+				Target:     "203.0.113.1:22",
+				ServerID:   "SSH-2.0-test",
+				KEXMethods: []string{tc.method},
+			}
+			ff := kexInitToFindings(result)
+			if len(ff) != 1 {
+				t.Fatalf("expected 1 finding, got %d", len(ff))
+			}
+			f := ff[0]
+			if f.PQCPresent != tc.wantPQC {
+				t.Errorf("PQCPresent = %v; want %v", f.PQCPresent, tc.wantPQC)
+			}
+			isSafe := f.QuantumRisk == findings.QRSafe
+			if isSafe != tc.wantSafe {
+				t.Errorf("QuantumRisk = %q; wantSafe=%v", f.QuantumRisk, tc.wantSafe)
+			}
+		})
+	}
+}
+
+func TestKexInitToFindings_SkipsEmptyMethod(t *testing.T) {
+	result := ProbeResult{
+		Target:     "203.0.113.2:22",
+		ServerID:   "SSH-2.0-test",
+		KEXMethods: []string{"", "curve25519-sha256", ""},
+	}
+	ff := kexInitToFindings(result)
+	if len(ff) != 1 {
+		t.Errorf("expected 1 finding (skipping empty methods), got %d", len(ff))
+	}
+}
+
+func TestKexInitToFindings_TargetInFilePath(t *testing.T) {
+	target := "203.0.113.3:22"
+	result := ProbeResult{
+		Target:     target,
+		ServerID:   "SSH-2.0-test",
+		KEXMethods: []string{"curve25519-sha256"},
+	}
+	ff := kexInitToFindings(result)
+	if len(ff) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(ff))
+	}
+	if !strings.Contains(ff[0].Location.File, target) {
+		t.Errorf("Location.File %q does not contain target %q", ff[0].Location.File, target)
+	}
+}

--- a/pkg/engines/sshprobe/engine.go
+++ b/pkg/engines/sshprobe/engine.go
@@ -1,0 +1,107 @@
+package sshprobe
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/engines"
+	"github.com/jimbo111/open-quantum-secure/pkg/findings"
+)
+
+const (
+	// maxConcurrency caps simultaneous SSH probes. >5 concurrent probes risk
+	// triggering server-side rate limiting or connection throttling — mirrors
+	// the empirical bound from tls-probe (Sprint 2 M1).
+	maxConcurrency = 5
+
+	// maxTargets is a sanity cap to prevent accidental mass-scanning.
+	maxTargets = 100
+)
+
+// Engine probes live SSH endpoints and detects quantum-vulnerable KEX methods
+// in their SSH_MSG_KEXINIT advertisement. Pure Go, always available.
+type Engine struct{}
+
+// New returns a new SSH probe Engine.
+func New() *Engine { return &Engine{} }
+
+func (e *Engine) Name() string                { return engineName }
+func (e *Engine) Tier() engines.Tier          { return engines.Tier5Network }
+func (e *Engine) SupportedLanguages() []string { return nil }
+func (e *Engine) Available() bool             { return true }
+func (e *Engine) Version() string             { return "embedded" }
+
+// Scan probes each target in opts.SSHTargets and returns findings for
+// quantum-vulnerable KEX methods observed in SSH_MSG_KEXINIT.
+// Returns nil immediately when NoNetwork is true or SSHTargets is empty.
+func (e *Engine) Scan(ctx context.Context, opts engines.ScanOptions) ([]findings.UnifiedFinding, error) {
+	if opts.NoNetwork {
+		return nil, nil
+	}
+	if len(opts.SSHTargets) == 0 {
+		return nil, nil
+	}
+	if len(opts.SSHTargets) > maxTargets {
+		return nil, fmt.Errorf("ssh-probe: too many targets (%d), maximum is %d", len(opts.SSHTargets), maxTargets)
+	}
+
+	timeout := defaultTimeout
+	if opts.SSHTimeout > 0 {
+		timeout = time.Duration(opts.SSHTimeout) * time.Second
+	}
+
+	results := make([]ProbeResult, len(opts.SSHTargets))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, maxConcurrency)
+
+	for i, target := range opts.SSHTargets {
+		if ctx.Err() != nil {
+			break
+		}
+		// Acquire semaphore in parent goroutine — prevents bursting beyond cap even
+		// momentarily (mirrors tls-probe M1 pattern from Sprint 2).
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			break
+		}
+		if ctx.Err() != nil {
+			break
+		}
+		wg.Add(1)
+		go func(idx int, t string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			if ctx.Err() != nil {
+				return
+			}
+			results[idx] = probeFn(ctx, t, timeout)
+		}(i, target)
+	}
+	wg.Wait()
+
+	var allFindings []findings.UnifiedFinding
+	var reachable, unreachable int
+
+	for _, r := range results {
+		if r.Error != nil {
+			unreachable++
+			fmt.Fprintf(os.Stderr, "WARNING: ssh-probe: %s: %v\n", r.Target, r.Error)
+			continue
+		}
+		reachable++
+		allFindings = append(allFindings, kexInitToFindings(r)...)
+	}
+
+	fmt.Fprintf(os.Stderr, "SSH Probe: probed %d target(s) — %d reachable, %d unreachable\n",
+		len(opts.SSHTargets), reachable, unreachable)
+
+	if reachable == 0 && unreachable > 0 {
+		return allFindings, fmt.Errorf("ssh-probe: all %d target(s) unreachable", unreachable)
+	}
+
+	return allFindings, nil
+}

--- a/pkg/engines/sshprobe/engine.go
+++ b/pkg/engines/sshprobe/engine.go
@@ -28,11 +28,11 @@ type Engine struct{}
 // New returns a new SSH probe Engine.
 func New() *Engine { return &Engine{} }
 
-func (e *Engine) Name() string                { return engineName }
-func (e *Engine) Tier() engines.Tier          { return engines.Tier5Network }
+func (e *Engine) Name() string                 { return engineName }
+func (e *Engine) Tier() engines.Tier           { return engines.Tier5Network }
 func (e *Engine) SupportedLanguages() []string { return nil }
-func (e *Engine) Available() bool             { return true }
-func (e *Engine) Version() string             { return "embedded" }
+func (e *Engine) Available() bool              { return true }
+func (e *Engine) Version() string              { return "embedded" }
 
 // Scan probes each target in opts.SSHTargets and returns findings for
 // quantum-vulnerable KEX methods observed in SSH_MSG_KEXINIT.
@@ -57,28 +57,27 @@ func (e *Engine) Scan(ctx context.Context, opts engines.ScanOptions) ([]findings
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, maxConcurrency)
 
+	// A5: Track how many goroutines were launched so the summary accurately
+	// reflects probed targets when the context is cancelled mid-scan.
+	var launched int
+
+	// A4: labelled loop so the select's ctx.Done case can break out of the
+	// for-range, not just out of the select statement.
+outer:
 	for i, target := range opts.SSHTargets {
-		if ctx.Err() != nil {
-			break
-		}
 		// Acquire semaphore in parent goroutine — prevents bursting beyond cap even
 		// momentarily (mirrors tls-probe M1 pattern from Sprint 2).
 		select {
 		case sem <- struct{}{}:
 		case <-ctx.Done():
-			break
+			break outer // A4: exits the for-range, not just the select
 		}
-		if ctx.Err() != nil {
-			break
-		}
+		launched++ // A5: count only goroutines that actually start
 		wg.Add(1)
 		go func(idx int, t string) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			if ctx.Err() != nil {
-				return
-			}
-			results[idx] = probeFn(ctx, t, timeout)
+			results[idx] = probeFn(ctx, t, timeout, opts.SSHDenyPrivate)
 		}(i, target)
 	}
 	wg.Wait()
@@ -86,7 +85,9 @@ func (e *Engine) Scan(ctx context.Context, opts engines.ScanOptions) ([]findings
 	var allFindings []findings.UnifiedFinding
 	var reachable, unreachable int
 
-	for _, r := range results {
+	// A5: Iterate only launched results — zero-value slots beyond launched are
+	// targets that were never started due to context cancellation.
+	for _, r := range results[:launched] {
 		if r.Error != nil {
 			unreachable++
 			fmt.Fprintf(os.Stderr, "WARNING: ssh-probe: %s: %v\n", r.Target, r.Error)
@@ -97,10 +98,10 @@ func (e *Engine) Scan(ctx context.Context, opts engines.ScanOptions) ([]findings
 	}
 
 	fmt.Fprintf(os.Stderr, "SSH Probe: probed %d target(s) — %d reachable, %d unreachable\n",
-		len(opts.SSHTargets), reachable, unreachable)
+		launched, reachable, unreachable)
 
 	if reachable == 0 && unreachable > 0 {
-		return allFindings, fmt.Errorf("ssh-probe: all %d target(s) unreachable", unreachable)
+		return nil, fmt.Errorf("ssh-probe: all %d target(s) unreachable", unreachable) // B5: return nil, not partial allFindings
 	}
 
 	return allFindings, nil

--- a/pkg/engines/sshprobe/engine_nonetwork_test.go
+++ b/pkg/engines/sshprobe/engine_nonetwork_test.go
@@ -1,0 +1,111 @@
+// engine_nonetwork_test.go — invariant tests for the NoNetwork kill-switch.
+//
+// Purpose: verify that when opts.NoNetwork=true, the Scan method returns
+// (nil, nil) immediately without invoking probeFn or opening any network
+// connections. This mirrors the tls-probe pattern from Sprint 2 M1.
+//
+// Seam: probeFn (package-level var in probe.go) is overridden with a
+// panicDialer that panics if ever called, proving the no-network gate fires
+// before any probe attempt.
+package sshprobe
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/engines"
+)
+
+// panicProbe is injected as probeFn when NoNetwork=true.
+// If it is ever called, the test fails (and panics to make the failure obvious).
+func panicProbe(ctx context.Context, target string, timeout time.Duration) ProbeResult {
+	panic("probeFn called with NoNetwork=true — engine must short-circuit before reaching the probe")
+}
+
+// TestNoNetwork_ShortCircuits verifies that NoNetwork=true causes Scan to return
+// (nil, nil) without calling probeFn.
+func TestNoNetwork_ShortCircuits(t *testing.T) {
+	original := probeFn
+	probeFn = panicProbe
+	defer func() { probeFn = original }()
+
+	e := New()
+	ff, err := e.Scan(context.Background(), engines.ScanOptions{
+		SSHTargets: []string{"example.com:22"},
+		NoNetwork:  true,
+	})
+	if err != nil {
+		t.Errorf("expected nil error with NoNetwork=true, got: %v", err)
+	}
+	if ff != nil {
+		t.Errorf("expected nil findings with NoNetwork=true, got %d findings", len(ff))
+	}
+}
+
+// TestNoNetwork_EmptyTargets_ShortCircuits verifies that an empty target list
+// also short-circuits before probeFn (separate early-return path).
+func TestNoNetwork_EmptyTargets_ShortCircuits(t *testing.T) {
+	original := probeFn
+	probeFn = panicProbe
+	defer func() { probeFn = original }()
+
+	e := New()
+	ff, err := e.Scan(context.Background(), engines.ScanOptions{
+		SSHTargets: nil,
+		NoNetwork:  false, // not NoNetwork — empty target list triggers a different guard
+	})
+	if err != nil {
+		t.Errorf("expected nil error for empty targets, got: %v", err)
+	}
+	if ff != nil {
+		t.Errorf("expected nil findings for empty targets, got %d findings", len(ff))
+	}
+}
+
+// TestNoNetwork_WithMultipleTargets verifies that even with many targets set,
+// NoNetwork=true blocks all probes.
+func TestNoNetwork_WithMultipleTargets(t *testing.T) {
+	original := probeFn
+	probeFn = panicProbe
+	defer func() { probeFn = original }()
+
+	targets := make([]string, maxTargets)
+	for i := range targets {
+		targets[i] = "198.51.100.1:22"
+	}
+
+	e := New()
+	ff, err := e.Scan(context.Background(), engines.ScanOptions{
+		SSHTargets: targets,
+		NoNetwork:  true,
+	})
+	if err != nil {
+		t.Errorf("expected nil error with NoNetwork=true + %d targets, got: %v", len(targets), err)
+	}
+	if ff != nil {
+		t.Errorf("expected nil findings with NoNetwork=true, got %d", len(ff))
+	}
+}
+
+// TestNoNetwork_NoNetwork_False_DoesCallProbe verifies the inverse: when
+// NoNetwork=false, probeFn IS called (so panicProbe would indeed panic).
+// This test uses a safe replacement to confirm the call path is active.
+func TestNoNetwork_NoNetwork_False_DoesCallProbe(t *testing.T) {
+	original := probeFn
+	var called bool
+	probeFn = func(ctx context.Context, target string, timeout time.Duration) ProbeResult {
+		called = true
+		return ProbeResult{Target: target, Error: context.Canceled}
+	}
+	defer func() { probeFn = original }()
+
+	e := New()
+	_, _ = e.Scan(context.Background(), engines.ScanOptions{
+		SSHTargets: []string{"198.51.100.2:22"},
+		NoNetwork:  false,
+	})
+	if !called {
+		t.Error("expected probeFn to be called when NoNetwork=false, but it was not")
+	}
+}

--- a/pkg/engines/sshprobe/engine_nonetwork_test.go
+++ b/pkg/engines/sshprobe/engine_nonetwork_test.go
@@ -19,7 +19,7 @@ import (
 
 // panicProbe is injected as probeFn when NoNetwork=true.
 // If it is ever called, the test fails (and panics to make the failure obvious).
-func panicProbe(ctx context.Context, target string, timeout time.Duration) ProbeResult {
+func panicProbe(_ context.Context, _ string, _ time.Duration, _ bool) ProbeResult {
 	panic("probeFn called with NoNetwork=true — engine must short-circuit before reaching the probe")
 }
 
@@ -94,7 +94,7 @@ func TestNoNetwork_WithMultipleTargets(t *testing.T) {
 func TestNoNetwork_NoNetwork_False_DoesCallProbe(t *testing.T) {
 	original := probeFn
 	var called bool
-	probeFn = func(ctx context.Context, target string, timeout time.Duration) ProbeResult {
+	probeFn = func(_ context.Context, target string, _ time.Duration, _ bool) ProbeResult {
 		called = true
 		return ProbeResult{Target: target, Error: context.Canceled}
 	}

--- a/pkg/engines/sshprobe/engine_stress_test.go
+++ b/pkg/engines/sshprobe/engine_stress_test.go
@@ -1,0 +1,220 @@
+// engine_stress_test.go — concurrency and cancellation stress tests for the SSH probe engine.
+//
+// Purpose: verify that the engine's bounded-concurrency design holds under load:
+//   1. 100 concurrent SSH targets → goroutine count never exceeds baseline + maxConcurrency + slack.
+//   2. Context cancellation propagates to all in-flight probes within 100ms.
+//   3. No data races under -race (all tests pass with go test -race -count=1).
+//
+// Seam note: these tests inject probeFn (already injectable via the package-level
+// var in probe.go) to avoid real network connections while maintaining control
+// over timing and goroutine coordination.
+package sshprobe
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/engines"
+)
+
+// TestEngineStress_GoroutineCapBounded verifies that scanning 100 targets
+// never spawns more than baseline + maxConcurrency + slack goroutines
+// simultaneously, enforcing the semaphore invariant (Sprint 4 M1 design).
+func TestEngineStress_GoroutineCapBounded(t *testing.T) {
+	// Record baseline goroutine count before the scan.
+	baseline := runtime.NumGoroutine()
+
+	// Semaphore to hold probe goroutines so we can observe peak count.
+	gate := make(chan struct{})
+	var mu sync.Mutex
+	var peakGoroutines int
+
+	original := probeFn
+	defer func() { probeFn = original }()
+	probeFn = func(ctx context.Context, target string, timeout time.Duration) ProbeResult {
+		// Record current goroutine count while blocked — this is when concurrent
+		// probes are at their peak.
+		current := runtime.NumGoroutine()
+		mu.Lock()
+		if current > peakGoroutines {
+			peakGoroutines = current
+		}
+		mu.Unlock()
+
+		// Block until the gate is closed (all probes launched before reading).
+		select {
+		case <-gate:
+		case <-ctx.Done():
+		}
+
+		return ProbeResult{Target: target, Error: fmt.Errorf("test stub")}
+	}
+
+	// Build 100 distinct targets.
+	targets := make([]string, 100)
+	for i := range targets {
+		targets[i] = fmt.Sprintf("192.0.2.%d:22", i+1)
+	}
+
+	// Run Scan in a background goroutine so we can close the gate after launch.
+	errCh := make(chan error, 1)
+	go func() {
+		e := New()
+		_, err := e.Scan(context.Background(), engines.ScanOptions{
+			SSHTargets: targets,
+		})
+		errCh <- err
+	}()
+
+	// Give the engine a moment to fill the semaphore (at most maxConcurrency probes
+	// will be in flight simultaneously).
+	time.Sleep(50 * time.Millisecond)
+
+	// Release all blocked probes.
+	close(gate)
+
+	// Wait for the scan to complete.
+	select {
+	case <-errCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("scan did not complete within 10s")
+	}
+
+	// Allow some slack for test framework goroutines, GC, and runtime internals.
+	// The strict bound is baseline + maxConcurrency; +10 provides tolerance for
+	// goroutines the test binary itself uses (e.g. GC, finalizer, netpoll).
+	const slack = 10
+	allowed := baseline + maxConcurrency + slack
+	if peakGoroutines > allowed {
+		t.Errorf("peak goroutines = %d; want ≤ %d (baseline=%d + cap=%d + slack=%d)",
+			peakGoroutines, allowed, baseline, maxConcurrency, slack)
+	}
+	t.Logf("peak goroutines = %d (baseline=%d, cap=%d, slack=%d)",
+		peakGoroutines, baseline, maxConcurrency, slack)
+}
+
+// TestEngineStress_ContextCancelWithin100ms verifies that cancelling the context
+// propagates to all in-flight probes and the Scan call returns within 100ms of
+// cancellation.
+func TestEngineStress_ContextCancelWithin100ms(t *testing.T) {
+	original := probeFn
+	defer func() { probeFn = original }()
+
+	var launched atomic.Int64
+	probeFn = func(ctx context.Context, target string, timeout time.Duration) ProbeResult {
+		launched.Add(1)
+		// Block until context is cancelled.
+		<-ctx.Done()
+		return ProbeResult{Target: target, Error: ctx.Err()}
+	}
+
+	targets := make([]string, 100)
+	for i := range targets {
+		targets[i] = fmt.Sprintf("192.0.2.%d:22", i+1)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	scanDone := make(chan struct{})
+	go func() {
+		e := New()
+		_, _ = e.Scan(ctx, engines.ScanOptions{SSHTargets: targets})
+		close(scanDone)
+	}()
+
+	// Wait until at least some probes are in flight.
+	deadline := time.Now().Add(2 * time.Second)
+	for launched.Load() == 0 && time.Now().Before(deadline) {
+		runtime.Gosched()
+	}
+
+	// Cancel and measure response time.
+	cancelAt := time.Now()
+	cancel()
+
+	select {
+	case <-scanDone:
+		elapsed := time.Since(cancelAt)
+		if elapsed > 100*time.Millisecond {
+			t.Errorf("context cancel took %v to propagate; want ≤ 100ms", elapsed)
+		}
+		t.Logf("cancel propagation latency: %v", elapsed)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Scan did not return within 500ms after context cancel")
+	}
+}
+
+// TestEngineStress_ConcurrencyRaceDetector runs a concurrency-sensitive scan
+// under -race to expose any shared-state races. Uses real goroutines and
+// concurrent access to the results slice.
+func TestEngineStress_ConcurrencyRaceDetector(t *testing.T) {
+	original := probeFn
+	defer func() { probeFn = original }()
+
+	// Minimal delay to ensure goroutines interleave.
+	probeFn = func(ctx context.Context, target string, timeout time.Duration) ProbeResult {
+		runtime.Gosched()
+		if ctx.Err() != nil {
+			return ProbeResult{Target: target, Error: ctx.Err()}
+		}
+		return ProbeResult{
+			Target:     target,
+			ServerID:   "SSH-2.0-test",
+			KEXMethods: []string{"curve25519-sha256", "diffie-hellman-group14-sha256"},
+		}
+	}
+
+	targets := make([]string, 50)
+	for i := range targets {
+		targets[i] = fmt.Sprintf("198.51.100.%d:22", i+1)
+	}
+
+	e := New()
+	ff, err := e.Scan(context.Background(), engines.ScanOptions{SSHTargets: targets})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// 50 targets × 2 methods each = 100 findings.
+	if len(ff) != 100 {
+		t.Errorf("findings count = %d; want 100 (50 targets × 2 methods)", len(ff))
+	}
+}
+
+// TestEngineStress_MaxTargetsExact verifies behaviour at exactly maxTargets
+// (accepted) and maxTargets+1 (rejected).
+func TestEngineStress_MaxTargetsExact(t *testing.T) {
+	original := probeFn
+	defer func() { probeFn = original }()
+	probeFn = func(ctx context.Context, target string, timeout time.Duration) ProbeResult {
+		return ProbeResult{Target: target, Error: fmt.Errorf("stub")}
+	}
+
+	// Exactly maxTargets → must not error with the count-check error.
+	targets := make([]string, maxTargets)
+	for i := range targets {
+		targets[i] = fmt.Sprintf("192.0.2.1:%d", 1000+i)
+	}
+	e := New()
+	_, err := e.Scan(context.Background(), engines.ScanOptions{SSHTargets: targets})
+	// All probes fail (stub returns error), so we expect an "all unreachable" error,
+	// NOT a "too many targets" error.
+	if err != nil && strings.Contains(err.Error(), "too many targets") {
+		t.Errorf("unexpected 'too many targets' error for exactly %d targets", maxTargets)
+	}
+
+	// maxTargets+1 → must return "too many targets" error.
+	tooMany := make([]string, maxTargets+1)
+	for i := range tooMany {
+		tooMany[i] = fmt.Sprintf("192.0.2.1:%d", 1000+i)
+	}
+	_, err2 := e.Scan(context.Background(), engines.ScanOptions{SSHTargets: tooMany})
+	if err2 == nil || !strings.Contains(err2.Error(), "too many targets") {
+		t.Errorf("expected 'too many targets' error for %d targets, got: %v", len(tooMany), err2)
+	}
+}

--- a/pkg/engines/sshprobe/engine_stress_test.go
+++ b/pkg/engines/sshprobe/engine_stress_test.go
@@ -37,7 +37,7 @@ func TestEngineStress_GoroutineCapBounded(t *testing.T) {
 
 	original := probeFn
 	defer func() { probeFn = original }()
-	probeFn = func(ctx context.Context, target string, timeout time.Duration) ProbeResult {
+	probeFn = func(ctx context.Context, target string, timeout time.Duration, _ bool) ProbeResult {
 		// Record current goroutine count while blocked — this is when concurrent
 		// probes are at their peak.
 		current := runtime.NumGoroutine()
@@ -107,7 +107,7 @@ func TestEngineStress_ContextCancelWithin100ms(t *testing.T) {
 	defer func() { probeFn = original }()
 
 	var launched atomic.Int64
-	probeFn = func(ctx context.Context, target string, timeout time.Duration) ProbeResult {
+	probeFn = func(ctx context.Context, target string, timeout time.Duration, _ bool) ProbeResult {
 		launched.Add(1)
 		// Block until context is cancelled.
 		<-ctx.Done()
@@ -158,7 +158,7 @@ func TestEngineStress_ConcurrencyRaceDetector(t *testing.T) {
 	defer func() { probeFn = original }()
 
 	// Minimal delay to ensure goroutines interleave.
-	probeFn = func(ctx context.Context, target string, timeout time.Duration) ProbeResult {
+	probeFn = func(ctx context.Context, target string, timeout time.Duration, _ bool) ProbeResult {
 		runtime.Gosched()
 		if ctx.Err() != nil {
 			return ProbeResult{Target: target, Error: ctx.Err()}
@@ -191,7 +191,7 @@ func TestEngineStress_ConcurrencyRaceDetector(t *testing.T) {
 func TestEngineStress_MaxTargetsExact(t *testing.T) {
 	original := probeFn
 	defer func() { probeFn = original }()
-	probeFn = func(ctx context.Context, target string, timeout time.Duration) ProbeResult {
+	probeFn = func(ctx context.Context, target string, timeout time.Duration, _ bool) ProbeResult {
 		return ProbeResult{Target: target, Error: fmt.Errorf("stub")}
 	}
 

--- a/pkg/engines/sshprobe/engine_test.go
+++ b/pkg/engines/sshprobe/engine_test.go
@@ -76,8 +76,8 @@ func TestScan_Integration(t *testing.T) {
 	// Inject a stub probeFn that enforces our timeout but talks to the fake server.
 	original := probeFn
 	defer func() { probeFn = original }()
-	probeFn = func(ctx context.Context, target string, timeout time.Duration) ProbeResult {
-		return probeSSH(ctx, addr, timeout)
+	probeFn = func(ctx context.Context, target string, timeout time.Duration, denyPrivate bool) ProbeResult {
+		return probeSSH(ctx, addr, timeout, denyPrivate)
 	}
 
 	ff, err := e.Scan(context.Background(), engines.ScanOptions{

--- a/pkg/engines/sshprobe/engine_test.go
+++ b/pkg/engines/sshprobe/engine_test.go
@@ -1,0 +1,112 @@
+package sshprobe
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/engines"
+)
+
+func TestEngineInterface(t *testing.T) {
+	e := New()
+
+	if e.Name() != "ssh-probe" {
+		t.Errorf("Name() = %q; want ssh-probe", e.Name())
+	}
+	if e.Tier() != engines.Tier5Network {
+		t.Errorf("Tier() = %v; want Tier5Network", e.Tier())
+	}
+	if !e.Available() {
+		t.Error("Available() = false; want true (embedded engine)")
+	}
+	if e.Version() != "embedded" {
+		t.Errorf("Version() = %q; want embedded", e.Version())
+	}
+	if langs := e.SupportedLanguages(); langs != nil {
+		t.Errorf("SupportedLanguages() = %v; want nil", langs)
+	}
+}
+
+func TestScan_EmptyTargets(t *testing.T) {
+	e := New()
+	ff, err := e.Scan(context.Background(), engines.ScanOptions{
+		SSHTargets: nil,
+	})
+	if err != nil {
+		t.Fatalf("Scan with no targets returned error: %v", err)
+	}
+	if len(ff) != 0 {
+		t.Errorf("expected no findings for empty targets, got %d", len(ff))
+	}
+}
+
+func TestScan_NoNetwork(t *testing.T) {
+	e := New()
+	ff, err := e.Scan(context.Background(), engines.ScanOptions{
+		SSHTargets: []string{"example.com:22"},
+		NoNetwork:  true,
+	})
+	if err != nil {
+		t.Fatalf("Scan with NoNetwork=true returned error: %v", err)
+	}
+	if len(ff) != 0 {
+		t.Errorf("expected no findings with NoNetwork, got %d", len(ff))
+	}
+}
+
+func TestScan_TooManyTargets(t *testing.T) {
+	targets := make([]string, maxTargets+1)
+	for i := range targets {
+		targets[i] = "192.0.2.1:22"
+	}
+	e := New()
+	_, err := e.Scan(context.Background(), engines.ScanOptions{SSHTargets: targets})
+	if err == nil {
+		t.Fatal("expected error for too many targets, got nil")
+	}
+}
+
+func TestScan_Integration(t *testing.T) {
+	methods := []string{"mlkem768x25519-sha256", "curve25519-sha256"}
+	addr := serveFakeSSH(t, "SSH-2.0-OpenSSH_10.0", methods)
+
+	e := New()
+
+	// Inject a stub probeFn that enforces our timeout but talks to the fake server.
+	original := probeFn
+	defer func() { probeFn = original }()
+	probeFn = func(ctx context.Context, target string, timeout time.Duration) ProbeResult {
+		return probeSSH(ctx, addr, timeout)
+	}
+
+	ff, err := e.Scan(context.Background(), engines.ScanOptions{
+		SSHTargets: []string{addr},
+	})
+	if err != nil {
+		t.Fatalf("Scan error: %v", err)
+	}
+	if len(ff) == 0 {
+		t.Fatal("expected findings, got none")
+	}
+	foundPQC := false
+	for _, f := range ff {
+		if f.PQCPresent {
+			foundPQC = true
+		}
+	}
+	if !foundPQC {
+		t.Error("expected at least one PQC-present finding")
+	}
+}
+
+func TestScan_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	e := New()
+	// Even with cancelled context, Scan should not panic and should return cleanly.
+	_, _ = e.Scan(ctx, engines.ScanOptions{
+		SSHTargets: []string{"127.0.0.1:22"},
+	})
+}

--- a/pkg/engines/sshprobe/engine_test.go
+++ b/pkg/engines/sshprobe/engine_test.go
@@ -110,3 +110,75 @@ func TestScan_ContextCancelled(t *testing.T) {
 		SSHTargets: []string{"127.0.0.1:22"},
 	})
 }
+
+// A4 — labelled break in select exits the for-range, not just the select.
+// Verify no goroutine leak when cancelling a scan with more targets than maxConcurrency.
+func TestScan_CancelExitsForLoop_NoGoroutineLeak(t *testing.T) {
+	original := probeFn
+	defer func() { probeFn = original }()
+
+	// Slow stub — blocks until ctx is done.
+	probeFn = func(ctx context.Context, target string, _ time.Duration, _ bool) ProbeResult {
+		<-ctx.Done()
+		return ProbeResult{Target: target, Error: ctx.Err()}
+	}
+
+	// More targets than maxConcurrency so the semaphore loop actually exercises
+	// the cancel path mid-iteration.
+	targets := make([]string, maxConcurrency*3)
+	for i := range targets {
+		targets[i] = "192.0.2.1:22"
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		e := New()
+		_, _ = e.Scan(ctx, engines.ScanOptions{SSHTargets: targets})
+	}()
+
+	// Cancel after a brief moment to ensure at least some goroutines are running.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Scan did not return within 500ms after context cancel")
+	}
+}
+
+// A5 — reachable/unreachable summary is accurate after a mid-scan cancel.
+// Verifies that Scan does not panic or index out-of-bounds on results[:launched].
+func TestScan_CancelAccurateLaunchedCounter(t *testing.T) {
+	original := probeFn
+	defer func() { probeFn = original }()
+
+	ready := make(chan struct{}, 1) // buffered so the first probe signals once
+	probeFn = func(ctx context.Context, target string, _ time.Duration, _ bool) ProbeResult {
+		select {
+		case ready <- struct{}{}:
+		default:
+		}
+		<-ctx.Done()
+		return ProbeResult{Target: target, Error: ctx.Err()}
+	}
+
+	targets := make([]string, maxConcurrency+2)
+	for i := range targets {
+		targets[i] = "192.0.2.1:22"
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-ready
+		cancel()
+	}()
+
+	e := New()
+	_, _ = e.Scan(ctx, engines.ScanOptions{SSHTargets: targets})
+	// After scan returns, launched ≤ len(targets). No panic, no index-out-of-bounds.
+	// The concurrency invariants are covered more thoroughly in engine_stress_test.go.
+}

--- a/pkg/engines/sshprobe/kex.go
+++ b/pkg/engines/sshprobe/kex.go
@@ -1,0 +1,69 @@
+package sshprobe
+
+import "strings"
+
+// kexInfo describes the PQC status of a SSH KEX method.
+type kexInfo struct {
+	pqcPresent bool
+	maturity   string // "final", "draft", or "" (classical)
+}
+
+// kexTable maps SSH KEX algorithm names to their PQC classification.
+// Sources: RFC 4253, OpenSSH release notes, IETF draft-ssh-pqc-* documents.
+var kexTable = map[string]kexInfo{
+	// IETF-standardised hybrid KEM (ML-KEM-768 + X25519, SHA-256).
+	// Adopted as the OpenSSH 10.0 default (released 2025).
+	// Ref: draft-ietf-crypto-sshpq-kem (expected RFC).
+	"mlkem768x25519-sha256": {pqcPresent: true, maturity: "final"},
+
+	// OpenSSH's pre-standard hybrid (sntrup761 + X25519, SHA-512).
+	// Default in OpenSSH 8.5–9.9; superseded by mlkem768x25519-sha256 in 10.0.
+	"sntrup761x25519-sha512@openssh.com": {pqcPresent: true, maturity: "draft"},
+
+	// Draft Kyber variants published before ML-KEM standardisation.
+	// These use the pre-FIPS-203 Kyber round-3 spec — deprecated per CNSA 2.0.
+	"kyber-512-sha256@pqc.ssh":             {pqcPresent: true, maturity: "draft"},
+	"kyber-768-sha256@pqc.ssh":             {pqcPresent: true, maturity: "draft"},
+	"kyber-1024-sha256@pqc.ssh":            {pqcPresent: true, maturity: "draft"},
+	"x25519-kyber-512-sha256@ietf.org":     {pqcPresent: true, maturity: "draft"},
+	"x25519-kyber-768-sha256@ietf.org":     {pqcPresent: true, maturity: "draft"},
+
+	// NTRUPrime variants (pre-sntrup761 era; rare in production).
+	"ntruprime-ntrulpr761x25519-sha512@openssh.com": {pqcPresent: true, maturity: "draft"},
+	"ntruprime-sntrup761x25519-sha512@openssh.com":  {pqcPresent: true, maturity: "draft"},
+
+	// Classical KEX methods — quantum-vulnerable (Shor's algorithm).
+	"diffie-hellman-group14-sha1":                    {pqcPresent: false},
+	"diffie-hellman-group14-sha256":                  {pqcPresent: false},
+	"diffie-hellman-group16-sha512":                  {pqcPresent: false},
+	"diffie-hellman-group18-sha512":                  {pqcPresent: false},
+	"diffie-hellman-group-exchange-sha1":             {pqcPresent: false},
+	"diffie-hellman-group-exchange-sha256":           {pqcPresent: false},
+	"diffie-hellman-group1-sha1":                     {pqcPresent: false},
+	"ecdh-sha2-nistp256":                             {pqcPresent: false},
+	"ecdh-sha2-nistp384":                             {pqcPresent: false},
+	"ecdh-sha2-nistp521":                             {pqcPresent: false},
+	"curve25519-sha256":                              {pqcPresent: false},
+	"curve25519-sha256@libssh.org":                   {pqcPresent: false},
+	"curve448-sha512":                                {pqcPresent: false},
+}
+
+// pqcHeuristics lists substrings that suggest a PQC KEX not yet in kexTable.
+// Used to return a more informative label for unknown-but-PQC-looking methods.
+var pqcHeuristics = []string{"mlkem", "kyber", "sntrup", "frodo", "ntru", "bike", "hqc", "mceliece"}
+
+// classifyKex returns the kexInfo for a KEX method name.
+// For names not in kexTable, it applies a heuristic based on pqcHeuristics.
+func classifyKex(method string) kexInfo {
+	if info, ok := kexTable[method]; ok {
+		return info
+	}
+	lower := strings.ToLower(method)
+	for _, hint := range pqcHeuristics {
+		if strings.Contains(lower, hint) {
+			// Unrecognised but looks PQC — report as draft so it surfaces in findings.
+			return kexInfo{pqcPresent: true, maturity: "draft"}
+		}
+	}
+	return kexInfo{pqcPresent: false}
+}

--- a/pkg/engines/sshprobe/kex.go
+++ b/pkg/engines/sshprobe/kex.go
@@ -50,7 +50,9 @@ var kexTable = map[string]kexInfo{
 
 // pqcHeuristics lists substrings that suggest a PQC KEX not yet in kexTable.
 // Used to return a more informative label for unknown-but-PQC-looking methods.
-var pqcHeuristics = []string{"mlkem", "kyber", "sntrup", "frodo", "ntru", "bike", "hqc", "mceliece"}
+// B6: "ntru" removed — "sntrup" and "ntruprime" substrings already cover real
+// PQC implementations; bare "ntru" risks false positives on unrelated algorithm names.
+var pqcHeuristics = []string{"mlkem", "kyber", "sntrup", "frodo", "ntruprime", "bike", "hqc", "mceliece"}
 
 // classifyKex returns the kexInfo for a KEX method name.
 // For names not in kexTable, it applies a heuristic based on pqcHeuristics.

--- a/pkg/engines/sshprobe/kex_matrix_test.go
+++ b/pkg/engines/sshprobe/kex_matrix_test.go
@@ -286,7 +286,7 @@ func TestKEXMatrix_ProbeRoundTrip(t *testing.T) {
 		t.Run(v.name+"_probe", func(t *testing.T) {
 			addr := serveFakeSSH(t, v.serverID, v.kexMethods)
 
-			result := probeSSH(t.Context(), addr, 5*time.Second)
+			result := probeSSH(t.Context(), addr, 5*time.Second, false)
 			if result.Error != nil {
 				t.Fatalf("probeSSH error: %v", result.Error)
 			}

--- a/pkg/engines/sshprobe/kex_matrix_test.go
+++ b/pkg/engines/sshprobe/kex_matrix_test.go
@@ -1,0 +1,318 @@
+// kex_matrix_test.go — KEX advertisement matrix tests for real-world OpenSSH versions.
+//
+// Purpose: verify that every documented OpenSSH default KEX advertisement
+// (versions 7.4 through 10.0) is correctly parsed and classified. Each version
+// fixture asserts:
+//   1. The first PQC method detected is the expected one (or none for pre-8.5).
+//   2. Total finding count == total method count.
+//   3. RiskSafe count (PQC-capable KEX methods) matches expected value.
+//   4. RiskVulnerable count (classical methods) matches expected value.
+//
+// Source: OpenSSH release notes + RFC 4253 §7.1 + IETF draft-ietf-crypto-sshpq-kem.
+// KEX lists reflect each version's compiled-in defaults before host-based filtering.
+package sshprobe
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/findings"
+)
+
+// opensshVersion describes the KEX advertisement of a specific OpenSSH release.
+type opensshVersion struct {
+	name string // e.g. "OpenSSH 7.4"
+	// serverID is the SSH identification string sent by the server.
+	serverID string
+	// kexMethods is the default kex_algorithms name-list in order.
+	kexMethods []string
+	// firstPQCMethod is the expected first method with pqcPresent=true, or "" for none.
+	firstPQCMethod string
+	// wantRiskSafe is the expected count of PQC-safe findings (QuantumRisk == QRSafe).
+	wantRiskSafe int
+	// wantNotSafe is the expected count of findings that are NOT QRSafe.
+	// This includes QRVulnerable, QRUnknown, QRDeprecated, etc.
+	// Note: curve25519-sha256 and curve25519-sha256@libssh.org are classified as
+	// QRUnknown (not QRVulnerable) by ClassifyAlgorithm because the generic
+	// classifier does not map SSH-specific method names to curve families.
+	wantNotSafe int
+}
+
+var opensshMatrix = []opensshVersion{
+	{
+		name:     "OpenSSH 7.4",
+		serverID: "SSH-2.0-OpenSSH_7.4",
+		// Released 2016-12-19. No PQC KEX. Classical only.
+		// curve25519-sha256 and curve25519-sha256@libssh.org → QRUnknown (2)
+		// ecdh-sha2-nistp{256,384,521} + 5× DH → QRVulnerable (8)
+		kexMethods: []string{
+			"curve25519-sha256",
+			"curve25519-sha256@libssh.org",
+			"ecdh-sha2-nistp256",
+			"ecdh-sha2-nistp384",
+			"ecdh-sha2-nistp521",
+			"diffie-hellman-group-exchange-sha256",
+			"diffie-hellman-group16-sha512",
+			"diffie-hellman-group18-sha512",
+			"diffie-hellman-group14-sha256",
+			"diffie-hellman-group14-sha1",
+		},
+		firstPQCMethod: "",
+		wantRiskSafe:   0,
+		wantNotSafe:    10,
+	},
+	{
+		name:     "OpenSSH 8.0",
+		serverID: "SSH-2.0-OpenSSH_8.0",
+		// Released 2019-04-18. Still classical only by default.
+		kexMethods: []string{
+			"curve25519-sha256",
+			"curve25519-sha256@libssh.org",
+			"ecdh-sha2-nistp256",
+			"ecdh-sha2-nistp384",
+			"ecdh-sha2-nistp521",
+			"diffie-hellman-group-exchange-sha256",
+			"diffie-hellman-group16-sha512",
+			"diffie-hellman-group18-sha512",
+			"diffie-hellman-group14-sha256",
+			"diffie-hellman-group14-sha1",
+		},
+		firstPQCMethod: "",
+		wantRiskSafe:   0,
+		wantNotSafe:    10,
+	},
+	{
+		name:     "OpenSSH 8.5",
+		serverID: "SSH-2.0-OpenSSH_8.5",
+		// Released 2021-03-03. First release with sntrup761x25519 as a compiled-in
+		// default (prepended before classical methods). Ref: OpenSSH 8.5 release notes.
+		kexMethods: []string{
+			"sntrup761x25519-sha512@openssh.com",
+			"curve25519-sha256",
+			"curve25519-sha256@libssh.org",
+			"ecdh-sha2-nistp256",
+			"ecdh-sha2-nistp384",
+			"ecdh-sha2-nistp521",
+			"diffie-hellman-group-exchange-sha256",
+			"diffie-hellman-group16-sha512",
+			"diffie-hellman-group18-sha512",
+			"diffie-hellman-group14-sha256",
+		},
+		firstPQCMethod: "sntrup761x25519-sha512@openssh.com",
+		wantRiskSafe:   1,
+		wantNotSafe:    9,
+	},
+	{
+		name:     "OpenSSH 9.0",
+		serverID: "SSH-2.0-OpenSSH_9.0",
+		// Released 2022-04-08. Same kex default list as 8.5.
+		kexMethods: []string{
+			"sntrup761x25519-sha512@openssh.com",
+			"curve25519-sha256",
+			"curve25519-sha256@libssh.org",
+			"ecdh-sha2-nistp256",
+			"ecdh-sha2-nistp384",
+			"ecdh-sha2-nistp521",
+			"diffie-hellman-group-exchange-sha256",
+			"diffie-hellman-group16-sha512",
+			"diffie-hellman-group18-sha512",
+			"diffie-hellman-group14-sha256",
+		},
+		firstPQCMethod: "sntrup761x25519-sha512@openssh.com",
+		wantRiskSafe:   1,
+		wantNotSafe:    9,
+	},
+	{
+		name:     "OpenSSH 9.9",
+		serverID: "SSH-2.0-OpenSSH_9.9",
+		// Last release before mlkem768 landing. sntrup761 remains default.
+		kexMethods: []string{
+			"sntrup761x25519-sha512@openssh.com",
+			"curve25519-sha256",
+			"curve25519-sha256@libssh.org",
+			"ecdh-sha2-nistp256",
+			"ecdh-sha2-nistp384",
+			"ecdh-sha2-nistp521",
+			"diffie-hellman-group-exchange-sha256",
+			"diffie-hellman-group16-sha512",
+			"diffie-hellman-group18-sha512",
+			"diffie-hellman-group14-sha256",
+		},
+		firstPQCMethod: "sntrup761x25519-sha512@openssh.com",
+		wantRiskSafe:   1,
+		wantNotSafe:    9,
+	},
+	{
+		name:     "OpenSSH 10.0",
+		serverID: "SSH-2.0-OpenSSH_10.0",
+		// Released 2025. Adopts mlkem768x25519-sha256 (draft-ietf-crypto-sshpq-kem)
+		// as the primary hybrid KEX; sntrup761 dropped from the default list.
+		// Ref: OpenSSH 10.0 release notes + CLAUDE.md.
+		kexMethods: []string{
+			"mlkem768x25519-sha256",
+			"curve25519-sha256",
+			"curve25519-sha256@libssh.org",
+			"ecdh-sha2-nistp256",
+			"ecdh-sha2-nistp384",
+			"ecdh-sha2-nistp521",
+			"diffie-hellman-group-exchange-sha256",
+			"diffie-hellman-group16-sha512",
+			"diffie-hellman-group18-sha512",
+			"diffie-hellman-group14-sha256",
+		},
+		firstPQCMethod: "mlkem768x25519-sha256",
+		wantRiskSafe:   1,
+		wantNotSafe:    9,
+	},
+	{
+		name:     "Dropbear 2020.80",
+		serverID: "SSH-2.0-dropbear_2020.80",
+		// Common embedded SSH server. Classical only, minimal method set.
+		// curve25519-sha256 → QRUnknown; 4 ECDH/DH → QRVulnerable.
+		kexMethods: []string{
+			"curve25519-sha256",
+			"ecdh-sha2-nistp256",
+			"ecdh-sha2-nistp384",
+			"ecdh-sha2-nistp521",
+			"diffie-hellman-group14-sha256",
+			"diffie-hellman-group14-sha1",
+		},
+		firstPQCMethod: "",
+		wantRiskSafe:   0,
+		wantNotSafe:    6,
+	},
+	{
+		name:     "Vendor_PQC_experimental",
+		serverID: "SSH-2.0-VendorSSH_3.0",
+		// Hypothetical vendor advertising multiple PQC methods alongside classical.
+		// mlkem768 + sntrup761 + kyber-768 → 3 QRSafe; curve25519 (QRUnknown) +
+		// ecdh-sha2-nistp256 (QRVulnerable) + diffie-hellman-group14 (QRVulnerable) → 3 not-safe.
+		kexMethods: []string{
+			"mlkem768x25519-sha256",
+			"sntrup761x25519-sha512@openssh.com",
+			"kyber-768-sha256@pqc.ssh",
+			"curve25519-sha256",
+			"ecdh-sha2-nistp256",
+			"diffie-hellman-group14-sha256",
+		},
+		firstPQCMethod: "mlkem768x25519-sha256",
+		wantRiskSafe:   3,
+		wantNotSafe:    3,
+	},
+}
+
+// TestKEXMatrix runs the full matrix of OpenSSH version fixtures against
+// kexInitToFindings, asserting PQC detection accuracy.
+func TestKEXMatrix(t *testing.T) {
+	for _, v := range opensshMatrix {
+		v := v
+		t.Run(v.name, func(t *testing.T) {
+			result := ProbeResult{
+				Target:     "203.0.113.5:22",
+				ServerID:   v.serverID,
+				KEXMethods: v.kexMethods,
+			}
+			ff := kexInitToFindings(result)
+
+			// 1. Total finding count must equal total method count.
+			if len(ff) != len(v.kexMethods) {
+				t.Fatalf("finding count = %d; want %d (one per method)", len(ff), len(v.kexMethods))
+			}
+
+			// 2. First PQC method detected must be correct.
+			firstPQC := ""
+			for _, f := range ff {
+				if f.PQCPresent {
+					firstPQC = f.Algorithm.Name
+					break
+				}
+			}
+			if firstPQC != v.firstPQCMethod {
+				t.Errorf("first PQC method = %q; want %q", firstPQC, v.firstPQCMethod)
+			}
+
+			// 3. RiskSafe count and not-safe count must match.
+			// Note: classical methods map to QRVulnerable or QRUnknown (curve25519-sha256
+			// is classified as QRUnknown by ClassifyAlgorithm since it doesn't recognise
+			// the SSH-specific method name format). wantNotSafe covers both.
+			var gotSafe, gotNotSafe int
+			for _, f := range ff {
+				if f.QuantumRisk == findings.QRSafe {
+					gotSafe++
+				} else {
+					gotNotSafe++
+				}
+			}
+			if gotSafe != v.wantRiskSafe {
+				t.Errorf("RiskSafe count = %d; want %d", gotSafe, v.wantRiskSafe)
+			}
+			if gotNotSafe != v.wantNotSafe {
+				t.Errorf("not-safe count = %d; want %d", gotNotSafe, v.wantNotSafe)
+			}
+
+			// 4. PQCMaturity for mlkem768 must be "final", sntrup761/kyber must be "draft".
+			for _, f := range ff {
+				if !f.PQCPresent {
+					continue
+				}
+				switch {
+				case strings.Contains(f.Algorithm.Name, "mlkem"):
+					if f.PQCMaturity != "final" {
+						t.Errorf("method %q: PQCMaturity=%q; want final", f.Algorithm.Name, f.PQCMaturity)
+					}
+				case strings.Contains(f.Algorithm.Name, "sntrup"), strings.Contains(f.Algorithm.Name, "kyber"):
+					if f.PQCMaturity != "draft" {
+						t.Errorf("method %q: PQCMaturity=%q; want draft", f.Algorithm.Name, f.PQCMaturity)
+					}
+				}
+			}
+
+			// 5. Algorithm primitive must always be "kex".
+			for i, f := range ff {
+				if f.Algorithm == nil || f.Algorithm.Primitive != "kex" {
+					t.Errorf("finding[%d] Algorithm.Primitive=%v; want kex", i, f.Algorithm)
+				}
+			}
+		})
+	}
+}
+
+// TestKEXMatrix_ProbeRoundTrip runs the full OpenSSH matrix through a live TCP
+// probe against a fake SSH server, verifying end-to-end probe + classification.
+func TestKEXMatrix_ProbeRoundTrip(t *testing.T) {
+	for _, v := range opensshMatrix {
+		v := v
+		t.Run(v.name+"_probe", func(t *testing.T) {
+			addr := serveFakeSSH(t, v.serverID, v.kexMethods)
+
+			result := probeSSH(t.Context(), addr, 5*time.Second)
+			if result.Error != nil {
+				t.Fatalf("probeSSH error: %v", result.Error)
+			}
+			if result.ServerID != v.serverID {
+				t.Errorf("ServerID=%q; want %q", result.ServerID, v.serverID)
+			}
+			if len(result.KEXMethods) != len(v.kexMethods) {
+				t.Fatalf("KEXMethods len=%d; want %d", len(result.KEXMethods), len(v.kexMethods))
+			}
+			for i, m := range v.kexMethods {
+				if result.KEXMethods[i] != m {
+					t.Errorf("method[%d]=%q; want %q", i, result.KEXMethods[i], m)
+				}
+			}
+
+			// Classify and assert PQC-safe split matches.
+			ff := kexInitToFindings(result)
+			var gotSafe int
+			for _, f := range ff {
+				if f.QuantumRisk == findings.QRSafe {
+					gotSafe++
+				}
+			}
+			if gotSafe != v.wantRiskSafe {
+				t.Errorf("probe round-trip RiskSafe=%d; want %d", gotSafe, v.wantRiskSafe)
+			}
+		})
+	}
+}

--- a/pkg/engines/sshprobe/kex_test.go
+++ b/pkg/engines/sshprobe/kex_test.go
@@ -1,0 +1,182 @@
+package sshprobe
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/findings"
+)
+
+func TestClassifyKex_KnownPQC(t *testing.T) {
+	pqcMethods := []struct {
+		method   string
+		maturity string
+	}{
+		{"mlkem768x25519-sha256", "final"},
+		{"sntrup761x25519-sha512@openssh.com", "draft"},
+		{"kyber-512-sha256@pqc.ssh", "draft"},
+		{"kyber-768-sha256@pqc.ssh", "draft"},
+		{"kyber-1024-sha256@pqc.ssh", "draft"},
+		{"x25519-kyber-512-sha256@ietf.org", "draft"},
+		{"x25519-kyber-768-sha256@ietf.org", "draft"},
+		{"ntruprime-ntrulpr761x25519-sha512@openssh.com", "draft"},
+		{"ntruprime-sntrup761x25519-sha512@openssh.com", "draft"},
+	}
+	for _, tc := range pqcMethods {
+		t.Run(tc.method, func(t *testing.T) {
+			info := classifyKex(tc.method)
+			if !info.pqcPresent {
+				t.Errorf("classifyKex(%q).pqcPresent = false; want true", tc.method)
+			}
+			if info.maturity != tc.maturity {
+				t.Errorf("classifyKex(%q).maturity = %q; want %q", tc.method, info.maturity, tc.maturity)
+			}
+		})
+	}
+}
+
+func TestClassifyKex_Classical(t *testing.T) {
+	classical := []string{
+		"diffie-hellman-group14-sha256",
+		"diffie-hellman-group14-sha1",
+		"diffie-hellman-group16-sha512",
+		"diffie-hellman-group18-sha512",
+		"diffie-hellman-group-exchange-sha256",
+		"diffie-hellman-group-exchange-sha1",
+		"diffie-hellman-group1-sha1",
+		"ecdh-sha2-nistp256",
+		"ecdh-sha2-nistp384",
+		"ecdh-sha2-nistp521",
+		"curve25519-sha256",
+		"curve25519-sha256@libssh.org",
+		"curve448-sha512",
+	}
+	for _, method := range classical {
+		t.Run(method, func(t *testing.T) {
+			info := classifyKex(method)
+			if info.pqcPresent {
+				t.Errorf("classifyKex(%q).pqcPresent = true; want false (classical method)", method)
+			}
+		})
+	}
+}
+
+func TestClassifyKex_UnknownPQCHeuristic(t *testing.T) {
+	heuristic := []string{
+		"mlkem1024x448-sha512@future.org",
+		"frodokem1344-sha512@example.com",
+		"sntrup1277x25519-sha512@openssh.com",
+		"kyber-999-sha256@unknown.tld",
+		"hqc256-sha512@draft.example",
+		"ntruprime-new-sha256@vendor.com",
+	}
+	for _, method := range heuristic {
+		t.Run(method, func(t *testing.T) {
+			info := classifyKex(method)
+			if !info.pqcPresent {
+				t.Errorf("classifyKex(%q).pqcPresent = false; want true (PQC heuristic match)", method)
+			}
+		})
+	}
+}
+
+func TestClassifyKex_UnknownClassical(t *testing.T) {
+	unknown := []string{
+		"totally-unknown-kex@example.com",
+		"custom-group-sha256",
+		"some-random-method",
+	}
+	for _, method := range unknown {
+		t.Run(method, func(t *testing.T) {
+			info := classifyKex(method)
+			if info.pqcPresent {
+				t.Errorf("classifyKex(%q).pqcPresent = true; want false (unrecognized method)", method)
+			}
+		})
+	}
+}
+
+func TestKexInitToFindings_ClassicalOnly(t *testing.T) {
+	result := ProbeResult{
+		Target:   "192.0.2.1:22",
+		ServerID: "SSH-2.0-OpenSSH_7.4",
+		KEXMethods: []string{
+			"curve25519-sha256",
+			"diffie-hellman-group14-sha256",
+		},
+	}
+	ff := kexInitToFindings(result)
+	if len(ff) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(ff))
+	}
+	for _, f := range ff {
+		if f.PQCPresent {
+			t.Errorf("finding for classical method has PQCPresent=true: %+v", f)
+		}
+		if f.QuantumRisk == findings.QRSafe {
+			t.Errorf("classical method should not be QRSafe: %+v", f)
+		}
+		if f.Algorithm == nil || f.Algorithm.Primitive != "kex" {
+			t.Errorf("expected Primitive=kex, got: %+v", f.Algorithm)
+		}
+		if f.SourceEngine != engineName {
+			t.Errorf("SourceEngine = %q; want %q", f.SourceEngine, engineName)
+		}
+	}
+}
+
+func TestKexInitToFindings_PQCPresent(t *testing.T) {
+	result := ProbeResult{
+		Target:   "192.0.2.2:22",
+		ServerID: "SSH-2.0-OpenSSH_10.0",
+		KEXMethods: []string{
+			"mlkem768x25519-sha256",
+			"curve25519-sha256",
+		},
+	}
+	ff := kexInitToFindings(result)
+	if len(ff) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(ff))
+	}
+	var pqcFound bool
+	for _, f := range ff {
+		if f.Algorithm.Name == "mlkem768x25519-sha256" {
+			pqcFound = true
+			if !f.PQCPresent {
+				t.Errorf("mlkem768x25519-sha256 should have PQCPresent=true")
+			}
+			if f.QuantumRisk != findings.QRSafe {
+				t.Errorf("mlkem768x25519-sha256 QuantumRisk = %q; want %q", f.QuantumRisk, findings.QRSafe)
+			}
+			if f.PQCMaturity != "final" {
+				t.Errorf("PQCMaturity = %q; want final", f.PQCMaturity)
+			}
+		}
+	}
+	if !pqcFound {
+		t.Fatal("PQC finding not emitted")
+	}
+}
+
+func TestKexInitToFindings_Error(t *testing.T) {
+	result := ProbeResult{
+		Target: "192.0.2.3:22",
+		Error:  fmt.Errorf("connection refused"),
+	}
+	ff := kexInitToFindings(result)
+	if len(ff) != 0 {
+		t.Errorf("expected no findings for error result, got %d", len(ff))
+	}
+}
+
+func TestKexInitToFindings_EmptyMethods(t *testing.T) {
+	result := ProbeResult{
+		Target:     "192.0.2.4:22",
+		ServerID:   "SSH-2.0-OpenSSH_9.0",
+		KEXMethods: []string{},
+	}
+	ff := kexInitToFindings(result)
+	if len(ff) != 0 {
+		t.Errorf("expected no findings for empty method list, got %d", len(ff))
+	}
+}

--- a/pkg/engines/sshprobe/probe.go
+++ b/pkg/engines/sshprobe/probe.go
@@ -1,0 +1,127 @@
+package sshprobe
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+const (
+	// clientBanner is sent immediately after connection. We identify as the scanner
+	// so server logs are unambiguous. RFC 4253 §4.2 allows any compliant string.
+	clientBanner = "SSH-2.0-OQS-Scanner_1.0\r\n"
+
+	// defaultTimeout caps the dial + banner + KEXINIT read per target.
+	defaultTimeout = 10 * time.Second
+
+	// kexinitCookieLen is the fixed 16-byte random cookie in SSH_MSG_KEXINIT.
+	kexinitCookieLen = 16
+
+	// kexinitNameListCount is the number of name-list fields before first_kex_packet_follows.
+	// RFC 4253 §7.1: kex, host-key, enc-c2s, enc-s2c, mac-c2s, mac-s2c, comp-c2s, comp-s2c, lang-c2s, lang-s2c.
+	kexinitNameListCount = 10
+)
+
+// ProbeResult captures the SSH KEXINIT data from a single endpoint.
+type ProbeResult struct {
+	Target     string // host:port as provided by caller
+	ServerID   string // SSH identification string, e.g. "SSH-2.0-OpenSSH_9.0"
+	KEXMethods []string
+	Error      error
+}
+
+// probeFn is the underlying per-endpoint probe function. Package-level variable
+// so tests can inject a stub without real network connections (mirrors tlsprobe pattern).
+var probeFn = probeSSH
+
+// probeSSH connects to host:port, exchanges banners, reads SSH_MSG_KEXINIT,
+// and extracts the kex_algorithms name-list. It does NOT negotiate a session.
+func probeSSH(ctx context.Context, target string, timeout time.Duration) ProbeResult {
+	dialer := net.Dialer{Timeout: timeout}
+	conn, err := dialer.DialContext(ctx, "tcp", target)
+	if err != nil {
+		return ProbeResult{Target: target, Error: fmt.Errorf("dial: %w", err)}
+	}
+	defer conn.Close()
+
+	deadline := time.Now().Add(timeout)
+	if err := conn.SetDeadline(deadline); err != nil {
+		return ProbeResult{Target: target, Error: fmt.Errorf("set deadline: %w", err)}
+	}
+
+	// Step 1: Read server identification banner.
+	serverID, err := readBanner(conn)
+	if err != nil {
+		return ProbeResult{Target: target, Error: fmt.Errorf("read server banner: %w", err)}
+	}
+	if !strings.HasPrefix(serverID, "SSH-") {
+		return ProbeResult{Target: target, Error: fmt.Errorf("unexpected server banner (not SSH): %q", serverID)}
+	}
+
+	// Step 2: Send client identification banner.
+	if _, err := conn.Write([]byte(clientBanner)); err != nil {
+		return ProbeResult{Target: target, Error: fmt.Errorf("send client banner: %w", err)}
+	}
+
+	// Step 3: Read server's SSH_MSG_KEXINIT packet.
+	// RFC 4253 §7.1: servers MUST send KEXINIT immediately after the banner.
+	// Some implementations (e.g. dropbear) send version-probe lines first;
+	// we skip any non-KEXINIT payloads up to a small limit.
+	kexMethods, err := readKEXInit(conn)
+	if err != nil {
+		return ProbeResult{Target: target, Error: err}
+	}
+
+	return ProbeResult{
+		Target:     target,
+		ServerID:   serverID,
+		KEXMethods: kexMethods,
+	}
+}
+
+// readKEXInit reads SSH binary packets until it finds SSH_MSG_KEXINIT (type=20),
+// then parses and returns the kex_algorithms name-list.
+// Skips up to 5 non-KEXINIT packets to tolerate implementations that send
+// informational packets before KEXINIT.
+func readKEXInit(conn net.Conn) ([]string, error) {
+	const maxSkip = 5
+	for skip := 0; skip < maxSkip; skip++ {
+		payload, err := readPacket(conn)
+		if err != nil {
+			return nil, fmt.Errorf("read packet: %w", err)
+		}
+		if len(payload) == 0 {
+			continue
+		}
+		if payload[0] != sshMsgKexInit {
+			continue // skip non-KEXINIT packet
+		}
+		return parseKEXInitPayload(payload)
+	}
+	return nil, fmt.Errorf("no SSH_MSG_KEXINIT received in first %d packets", maxSkip)
+}
+
+// parseKEXInitPayload extracts the kex_algorithms name-list from a KEXINIT payload.
+// Payload layout (RFC 4253 §7.1):
+//
+//	[0]     byte SSH_MSG_KEXINIT (20)
+//	[1..16] byte[16] cookie (random)
+//	[17..]  name-list kex_algorithms (uint32 len + bytes)
+//	        ... 9 more name-lists (host-key, enc×2, mac×2, comp×2, lang×2)
+//	        boolean first_kex_packet_follows
+//	        uint32 reserved (0)
+func parseKEXInitPayload(payload []byte) ([]string, error) {
+	// Skip: type byte (1) + cookie (16).
+	offset := 1 + kexinitCookieLen
+	if offset > len(payload) {
+		return nil, fmt.Errorf("KEXINIT payload too short (%d bytes)", len(payload))
+	}
+
+	kexMethods, _, err := parseNameList(payload, offset)
+	if err != nil {
+		return nil, fmt.Errorf("parse kex_algorithms: %w", err)
+	}
+	return kexMethods, nil
+}

--- a/pkg/engines/sshprobe/probe.go
+++ b/pkg/engines/sshprobe/probe.go
@@ -3,9 +3,12 @@ package sshprobe
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"strings"
 	"time"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/engines/netutil"
 )
 
 const (
@@ -22,6 +25,10 @@ const (
 	// kexinitNameListCount is the number of name-list fields before first_kex_packet_follows.
 	// RFC 4253 §7.1: kex, host-key, enc-c2s, enc-s2c, mac-c2s, mac-s2c, comp-c2s, comp-s2c, lang-c2s, lang-s2c.
 	kexinitNameListCount = 10
+
+	// A1: preamble limits per RFC 4253 §4.2 (servers MAY send lines before the SSH- banner).
+	maxBannerLines   = 10
+	maxPreambleBytes = 8 * 1024
 )
 
 // ProbeResult captures the SSH KEXINIT data from a single endpoint.
@@ -38,26 +45,53 @@ var probeFn = probeSSH
 
 // probeSSH connects to host:port, exchanges banners, reads SSH_MSG_KEXINIT,
 // and extracts the kex_algorithms name-list. It does NOT negotiate a session.
-func probeSSH(ctx context.Context, target string, timeout time.Duration) ProbeResult {
+func probeSSH(ctx context.Context, target string, timeout time.Duration, denyPrivate bool) ProbeResult {
+	// A2: Parse host and port for DNS validation and pinned dialing.
+	host, port, err := sshParseTarget(target)
+	if err != nil {
+		return ProbeResult{Target: target, Error: err}
+	}
+
+	// A2: Resolve and validate — blocks RFC 1918 / loopback IPs when denyPrivate is set.
+	resolvedIP, err := netutil.ResolveAndValidate(ctx, host, denyPrivate)
+	if err != nil {
+		return ProbeResult{Target: target, Error: err}
+	}
+
 	dialer := net.Dialer{Timeout: timeout}
-	conn, err := dialer.DialContext(ctx, "tcp", target)
+	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(resolvedIP, port))
 	if err != nil {
 		return ProbeResult{Target: target, Error: fmt.Errorf("dial: %w", err)}
 	}
 	defer conn.Close()
+
+	// A3: Context watchdog — closes the connection when ctx is cancelled so that
+	// blocked reads return promptly. conn.SetDeadline is decoupled from ctx; without
+	// this goroutine, orchestrator cancellations have up to timeout×ceil(n/5) lag.
+	ctxDone := make(chan struct{})
+	defer close(ctxDone)
+	go func() {
+		select {
+		case <-ctx.Done():
+			conn.Close()
+		case <-ctxDone:
+		}
+	}()
 
 	deadline := time.Now().Add(timeout)
 	if err := conn.SetDeadline(deadline); err != nil {
 		return ProbeResult{Target: target, Error: fmt.Errorf("set deadline: %w", err)}
 	}
 
-	// Step 1: Read server identification banner.
-	serverID, err := readBanner(conn)
+	// Step 1: Read server identification banner (A1: tolerates RFC 4253 preamble lines).
+	serverID, err := readBannerWithPreamble(conn)
 	if err != nil {
 		return ProbeResult{Target: target, Error: fmt.Errorf("read server banner: %w", err)}
 	}
-	if !strings.HasPrefix(serverID, "SSH-") {
-		return ProbeResult{Target: target, Error: fmt.Errorf("unexpected server banner (not SSH): %q", serverID)}
+
+	// B4: Reject SSH-1.x; only SSH-2.0 and SSH-1.99 are RFC 4253-compliant.
+	if !strings.HasPrefix(serverID, "SSH-2.0-") && !strings.HasPrefix(serverID, "SSH-1.99-") {
+		return ProbeResult{Target: target, Error: fmt.Errorf("unsupported SSH version in banner %q (only SSH-2.0 and SSH-1.99 accepted)", serverID)}
 	}
 
 	// Step 2: Send client identification banner.
@@ -81,12 +115,46 @@ func probeSSH(ctx context.Context, target string, timeout time.Duration) ProbeRe
 	}
 }
 
+// readBannerWithPreamble reads lines until an SSH-prefixed identification string
+// is found, skipping up to maxBannerLines–1 RFC 4253 preamble lines first.
+// Total preamble bytes are bounded by maxPreambleBytes to prevent amplification.
+// The returned banner is validated for printable US-ASCII (B1: RFC 4253 §4.2).
+func readBannerWithPreamble(r io.Reader) (string, error) {
+	var totalBytes int
+	for i := 0; i < maxBannerLines; i++ {
+		line, err := readBanner(r)
+		if err != nil {
+			return "", err
+		}
+		totalBytes += len(line) + 2 // +2 for \r\n stripped by readBanner
+		if totalBytes > maxPreambleBytes {
+			return "", fmt.Errorf("banner preamble exceeded %d bytes", maxPreambleBytes)
+		}
+		if !strings.HasPrefix(line, "SSH-") {
+			continue // preamble line — skip and read the next one
+		}
+		// B1: Validate banner contains only printable US-ASCII [0x20, 0x7E].
+		for j := 0; j < len(line); j++ {
+			b := line[j]
+			if b < 0x20 || b > 0x7E {
+				return "", fmt.Errorf("ssh banner contains non-printable byte 0x%02x at offset %d", b, j)
+			}
+		}
+		return line, nil
+	}
+	return "", fmt.Errorf("no SSH banner found after %d preamble lines", maxBannerLines)
+}
+
 // readKEXInit reads SSH binary packets until it finds SSH_MSG_KEXINIT (type=20),
 // then parses and returns the kex_algorithms name-list.
-// Skips up to 5 non-KEXINIT packets to tolerate implementations that send
-// informational packets before KEXINIT.
+// B3: maxSkip reduced to 2 (real servers send KEXINIT first per RFC 4253 §7.1).
+// B3: Cumulative skipped bytes capped at 64 KB to prevent attacker amplification.
 func readKEXInit(conn net.Conn) ([]string, error) {
-	const maxSkip = 5
+	const (
+		maxSkip      = 2          // B3: real SSH servers send KEXINIT first
+		maxSkipBytes = 64 * 1024  // B3: per-connection amplification cap
+	)
+	var totalSkipped int
 	for skip := 0; skip < maxSkip; skip++ {
 		payload, err := readPacket(conn)
 		if err != nil {
@@ -96,6 +164,10 @@ func readKEXInit(conn net.Conn) ([]string, error) {
 			continue
 		}
 		if payload[0] != sshMsgKexInit {
+			totalSkipped += len(payload) + 8 // +8 approximates packet framing overhead
+			if totalSkipped > maxSkipBytes {
+				return nil, fmt.Errorf("exceeded %d byte limit waiting for KEXINIT", maxSkipBytes)
+			}
 			continue // skip non-KEXINIT packet
 		}
 		return parseKEXInitPayload(payload)
@@ -124,4 +196,21 @@ func parseKEXInitPayload(payload []byte) ([]string, error) {
 		return nil, fmt.Errorf("parse kex_algorithms: %w", err)
 	}
 	return kexMethods, nil
+}
+
+// sshParseTarget splits a "host:port" target into its components.
+// Defaults to port 22 when no port is specified.
+func sshParseTarget(target string) (host, port string, err error) {
+	h, p, e := net.SplitHostPort(target)
+	if e != nil {
+		// Try adding default SSH port.
+		h, p, e = net.SplitHostPort(target + ":22")
+		if e != nil {
+			return "", "", fmt.Errorf("invalid SSH target %q: %w", target, e)
+		}
+	}
+	if h == "" {
+		return "", "", fmt.Errorf("empty host in SSH target %q", target)
+	}
+	return h, p, nil
 }

--- a/pkg/engines/sshprobe/probe_test.go
+++ b/pkg/engines/sshprobe/probe_test.go
@@ -1,0 +1,245 @@
+package sshprobe
+
+import (
+	"encoding/binary"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// buildKEXInitPacket creates a minimal SSH_MSG_KEXINIT binary packet with the
+// given kex_algorithms list. All other name-list fields are empty.
+func buildKEXInitPacket(kexMethods []string) []byte {
+	payload := buildKEXInitPayload(kexMethods)
+	return buildSSHPacket(payload)
+}
+
+// buildKEXInitPayload creates the raw KEXINIT payload (without binary packet framing).
+func buildKEXInitPayload(kexMethods []string) []byte {
+	var buf []byte
+
+	// Type byte
+	buf = append(buf, sshMsgKexInit)
+
+	// 16-byte cookie (zeros for tests)
+	buf = append(buf, make([]byte, kexinitCookieLen)...)
+
+	// kex_algorithms name-list
+	buf = append(buf, encodeNameList(kexMethods)...)
+
+	// 9 remaining name-lists (all empty)
+	emptyList := encodeNameList(nil)
+	for i := 0; i < kexinitNameListCount-1; i++ {
+		buf = append(buf, emptyList...)
+	}
+
+	// first_kex_packet_follows boolean
+	buf = append(buf, 0)
+
+	// reserved uint32
+	buf = append(buf, 0, 0, 0, 0)
+
+	return buf
+}
+
+// serveFakeSSH serves a minimal SSH handshake: sends banner + KEXINIT,
+// reads client banner, then closes. Implemented as a test helper using
+// net.Pipe so no real network port is used.
+func serveFakeSSH(t *testing.T, serverID string, kexMethods []string) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+
+	go func() {
+		defer ln.Close()
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+		// Send server banner.
+		_, _ = conn.Write([]byte(serverID + "\r\n"))
+
+		// Read client banner (ignore it).
+		buf := make([]byte, 512)
+		for {
+			n, err := conn.Read(buf)
+			if err != nil || n == 0 {
+				break
+			}
+			s := string(buf[:n])
+			if strings.Contains(s, "\n") {
+				break
+			}
+		}
+
+		// Send KEXINIT.
+		pkt := buildKEXInitPacket(kexMethods)
+		_, _ = conn.Write(pkt)
+	}()
+
+	return addr
+}
+
+func TestProbe_ClassicalOnly(t *testing.T) {
+	methods := []string{
+		"curve25519-sha256",
+		"diffie-hellman-group14-sha256",
+		"ecdh-sha2-nistp256",
+	}
+	addr := serveFakeSSH(t, "SSH-2.0-OpenSSH_7.4", methods)
+
+	result := probeSSH(t.Context(), addr, 5*time.Second)
+
+	if result.Error != nil {
+		t.Fatalf("probeSSH error: %v", result.Error)
+	}
+	if result.ServerID != "SSH-2.0-OpenSSH_7.4" {
+		t.Errorf("ServerID = %q; want SSH-2.0-OpenSSH_7.4", result.ServerID)
+	}
+	if len(result.KEXMethods) != len(methods) {
+		t.Fatalf("KEXMethods len = %d; want %d", len(result.KEXMethods), len(methods))
+	}
+	for i, m := range methods {
+		if result.KEXMethods[i] != m {
+			t.Errorf("KEXMethods[%d] = %q; want %q", i, result.KEXMethods[i], m)
+		}
+	}
+}
+
+func TestProbe_MLKEMEnabled(t *testing.T) {
+	methods := []string{
+		"mlkem768x25519-sha256",
+		"curve25519-sha256",
+		"ecdh-sha2-nistp256",
+	}
+	addr := serveFakeSSH(t, "SSH-2.0-OpenSSH_10.0", methods)
+
+	result := probeSSH(t.Context(), addr, 5*time.Second)
+
+	if result.Error != nil {
+		t.Fatalf("probeSSH error: %v", result.Error)
+	}
+	if len(result.KEXMethods) == 0 {
+		t.Fatal("no KEX methods returned")
+	}
+	found := false
+	for _, m := range result.KEXMethods {
+		if m == "mlkem768x25519-sha256" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("mlkem768x25519-sha256 not in KEX methods: %v", result.KEXMethods)
+	}
+}
+
+func TestProbe_SntrupEnabled(t *testing.T) {
+	methods := []string{
+		"sntrup761x25519-sha512@openssh.com",
+		"curve25519-sha256",
+		"ecdh-sha2-nistp256",
+	}
+	addr := serveFakeSSH(t, "SSH-2.0-OpenSSH_9.0", methods)
+
+	result := probeSSH(t.Context(), addr, 5*time.Second)
+
+	if result.Error != nil {
+		t.Fatalf("probeSSH error: %v", result.Error)
+	}
+	found := false
+	for _, m := range result.KEXMethods {
+		if m == "sntrup761x25519-sha512@openssh.com" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("sntrup not in KEX methods: %v", result.KEXMethods)
+	}
+}
+
+func TestProbe_MixedPQC(t *testing.T) {
+	methods := []string{
+		"mlkem768x25519-sha256",
+		"sntrup761x25519-sha512@openssh.com",
+		"curve25519-sha256",
+		"diffie-hellman-group14-sha256",
+	}
+	addr := serveFakeSSH(t, "SSH-2.0-OpenSSH_10.0p1", methods)
+
+	result := probeSSH(t.Context(), addr, 5*time.Second)
+
+	if result.Error != nil {
+		t.Fatalf("probeSSH error: %v", result.Error)
+	}
+	if len(result.KEXMethods) != len(methods) {
+		t.Errorf("KEXMethods len = %d; want %d", len(result.KEXMethods), len(methods))
+	}
+}
+
+func TestProbe_Unreachable(t *testing.T) {
+	// Use a port that is not listening.
+	result := probeSSH(t.Context(), "127.0.0.1:1", 1*time.Second)
+	if result.Error == nil {
+		t.Fatal("expected error for unreachable target, got nil")
+	}
+}
+
+func TestProbe_NotSSH(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	go func() {
+		conn, _ := ln.Accept()
+		defer conn.Close()
+		_, _ = conn.Write([]byte("HTTP/1.0 200 OK\r\n\r\n"))
+	}()
+	defer ln.Close()
+
+	result := probeSSH(t.Context(), addr, 2*time.Second)
+	if result.Error == nil {
+		t.Fatal("expected error for non-SSH server, got nil")
+	}
+}
+
+// TestParseKEXInitPayload_Roundtrip verifies that a payload built by
+// buildKEXInitPayload is correctly parsed by parseKEXInitPayload.
+func TestParseKEXInitPayload_Roundtrip(t *testing.T) {
+	methods := []string{"mlkem768x25519-sha256", "curve25519-sha256"}
+	payload := buildKEXInitPayload(methods)
+	got, err := parseKEXInitPayload(payload)
+	if err != nil {
+		t.Fatalf("parseKEXInitPayload: %v", err)
+	}
+	if len(got) != len(methods) {
+		t.Fatalf("got %d methods; want %d", len(got), len(methods))
+	}
+	for i, m := range methods {
+		if got[i] != m {
+			t.Errorf("method[%d] = %q; want %q", i, got[i], m)
+		}
+	}
+}
+
+func TestParseKEXInitPayload_TooShort(t *testing.T) {
+	_, err := parseKEXInitPayload([]byte{sshMsgKexInit})
+	if err == nil {
+		t.Fatal("expected error for truncated KEXINIT, got nil")
+	}
+}
+
+// encodeNameList is duplicated from wire_test.go to keep probe_test self-contained.
+// Go test files in the same package share helpers, but we keep it explicit for clarity.
+func mustEncodeUint32(v uint32) []byte {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, v)
+	return b
+}

--- a/pkg/engines/sshprobe/probe_test.go
+++ b/pkg/engines/sshprobe/probe_test.go
@@ -95,7 +95,7 @@ func TestProbe_ClassicalOnly(t *testing.T) {
 	}
 	addr := serveFakeSSH(t, "SSH-2.0-OpenSSH_7.4", methods)
 
-	result := probeSSH(t.Context(), addr, 5*time.Second)
+	result := probeSSH(t.Context(), addr, 5*time.Second, false)
 
 	if result.Error != nil {
 		t.Fatalf("probeSSH error: %v", result.Error)
@@ -121,7 +121,7 @@ func TestProbe_MLKEMEnabled(t *testing.T) {
 	}
 	addr := serveFakeSSH(t, "SSH-2.0-OpenSSH_10.0", methods)
 
-	result := probeSSH(t.Context(), addr, 5*time.Second)
+	result := probeSSH(t.Context(), addr, 5*time.Second, false)
 
 	if result.Error != nil {
 		t.Fatalf("probeSSH error: %v", result.Error)
@@ -148,7 +148,7 @@ func TestProbe_SntrupEnabled(t *testing.T) {
 	}
 	addr := serveFakeSSH(t, "SSH-2.0-OpenSSH_9.0", methods)
 
-	result := probeSSH(t.Context(), addr, 5*time.Second)
+	result := probeSSH(t.Context(), addr, 5*time.Second, false)
 
 	if result.Error != nil {
 		t.Fatalf("probeSSH error: %v", result.Error)
@@ -173,7 +173,7 @@ func TestProbe_MixedPQC(t *testing.T) {
 	}
 	addr := serveFakeSSH(t, "SSH-2.0-OpenSSH_10.0p1", methods)
 
-	result := probeSSH(t.Context(), addr, 5*time.Second)
+	result := probeSSH(t.Context(), addr, 5*time.Second, false)
 
 	if result.Error != nil {
 		t.Fatalf("probeSSH error: %v", result.Error)
@@ -185,7 +185,7 @@ func TestProbe_MixedPQC(t *testing.T) {
 
 func TestProbe_Unreachable(t *testing.T) {
 	// Use a port that is not listening.
-	result := probeSSH(t.Context(), "127.0.0.1:1", 1*time.Second)
+	result := probeSSH(t.Context(), "127.0.0.1:1", 1*time.Second, false)
 	if result.Error == nil {
 		t.Fatal("expected error for unreachable target, got nil")
 	}
@@ -204,7 +204,7 @@ func TestProbe_NotSSH(t *testing.T) {
 	}()
 	defer ln.Close()
 
-	result := probeSSH(t.Context(), addr, 2*time.Second)
+	result := probeSSH(t.Context(), addr, 2*time.Second, false)
 	if result.Error == nil {
 		t.Fatal("expected error for non-SSH server, got nil")
 	}

--- a/pkg/engines/sshprobe/probe_test.go
+++ b/pkg/engines/sshprobe/probe_test.go
@@ -1,6 +1,7 @@
 package sshprobe
 
 import (
+	"context"
 	"encoding/binary"
 	"net"
 	"strings"
@@ -242,4 +243,213 @@ func mustEncodeUint32(v uint32) []byte {
 	b := make([]byte, 4)
 	binary.BigEndian.PutUint32(b, v)
 	return b
+}
+
+// serveFakeSSHWithPreamble sends preamble lines before the SSH banner.
+func serveFakeSSHWithPreamble(t *testing.T, preambleLines []string, serverID string, kexMethods []string) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+
+	go func() {
+		defer ln.Close()
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+		for _, line := range preambleLines {
+			_, _ = conn.Write([]byte(line + "\r\n"))
+		}
+		_, _ = conn.Write([]byte(serverID + "\r\n"))
+		buf := make([]byte, 512)
+		for {
+			n, err := conn.Read(buf)
+			if err != nil || n == 0 {
+				break
+			}
+			if strings.Contains(string(buf[:n]), "\n") {
+				break
+			}
+		}
+		pkt := buildKEXInitPacket(kexMethods)
+		_, _ = conn.Write(pkt)
+	}()
+
+	return addr
+}
+
+// A1 tests — RFC 4253 preamble line handling.
+
+func TestReadBannerWithPreamble_ZeroPreamble(t *testing.T) {
+	methods := []string{"curve25519-sha256"}
+	addr := serveFakeSSHWithPreamble(t, nil, "SSH-2.0-OpenSSH_9.0", methods)
+	result := probeSSH(t.Context(), addr, 5*time.Second, false)
+	if result.Error != nil {
+		t.Fatalf("expected success with no preamble: %v", result.Error)
+	}
+	if result.ServerID != "SSH-2.0-OpenSSH_9.0" {
+		t.Errorf("ServerID = %q; want SSH-2.0-OpenSSH_9.0", result.ServerID)
+	}
+}
+
+func TestReadBannerWithPreamble_OnePreamble(t *testing.T) {
+	methods := []string{"curve25519-sha256"}
+	addr := serveFakeSSHWithPreamble(t, []string{"This is a proxy greeting"}, "SSH-2.0-OpenSSH_9.0", methods)
+	result := probeSSH(t.Context(), addr, 5*time.Second, false)
+	if result.Error != nil {
+		t.Fatalf("expected success with 1 preamble line: %v", result.Error)
+	}
+	if result.ServerID != "SSH-2.0-OpenSSH_9.0" {
+		t.Errorf("ServerID = %q; want SSH-2.0-OpenSSH_9.0", result.ServerID)
+	}
+}
+
+func TestReadBannerWithPreamble_FivePreamble(t *testing.T) {
+	preamble := []string{
+		"Welcome to Bastion",
+		"Authorized access only",
+		"Session logged",
+		"Rate-limited: 3 per hour",
+		"Please authenticate",
+	}
+	methods := []string{"curve25519-sha256"}
+	addr := serveFakeSSHWithPreamble(t, preamble, "SSH-2.0-OpenSSH_9.0", methods)
+	result := probeSSH(t.Context(), addr, 5*time.Second, false)
+	if result.Error != nil {
+		t.Fatalf("expected success with 5 preamble lines: %v", result.Error)
+	}
+	if result.ServerID != "SSH-2.0-OpenSSH_9.0" {
+		t.Errorf("ServerID = %q; want SSH-2.0-OpenSSH_9.0", result.ServerID)
+	}
+}
+
+func TestReadBannerWithPreamble_TooManyLines(t *testing.T) {
+	// 10 preamble lines with no SSH- banner afterward → should error.
+	preamble := make([]string, maxBannerLines)
+	for i := range preamble {
+		preamble[i] = "preamble line"
+	}
+	// All lines are non-SSH-prefixed; the loop exhausts without finding a banner.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+		for _, line := range preamble {
+			_, _ = conn.Write([]byte(line + "\r\n"))
+		}
+		// No SSH- banner — connection eventually closes.
+	}()
+
+	result := probeSSH(t.Context(), ln.Addr().String(), 5*time.Second, false)
+	if result.Error == nil {
+		t.Fatal("expected error when 10 preamble lines have no SSH- banner")
+	}
+}
+
+func TestReadBannerWithPreamble_NoBannerEver(t *testing.T) {
+	// Server sends only preamble lines, never an SSH- line.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+		for i := 0; i < 3; i++ {
+			_, _ = conn.Write([]byte("not an ssh banner\r\n"))
+		}
+	}()
+
+	result := probeSSH(t.Context(), ln.Addr().String(), 5*time.Second, false)
+	if result.Error == nil {
+		t.Fatal("expected error when no SSH- banner was ever sent")
+	}
+}
+
+// A3 test — context cancel closes connection promptly mid-handshake.
+
+func TestProbeSSH_ContextCancelMidHandshake(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	// Stall server — accepts connection but never sends data.
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		time.Sleep(30 * time.Second) // stall indefinitely
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan ProbeResult, 1)
+	go func() {
+		done <- probeSSH(ctx, ln.Addr().String(), 10*time.Second, false)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case result := <-done:
+		if result.Error == nil {
+			t.Fatal("expected error after context cancel, got nil")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("probe did not return within 100ms after context cancel")
+	}
+}
+
+// B4 test — SSH-1.x banner rejection.
+
+func TestProbeSSH_SSH1xRejected(t *testing.T) {
+	cases := []struct {
+		name     string
+		serverID string
+		wantErr  bool
+	}{
+		{"ssh-2.0 accepted", "SSH-2.0-OpenSSH_9.0", false},
+		{"ssh-1.99 accepted", "SSH-1.99-OpenSSH_3.4", false},
+		{"ssh-1.5 rejected", "SSH-1.5-1.5.8", true},
+		{"ssh-1.0 rejected", "SSH-1.0-JSCH", true},
+		{"ssh-1.3 rejected", "SSH-1.3-PuTTY", true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			methods := []string{"diffie-hellman-group14-sha256"}
+			addr := serveFakeSSH(t, tc.serverID, methods)
+			result := probeSSH(t.Context(), addr, 5*time.Second, false)
+			if tc.wantErr && result.Error == nil {
+				t.Errorf("expected error for %q, got nil", tc.serverID)
+			}
+			if !tc.wantErr && result.Error != nil {
+				t.Errorf("unexpected error for %q: %v", tc.serverID, result.Error)
+			}
+		})
+	}
 }

--- a/pkg/engines/sshprobe/wire.go
+++ b/pkg/engines/sshprobe/wire.go
@@ -8,24 +8,23 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"net"
 	"strings"
 )
 
 const (
 	sshMsgKexInit  = 20
 	maxBannerLen   = 255
-	maxPacketLen   = 256 * 1024 // 256 KB safety cap per RFC 4253 §6.1
+	maxPacketLen   = 256 * 1024 // 256 KB defensive cap; RFC 4253 §6.1 requires ≥35000 bytes support, we accept larger with OOM protection
 	maxNameListLen = 64 * 1024  // 64 KB per name-list field
 )
 
 // readBanner reads the SSH identification string line (e.g. "SSH-2.0-OpenSSH_9.0").
 // It reads byte-by-byte until \n (with optional preceding \r), up to maxBannerLen.
 // Ref: RFC 4253 §4.2.
-func readBanner(conn net.Conn) (string, error) {
+func readBanner(r io.Reader) (string, error) {
 	buf := make([]byte, maxBannerLen+2)
 	for i := range buf {
-		if _, err := io.ReadFull(conn, buf[i:i+1]); err != nil {
+		if _, err := io.ReadFull(r, buf[i:i+1]); err != nil {
 			return "", fmt.Errorf("read banner: %w", err)
 		}
 		if buf[i] == '\n' {
@@ -38,9 +37,9 @@ func readBanner(conn net.Conn) (string, error) {
 
 // readPacket reads one binary SSH packet and returns the payload (without padding).
 // Ref: RFC 4253 §6 — uint32 packet_length, byte padding_length, payload, padding.
-func readPacket(conn net.Conn) ([]byte, error) {
+func readPacket(r io.Reader) ([]byte, error) {
 	var lenBuf [4]byte
-	if _, err := io.ReadFull(conn, lenBuf[:]); err != nil {
+	if _, err := io.ReadFull(r, lenBuf[:]); err != nil {
 		return nil, fmt.Errorf("read packet length: %w", err)
 	}
 	pktLen := binary.BigEndian.Uint32(lenBuf[:])
@@ -49,7 +48,7 @@ func readPacket(conn net.Conn) ([]byte, error) {
 	}
 
 	body := make([]byte, pktLen)
-	if _, err := io.ReadFull(conn, body); err != nil {
+	if _, err := io.ReadFull(r, body); err != nil {
 		return nil, fmt.Errorf("read packet body: %w", err)
 	}
 
@@ -65,6 +64,8 @@ func readPacket(conn net.Conn) ([]byte, error) {
 // parseNameList reads a comma-separated SSH name-list from payload starting at
 // offset. Returns the names, the new offset after the list, and any error.
 // Ref: RFC 4253 §5 — name-list = uint32 length + bytes (comma-separated).
+// A6: Each name is validated for printable US-ASCII per RFC 4253 §5 (bytes
+// 0x21–0x2B, 0x2D–0x7E; excludes space 0x20 and comma 0x2C).
 func parseNameList(payload []byte, offset int) ([]string, int, error) {
 	if offset+4 > len(payload) {
 		return nil, offset, fmt.Errorf("parseNameList: need 4 bytes for length at offset %d, have %d", offset, len(payload)-offset)
@@ -82,5 +83,29 @@ func parseNameList(payload []byte, offset int) ([]string, int, error) {
 	if raw == "" {
 		return nil, offset, nil
 	}
-	return strings.Split(raw, ","), offset, nil
+	names := strings.Split(raw, ",")
+	for _, name := range names {
+		if !isValidNameASCII(name) {
+			return nil, offset, fmt.Errorf("parseNameList: algorithm name contains invalid byte: %q", name)
+		}
+	}
+	return names, offset, nil
+}
+
+// isValidNameASCII reports whether every byte in s is within the printable
+// US-ASCII range permitted for SSH algorithm names per RFC 4253 §5:
+// 0x21–0x2B and 0x2D–0x7E (printable ASCII excluding space 0x20 and comma 0x2C).
+// An empty name is rejected (commas create empty fields → malformed name-list).
+func isValidNameASCII(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		if (b >= 0x21 && b <= 0x2B) || (b >= 0x2D && b <= 0x7E) {
+			continue
+		}
+		return false
+	}
+	return true
 }

--- a/pkg/engines/sshprobe/wire.go
+++ b/pkg/engines/sshprobe/wire.go
@@ -1,0 +1,86 @@
+// Package sshprobe implements a Tier 5 (Network) engine that probes live SSH
+// endpoints and detects quantum-vulnerable key exchange methods advertised in
+// SSH_MSG_KEXINIT. It is pure Go, requires no external binaries, and only
+// reads the server's KEXINIT advertisement — it never completes an SSH session.
+package sshprobe
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+)
+
+const (
+	sshMsgKexInit  = 20
+	maxBannerLen   = 255
+	maxPacketLen   = 256 * 1024 // 256 KB safety cap per RFC 4253 §6.1
+	maxNameListLen = 64 * 1024  // 64 KB per name-list field
+)
+
+// readBanner reads the SSH identification string line (e.g. "SSH-2.0-OpenSSH_9.0").
+// It reads byte-by-byte until \n (with optional preceding \r), up to maxBannerLen.
+// Ref: RFC 4253 §4.2.
+func readBanner(conn net.Conn) (string, error) {
+	buf := make([]byte, maxBannerLen+2)
+	for i := range buf {
+		if _, err := io.ReadFull(conn, buf[i:i+1]); err != nil {
+			return "", fmt.Errorf("read banner: %w", err)
+		}
+		if buf[i] == '\n' {
+			line := string(buf[:i])
+			return strings.TrimSuffix(line, "\r"), nil
+		}
+	}
+	return "", fmt.Errorf("ssh banner too long (exceeded %d bytes without newline)", maxBannerLen)
+}
+
+// readPacket reads one binary SSH packet and returns the payload (without padding).
+// Ref: RFC 4253 §6 — uint32 packet_length, byte padding_length, payload, padding.
+func readPacket(conn net.Conn) ([]byte, error) {
+	var lenBuf [4]byte
+	if _, err := io.ReadFull(conn, lenBuf[:]); err != nil {
+		return nil, fmt.Errorf("read packet length: %w", err)
+	}
+	pktLen := binary.BigEndian.Uint32(lenBuf[:])
+	if pktLen < 2 || pktLen > maxPacketLen {
+		return nil, fmt.Errorf("invalid packet_length %d (must be 2..%d)", pktLen, maxPacketLen)
+	}
+
+	body := make([]byte, pktLen)
+	if _, err := io.ReadFull(conn, body); err != nil {
+		return nil, fmt.Errorf("read packet body: %w", err)
+	}
+
+	// body[0] = padding_length; payload = body[1 : pktLen-padding_length]
+	paddingLen := int(body[0])
+	payloadLen := int(pktLen) - 1 - paddingLen
+	if payloadLen < 0 || payloadLen > int(pktLen)-1 {
+		return nil, fmt.Errorf("invalid padding_length %d for packet_length %d", paddingLen, pktLen)
+	}
+	return body[1 : 1+payloadLen], nil
+}
+
+// parseNameList reads a comma-separated SSH name-list from payload starting at
+// offset. Returns the names, the new offset after the list, and any error.
+// Ref: RFC 4253 §5 — name-list = uint32 length + bytes (comma-separated).
+func parseNameList(payload []byte, offset int) ([]string, int, error) {
+	if offset+4 > len(payload) {
+		return nil, offset, fmt.Errorf("parseNameList: need 4 bytes for length at offset %d, have %d", offset, len(payload)-offset)
+	}
+	length := int(binary.BigEndian.Uint32(payload[offset : offset+4]))
+	offset += 4
+	if length > maxNameListLen {
+		return nil, offset, fmt.Errorf("parseNameList: length %d exceeds max %d", length, maxNameListLen)
+	}
+	if offset+length > len(payload) {
+		return nil, offset, fmt.Errorf("parseNameList: truncated: need %d bytes at offset %d, have %d", length, offset, len(payload)-offset)
+	}
+	raw := string(payload[offset : offset+length])
+	offset += length
+	if raw == "" {
+		return nil, offset, nil
+	}
+	return strings.Split(raw, ","), offset, nil
+}

--- a/pkg/engines/sshprobe/wire_boundary_test.go
+++ b/pkg/engines/sshprobe/wire_boundary_test.go
@@ -1,0 +1,299 @@
+// wire_boundary_test.go — boundary-value tests for SSH wire-format parsing.
+//
+// Purpose: exhaustively verify that readPacket, parseNameList, and readBanner
+// enforce documented limits at exact boundary values. Tests are grouped by
+// function and cover zero, just-below-minimum, exactly-at-maximum, and
+// just-over-maximum inputs. All "must error" cases assert a non-nil error.
+package sshprobe
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+// ─── readPacket packet_length boundaries ────────────────────────────────────
+
+// TestReadPacket_Boundary_PacketLength verifies every defined boundary for
+// the packet_length field. packet_length must be in [2, maxPacketLen].
+func TestReadPacket_Boundary_PacketLength(t *testing.T) {
+	cases := []struct {
+		name      string
+		pktLen    uint32
+		wantError bool
+		note      string
+	}{
+		{
+			name: "length_0_must_error",
+			// packet_length=0 fails: min is 2 (1 byte padding_length + ≥1 byte payload)
+			pktLen: 0, wantError: true, note: "below minimum (< 2)",
+		},
+		{
+			name: "length_1_must_error",
+			// packet_length=1 fails: still below minimum of 2
+			pktLen: 1, wantError: true, note: "at minimum-1 (still < 2)",
+		},
+		{
+			name: "length_2_minimum_valid",
+			// packet_length=2: padding_length(1)+payload(1). Body read will succeed
+			// only if we actually send the 2-byte body. Build via helper.
+			pktLen:    0, // not used when building via helper
+			wantError: false,
+		},
+		{
+			name: "length_35000_valid",
+			// 35000 bytes is well within the 256 KB (262144) cap.
+			pktLen:    0,
+			wantError: false,
+		},
+		{
+			name: "length_maxPacketLen_valid",
+			// Exactly at the cap must succeed.
+			pktLen:    0,
+			wantError: false,
+		},
+		{
+			name:      "length_maxPacketLen_plus1_must_error",
+			pktLen:    uint32(maxPacketLen) + 1,
+			wantError: true,
+			note:      "one over cap",
+		},
+		{
+			name:      "length_0xFFFFFFFF_must_error",
+			pktLen:    0xFFFFFFFF,
+			wantError: true,
+			note:      "max uint32",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var raw []byte
+			switch tc.name {
+			case "length_2_minimum_valid":
+				// Build a real packet with 1-byte payload (0x00)
+				raw = buildSSHPacket([]byte{0x00})
+			case "length_35000_valid":
+				raw = buildSSHPacket(bytes.Repeat([]byte{0x42}, 35000))
+			case "length_maxPacketLen_valid":
+				// maxPacketLen bytes payload is too large to build directly in memory
+				// (it would be 256 KB). Instead, send the 4-byte header + minimal body
+				// indicating padding_length=0 and fill payload so total body = maxPacketLen.
+				body := make([]byte, maxPacketLen)
+				body[0] = 0 // padding_length = 0
+				fill := make([]byte, 4)
+				binary.BigEndian.PutUint32(fill, uint32(maxPacketLen))
+				raw = append(fill, body...)
+			default:
+				// For error cases, only send the 4-byte length header (no body).
+				raw = make([]byte, 4)
+				binary.BigEndian.PutUint32(raw, tc.pktLen)
+			}
+
+			conn := connFromBytes(t, raw)
+			_, err := readPacket(conn)
+			if tc.wantError {
+				if err == nil {
+					t.Errorf("[%s] expected error (note: %s), got nil", tc.name, tc.note)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("[%s] unexpected error: %v", tc.name, err)
+				}
+			}
+		})
+	}
+}
+
+// ─── parseNameList name-list length boundaries ───────────────────────────────
+
+// TestParseNameList_Boundary_Length verifies name-list length field boundaries.
+func TestParseNameList_Boundary_Length(t *testing.T) {
+	t.Run("length_0_empty_list", func(t *testing.T) {
+		// length=0 → empty name-list, no error.
+		payload := encodeNameList(nil)
+		got, off, err := parseNameList(payload, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("expected empty list, got %v", got)
+		}
+		if off != len(payload) {
+			t.Errorf("offset=%d, want %d", off, len(payload))
+		}
+	})
+
+	t.Run("length_4_single_name", func(t *testing.T) {
+		// length=4 bytes, content="curl" → single name "curl"
+		payload := encodeNameList([]string{"curl"})
+		got, _, err := parseNameList(payload, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 || got[0] != "curl" {
+			t.Errorf("expected [curl], got %v", got)
+		}
+	})
+
+	t.Run("length_exactly_maxNameListLen_valid", func(t *testing.T) {
+		// A single name of exactly maxNameListLen bytes should succeed.
+		name := strings.Repeat("x", maxNameListLen)
+		payload := encodeNameList([]string{name})
+		_, _, err := parseNameList(payload, 0)
+		if err != nil {
+			t.Errorf("unexpected error at exact maxNameListLen: %v", err)
+		}
+	})
+
+	t.Run("length_1MiB_must_error", func(t *testing.T) {
+		// 1 MiB > maxNameListLen (64 KB) — must be rejected immediately.
+		const oneMiB = 1 << 20
+		payload := make([]byte, 4)
+		binary.BigEndian.PutUint32(payload, oneMiB)
+		_, _, err := parseNameList(payload, 0)
+		if err == nil {
+			t.Error("expected error for 1 MiB name-list length, got nil")
+		}
+	})
+
+	t.Run("length_maxNameListLen_plus1_must_error", func(t *testing.T) {
+		payload := make([]byte, 4)
+		binary.BigEndian.PutUint32(payload, uint32(maxNameListLen+1))
+		_, _, err := parseNameList(payload, 0)
+		if err == nil {
+			t.Error("expected error for maxNameListLen+1, got nil")
+		}
+	})
+
+	t.Run("length_0xFFFFFFFF_must_error", func(t *testing.T) {
+		payload := make([]byte, 4)
+		binary.BigEndian.PutUint32(payload, 0xFFFFFFFF)
+		_, _, err := parseNameList(payload, 0)
+		if err == nil {
+			t.Error("expected error for 0xFFFFFFFF, got nil")
+		}
+	})
+
+	t.Run("claimed_length_exceeds_payload_must_error", func(t *testing.T) {
+		// Claim 1000 bytes but only provide 4 (just the length header).
+		payload := make([]byte, 4)
+		binary.BigEndian.PutUint32(payload, 1000)
+		_, _, err := parseNameList(payload, 0)
+		if err == nil {
+			t.Error("expected error for truncated payload, got nil")
+		}
+	})
+
+	t.Run("payload_too_short_for_length_field", func(t *testing.T) {
+		// Only 3 bytes — cannot read the 4-byte length prefix.
+		_, _, err := parseNameList([]byte{0, 0, 0}, 0)
+		if err == nil {
+			t.Error("expected error for 3-byte payload, got nil")
+		}
+	})
+
+	t.Run("offset_at_end_must_error", func(t *testing.T) {
+		payload := []byte{1, 2, 3, 4}
+		_, _, err := parseNameList(payload, 4) // offset == len(payload)
+		if err == nil {
+			t.Error("expected error when offset == len(payload), got nil")
+		}
+	})
+
+	t.Run("offset_beyond_payload_must_error", func(t *testing.T) {
+		payload := []byte{1, 2, 3, 4}
+		_, _, err := parseNameList(payload, 10) // offset > len(payload)
+		if err == nil {
+			t.Error("expected error when offset > len(payload), got nil")
+		}
+	})
+}
+
+// ─── readBanner banner length boundaries ─────────────────────────────────────
+
+// TestReadBanner_Boundary_Length verifies readBanner at critical byte counts.
+func TestReadBanner_Boundary_Length(t *testing.T) {
+	t.Run("zero_bytes_must_error", func(t *testing.T) {
+		conn := connFromBytes(t, []byte{})
+		_, err := readBanner(conn)
+		if err == nil {
+			t.Error("expected error for 0-byte input, got nil")
+		}
+	})
+
+	t.Run("newline_only", func(t *testing.T) {
+		// Single '\n' → valid banner, returns empty string.
+		conn := connFromBytes(t, []byte{'\n'})
+		got, err := readBanner(conn)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "" {
+			t.Errorf("expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("crlf_only", func(t *testing.T) {
+		conn := connFromBytes(t, []byte{'\r', '\n'})
+		got, err := readBanner(conn)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "" {
+			t.Errorf("expected empty string after stripping CRLF, got %q", got)
+		}
+	})
+
+	t.Run("254_bytes_with_crlf_valid", func(t *testing.T) {
+		// 254 content bytes + "\r\n" = 256 total.
+		// readBanner loops up to maxBannerLen+2 = 257 iterations.
+		// '\n' is at position 255, within the loop range — must succeed.
+		content := bytes.Repeat([]byte("X"), 254)
+		data := append(content, '\r', '\n')
+		conn := connFromBytes(t, data)
+		got, err := readBanner(conn)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 254 {
+			t.Errorf("got banner len=%d, want 254", len(got))
+		}
+	})
+
+	t.Run("255_bytes_no_newline_must_error", func(t *testing.T) {
+		// 255 bytes with no newline: loop exhausts buffer (maxBannerLen+2=257),
+		// then EOF — must error.
+		data := bytes.Repeat([]byte("A"), 255)
+		conn := connFromBytes(t, data)
+		_, err := readBanner(conn)
+		if err == nil {
+			t.Error("expected error for 255-byte banner with no newline, got nil")
+		}
+	})
+
+	t.Run("banner_at_max_content_plus_newline", func(t *testing.T) {
+		// maxBannerLen content bytes + '\n': '\n' is at position maxBannerLen (255),
+		// which is index 255 in the buf of size 257. Within loop bounds — should succeed.
+		data := append(bytes.Repeat([]byte("B"), maxBannerLen), '\n')
+		conn := connFromBytes(t, data)
+		got, err := readBanner(conn)
+		if err != nil {
+			t.Fatalf("unexpected error at maxBannerLen content + newline: %v", err)
+		}
+		if len(got) != maxBannerLen {
+			t.Errorf("banner len=%d, want %d", len(got), maxBannerLen)
+		}
+	})
+
+	t.Run("over_max_banner_no_newline_must_error", func(t *testing.T) {
+		// maxBannerLen+1 bytes with no newline exhausts the loop.
+		data := bytes.Repeat([]byte("C"), maxBannerLen+10)
+		conn := connFromBytes(t, data)
+		_, err := readBanner(conn)
+		if err == nil {
+			t.Error("expected error for banner exceeding maxBannerLen+2 without newline, got nil")
+		}
+	})
+}

--- a/pkg/engines/sshprobe/wire_fuzz_test.go
+++ b/pkg/engines/sshprobe/wire_fuzz_test.go
@@ -1,0 +1,225 @@
+// wire_fuzz_test.go — fuzz tests for the SSH wire-format parsing functions.
+//
+// Purpose: drive FuzzReadBanner, FuzzReadPacket, and FuzzParseNameList with
+// structured seed corpus (valid SSH captures + malformed variants) and assert
+// that no input causes a panic. Each fuzzer is seeded with real-world values
+// synthesised from RFC 4253 §4, §6 and the OpenSSH 7.4/8.5/9.0/10.0 defaults.
+//
+// Run with:
+//   go test -fuzz=FuzzReadBanner   -fuzztime=60s ./pkg/engines/sshprobe/
+//   go test -fuzz=FuzzReadPacket   -fuzztime=60s ./pkg/engines/sshprobe/
+//   go test -fuzz=FuzzParseNameList -fuzztime=60s ./pkg/engines/sshprobe/
+package sshprobe
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fuzzConnFromBytes wraps data in a net.Conn-like pipe with a short deadline so
+// fuzz iterations don't block indefinitely on partial reads.
+func fuzzConnFromBytes(data []byte) net.Conn {
+	client, server := net.Pipe()
+	_ = client.SetDeadline(time.Now().Add(2 * time.Second))
+	_ = server.SetDeadline(time.Now().Add(2 * time.Second))
+	go func() {
+		_, _ = server.Write(data)
+		server.Close()
+	}()
+	return client
+}
+
+// FuzzReadBanner feeds arbitrary byte sequences to readBanner and asserts no panic.
+// Seeds:
+//   - valid OpenSSH banners (7.4, 8.5, 9.0, 10.0)
+//   - truncated banner (no newline)
+//   - zero-length input
+//   - max-length content without newline
+//   - embedded NUL bytes
+//   - CRLF injection (\r\n in the middle of the string)
+//   - invalid UTF-8 sequences
+func FuzzReadBanner(f *testing.F) {
+	// Valid seeds from OpenSSH history
+	f.Add([]byte("SSH-2.0-OpenSSH_7.4\r\n"))
+	f.Add([]byte("SSH-2.0-OpenSSH_8.5\r\n"))
+	f.Add([]byte("SSH-2.0-OpenSSH_9.0\r\n"))
+	f.Add([]byte("SSH-2.0-OpenSSH_10.0\r\n"))
+	f.Add([]byte("SSH-2.0-dropbear_2022.83\r\n"))
+	f.Add([]byte("SSH-1.99-OpenSSH_3.8p1\r\n"))
+
+	// Malformed variants
+	f.Add([]byte{}) // zero-length
+	f.Add([]byte("SSH-2.0-OpenSSH_9.0")) // no newline — truncated
+	f.Add(bytes.Repeat([]byte("A"), maxBannerLen+50)) // exceeds cap, no newline
+	f.Add([]byte("SSH-2.0-\x00NUL\r\n")) // embedded NUL
+	f.Add([]byte("SSH-2.0-test\r\nEXTRA")) // extra bytes after banner
+	f.Add([]byte("\r\n")) // bare CRLF — empty banner
+	f.Add([]byte{0xFF, 0xFE, 0xFD, '\n'}) // invalid UTF-8 before newline
+	f.Add([]byte("SSH-2.0-\xc3\x28\r\n")) // invalid UTF-8 sequence mid-banner
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		conn := fuzzConnFromBytes(data)
+		defer conn.Close()
+		// Must not panic — error is expected for malformed input.
+		_, _ = readBanner(conn)
+	})
+}
+
+// FuzzReadPacket feeds arbitrary byte sequences to readPacket and asserts no panic.
+// Seeds:
+//   - valid SSH binary packets with KEXINIT payload
+//   - truncated (only 4-byte length header)
+//   - zero-length packet_length field bytes
+//   - max packet_length (256 KB)
+//   - oversized claimed length (0xFFFFFFFF)
+//   - padding_length larger than body
+//   - single-byte payload
+func FuzzReadPacket(f *testing.F) {
+	// Build valid seed packets using the helper from wire_test.go.
+	validPayload := []byte{sshMsgKexInit, 1, 2, 3}
+	f.Add(buildSSHPacket(validPayload))
+
+	// Minimal valid packet (padding_length + 1 byte payload)
+	f.Add(buildSSHPacket([]byte{42}))
+
+	// Truncated: just the length field, no body
+	f.Add([]byte{0, 0, 0, 10})
+
+	// Zero-length packet_length
+	hdr := make([]byte, 4)
+	binary.BigEndian.PutUint32(hdr, 0)
+	f.Add(hdr)
+
+	// packet_length = 1 (below minimum of 2)
+	hdr1 := make([]byte, 4)
+	binary.BigEndian.PutUint32(hdr1, 1)
+	f.Add(hdr1)
+
+	// packet_length exactly at maxPacketLen
+	hdrMax := make([]byte, 4)
+	binary.BigEndian.PutUint32(hdrMax, uint32(maxPacketLen))
+	f.Add(hdrMax) // no body — body read will fail, but no panic
+
+	// packet_length > maxPacketLen (0xFFFFFFFF)
+	hdrBig := make([]byte, 4)
+	binary.BigEndian.PutUint32(hdrBig, 0xFFFFFFFF)
+	f.Add(hdrBig)
+
+	// padding_length == body length (payloadLen would be 0 or negative)
+	// packet_length = 5: body[0]=padding_length=4, body[1..4]=payload, no room
+	body5 := make([]byte, 9) // 4-byte hdr + 5-byte body
+	binary.BigEndian.PutUint32(body5[:4], 5)
+	body5[4] = 4 // padding = 4, payload = 0
+	f.Add(body5)
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		conn := fuzzConnFromBytes(data)
+		defer conn.Close()
+		_, _ = readPacket(conn)
+	})
+}
+
+// FuzzParseNameList feeds arbitrary byte payloads to parseNameList and asserts no panic.
+// Property check: if parsing succeeds and the input was produced by encodeNameList,
+// the round-trip must recover the original list.
+// Seeds:
+//   - real-world OpenSSH 7.4/8.5/9.0/10.0 kex name-list encodings
+//   - zero-length list
+//   - billion-comma injection (large name-list with many empty entries)
+//   - embedded NUL bytes inside names
+//   - invalid UTF-8 bytes within names
+//   - claimed length exceeding actual payload
+//   - claimed length 0xFFFFFFFF
+func FuzzParseNameList(f *testing.F) {
+	// Valid seeds: real OpenSSH kex advertisements
+	openssh74 := []string{
+		"curve25519-sha256", "curve25519-sha256@libssh.org",
+		"ecdh-sha2-nistp256", "ecdh-sha2-nistp384", "ecdh-sha2-nistp521",
+		"diffie-hellman-group-exchange-sha256", "diffie-hellman-group14-sha256",
+		"diffie-hellman-group14-sha1",
+	}
+	f.Add(encodeNameList(openssh74))
+
+	openssh85 := []string{
+		"sntrup761x25519-sha512@openssh.com",
+		"curve25519-sha256", "curve25519-sha256@libssh.org",
+		"ecdh-sha2-nistp256", "ecdh-sha2-nistp384", "ecdh-sha2-nistp521",
+		"diffie-hellman-group-exchange-sha256", "diffie-hellman-group16-sha512",
+		"diffie-hellman-group18-sha512", "diffie-hellman-group14-sha256",
+	}
+	f.Add(encodeNameList(openssh85))
+
+	openssh100 := []string{
+		"mlkem768x25519-sha256",
+		"curve25519-sha256", "curve25519-sha256@libssh.org",
+		"ecdh-sha2-nistp256", "ecdh-sha2-nistp384", "ecdh-sha2-nistp521",
+		"diffie-hellman-group-exchange-sha256", "diffie-hellman-group16-sha512",
+		"diffie-hellman-group18-sha512", "diffie-hellman-group14-sha256",
+	}
+	f.Add(encodeNameList(openssh100))
+
+	// Empty list
+	f.Add(encodeNameList(nil))
+
+	// Single name
+	f.Add(encodeNameList([]string{"curve25519-sha256"}))
+
+	// Billion-comma injection: a single 64-KB buffer of commas
+	commas := bytes.Repeat([]byte(","), maxNameListLen)
+	commaPayload := make([]byte, 4+len(commas))
+	binary.BigEndian.PutUint32(commaPayload[:4], uint32(len(commas)))
+	copy(commaPayload[4:], commas)
+	f.Add(commaPayload)
+
+	// Claimed length 0xFFFFFFFF (must reject immediately)
+	bigLen := make([]byte, 4)
+	binary.BigEndian.PutUint32(bigLen, 0xFFFFFFFF)
+	f.Add(bigLen)
+
+	// Payload shorter than claimed length
+	shortPayload := make([]byte, 4+2)
+	binary.BigEndian.PutUint32(shortPayload[:4], 100)
+	f.Add(shortPayload)
+
+	// Embedded NUL in name
+	nullName := encodeNameList([]string{"curve25519\x00-sha256"})
+	f.Add(nullName)
+
+	// Invalid UTF-8 inside name
+	invalidUTF8 := encodeNameList([]string{"mlkem768\xc3\x28-sha256"})
+	f.Add(invalidUTF8)
+
+	// CRLF injection inside name
+	crlfName := encodeNameList([]string{"diffie-hellman\r\ninjection"})
+	f.Add(crlfName)
+
+	// Max-length single name (at the 64 KB cap)
+	maxName := strings.Repeat("x", maxNameListLen)
+	f.Add(encodeNameList([]string{maxName}))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Must not panic regardless of input.
+		names, _, _ := parseNameList(data, 0)
+
+		// Property: if the data was produced by encodeNameList, parsed names must
+		// be decodable back to the same content.
+		// We can't verify round-trip in fuzz mode (input is mutated), but we CAN
+		// verify internal consistency: re-encoding the parsed names and parsing again
+		// must produce the same list.
+		if len(names) > 0 {
+			re := encodeNameList(names)
+			names2, _, err2 := parseNameList(re, 0)
+			if err2 != nil {
+				t.Errorf("re-encoding parsed names failed: %v", err2)
+				return
+			}
+			if strings.Join(names2, ",") != strings.Join(names, ",") {
+				t.Errorf("round-trip mismatch: %v vs %v", names, names2)
+			}
+		}
+	})
+}

--- a/pkg/engines/sshprobe/wire_property_test.go
+++ b/pkg/engines/sshprobe/wire_property_test.go
@@ -1,0 +1,140 @@
+// wire_property_test.go — property-based tests for SSH wire-format codec functions.
+//
+// Purpose: verify that encodeNameList / parseNameList form a lossless round-trip
+// for arbitrary valid UTF-8 name lists, and that buildSSHPacket / readPacket form
+// a lossless round-trip for arbitrary payload lengths (0..35000 bytes).
+//
+// Uses testing/quick for randomised generation; deterministic with a fixed seed
+// via testing.F for regression stability.
+package sshprobe
+
+import (
+	"bytes"
+	"math/rand"
+	"strings"
+	"testing"
+	"testing/quick"
+)
+
+// TestNameListRoundTrip_Property verifies parseNameList(encodeNameList(list)) == list
+// for randomised name lists. Names are restricted to printable ASCII to stay within
+// valid SSH name-list encoding (RFC 4253 §5: names are US-ASCII printable).
+func TestNameListRoundTrip_Property(t *testing.T) {
+	// quick.Check generates random inputs. The property function receives a
+	// []string and asserts the codec round-trip.
+	err := quick.Check(func(names []string) bool {
+		// Filter to printable ASCII names (RFC 4253 compliance).
+		valid := make([]string, 0, len(names))
+		for _, n := range names {
+			if n == "" {
+				continue // empty names are dropped; skip to keep test pure
+			}
+			if isPrintableASCII(n) {
+				valid = append(valid, n)
+			}
+		}
+		if len(valid) == 0 {
+			return true // nothing to test for empty-after-filter input
+		}
+		// Total encoded size must not exceed maxNameListLen to avoid triggering
+		// the cap (which is tested separately in wire_boundary_test.go).
+		joined := strings.Join(valid, ",")
+		if len(joined) > maxNameListLen {
+			return true // skip oversized inputs
+		}
+
+		encoded := encodeNameList(valid)
+		got, newOff, err := parseNameList(encoded, 0)
+		if err != nil {
+			return false
+		}
+		if newOff != len(encoded) {
+			return false
+		}
+		return strings.Join(got, ",") == strings.Join(valid, ",")
+	}, &quick.Config{MaxCount: 1000})
+	if err != nil {
+		t.Errorf("name-list round-trip property failed: %v", err)
+	}
+}
+
+// TestNameListRoundTrip_KnownLists verifies the codec against concrete real-world
+// OpenSSH KEX method lists (deterministic complement to the property test).
+func TestNameListRoundTrip_KnownLists(t *testing.T) {
+	lists := [][]string{
+		{"curve25519-sha256"},
+		{"mlkem768x25519-sha256", "curve25519-sha256", "ecdh-sha2-nistp256"},
+		{"sntrup761x25519-sha512@openssh.com", "curve25519-sha256@libssh.org"},
+		{"diffie-hellman-group14-sha256", "diffie-hellman-group14-sha1"},
+	}
+	for _, list := range lists {
+		encoded := encodeNameList(list)
+		got, off, err := parseNameList(encoded, 0)
+		if err != nil {
+			t.Errorf("parseNameList error for %v: %v", list, err)
+			continue
+		}
+		if off != len(encoded) {
+			t.Errorf("newOffset=%d, want %d for %v", off, len(encoded), list)
+		}
+		if strings.Join(got, ",") != strings.Join(list, ",") {
+			t.Errorf("round-trip mismatch: got %v, want %v", got, list)
+		}
+	}
+}
+
+// TestReadPacketRoundTrip_Property verifies buildSSHPacket / readPacket round-trip
+// for payloads of random lengths in [0..35000] bytes.
+func TestReadPacketRoundTrip_Property(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x53534842)) // deterministic seed: "SSHB"
+	const iterations = 300
+
+	for i := 0; i < iterations; i++ {
+		size := rng.Intn(35001) // [0, 35000]
+		payload := make([]byte, size)
+		if size > 0 {
+			_, _ = rng.Read(payload)
+		}
+
+		raw := buildSSHPacket(payload)
+		conn := connFromBytes(t, raw)
+		got, err := readPacket(conn)
+		if err != nil {
+			t.Errorf("iteration %d (size=%d): readPacket error: %v", i, size, err)
+			continue
+		}
+		if !bytes.Equal(got, payload) {
+			t.Errorf("iteration %d (size=%d): payload mismatch: got %d bytes, want %d bytes",
+				i, size, len(got), len(payload))
+		}
+	}
+}
+
+// TestReadPacketRoundTrip_FixedSizes verifies exact payload sizes that hit edge cases
+// in the padding calculation inside buildSSHPacket.
+func TestReadPacketRoundTrip_FixedSizes(t *testing.T) {
+	for _, size := range []int{0, 1, 7, 8, 9, 15, 16, 17, 255, 256, 1023, 1024, 32767, 35000} {
+		payload := bytes.Repeat([]byte{0x42}, size)
+		raw := buildSSHPacket(payload)
+		conn := connFromBytes(t, raw)
+		got, err := readPacket(conn)
+		if err != nil {
+			t.Errorf("size=%d: readPacket error: %v", size, err)
+			continue
+		}
+		if !bytes.Equal(got, payload) {
+			t.Errorf("size=%d: round-trip mismatch: got %d bytes", size, len(got))
+		}
+	}
+}
+
+// isPrintableASCII returns true if every byte in s is a printable ASCII character
+// and does not contain a comma (commas are the name-list delimiter).
+func isPrintableASCII(s string) bool {
+	for _, b := range []byte(s) {
+		if b < 0x21 || b > 0x7E || b == ',' {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/engines/sshprobe/wire_test.go
+++ b/pkg/engines/sshprobe/wire_test.go
@@ -214,3 +214,69 @@ func connFromReader(t *testing.T, data []byte) net.Conn {
 	t.Cleanup(func() { c.Close() })
 	return c
 }
+
+// A6 — printable-ASCII validation in parseNameList.
+
+// buildNameListWithRaw builds a name-list payload containing exactly the raw bytes
+// provided as the single algorithm name (bypasses encodeNameList's string handling).
+func buildNameListWithRaw(name []byte) []byte {
+	buf := make([]byte, 4+len(name))
+	binary.BigEndian.PutUint32(buf, uint32(len(name)))
+	copy(buf[4:], name)
+	return buf
+}
+
+func TestParseNameList_NULByte(t *testing.T) {
+	payload := buildNameListWithRaw([]byte("curve25519-sha256\x00evil"))
+	_, _, err := parseNameList(payload, 0)
+	if err == nil {
+		t.Fatal("expected error for name containing NUL byte, got nil")
+	}
+}
+
+func TestParseNameList_ANSIEscape(t *testing.T) {
+	payload := buildNameListWithRaw([]byte("\x1b[31mcurve25519-sha256\x1b[0m"))
+	_, _, err := parseNameList(payload, 0)
+	if err == nil {
+		t.Fatal("expected error for name containing ANSI escape sequence, got nil")
+	}
+}
+
+func TestParseNameList_EmbeddedNewline(t *testing.T) {
+	payload := buildNameListWithRaw([]byte("curve25519\nsha256"))
+	_, _, err := parseNameList(payload, 0)
+	if err == nil {
+		t.Fatal("expected error for name containing embedded newline, got nil")
+	}
+}
+
+func TestParseNameList_ValidWithAtDomainSuffix(t *testing.T) {
+	// RFC 4250 §4.6.1: vendor-specific names use the form name@domain.tld.
+	// Ensure '@', '.', '-' and alphanumerics all pass validation.
+	name := "sntrup761x25519-sha512@openssh.com"
+	payload := encodeNameList([]string{name})
+	got, _, err := parseNameList(payload, 0)
+	if err != nil {
+		t.Fatalf("unexpected error for valid @domain name: %v", err)
+	}
+	if len(got) != 1 || got[0] != name {
+		t.Errorf("got %v; want [%q]", got, name)
+	}
+}
+
+func TestParseNameList_SpaceInName(t *testing.T) {
+	payload := buildNameListWithRaw([]byte("curve 25519-sha256"))
+	_, _, err := parseNameList(payload, 0)
+	if err == nil {
+		t.Fatal("expected error for name containing space (0x20), got nil")
+	}
+}
+
+func TestParseNameList_EmptyNameEntry(t *testing.T) {
+	// Two commas produce an empty name: "a,,b" → ["a", "", "b"]
+	payload := buildNameListWithRaw([]byte("curve25519-sha256,,diffie-hellman-group14-sha256"))
+	_, _, err := parseNameList(payload, 0)
+	if err == nil {
+		t.Fatal("expected error for empty algorithm name in list, got nil")
+	}
+}

--- a/pkg/engines/sshprobe/wire_test.go
+++ b/pkg/engines/sshprobe/wire_test.go
@@ -1,0 +1,216 @@
+package sshprobe
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// connFromBytes wraps a byte slice in a net.Conn-shaped reader using net.Pipe.
+func connFromBytes(t *testing.T, data []byte) net.Conn {
+	t.Helper()
+	client, server := net.Pipe()
+	go func() {
+		_, _ = server.Write(data)
+		server.Close()
+	}()
+	t.Cleanup(func() { client.Close() })
+	return client
+}
+
+func TestReadBanner(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"unix newline", "SSH-2.0-OpenSSH_9.0\n", "SSH-2.0-OpenSSH_9.0", false},
+		{"crlf newline", "SSH-2.0-OpenSSH_9.0\r\n", "SSH-2.0-OpenSSH_9.0", false},
+		{"dropbear", "SSH-2.0-dropbear_2022.83\r\n", "SSH-2.0-dropbear_2022.83", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := connFromBytes(t, []byte(tc.input))
+			got, err := readBanner(conn)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("readBanner = %q; want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadBannerTooLong(t *testing.T) {
+	// 300 bytes without newline should error.
+	data := bytes.Repeat([]byte("A"), 300)
+	conn := connFromBytes(t, data)
+	_, err := readBanner(conn)
+	if err == nil {
+		t.Fatal("expected error for oversized banner, got nil")
+	}
+}
+
+// buildSSHPacket encodes payload as an SSH binary packet (RFC 4253 §6).
+func buildSSHPacket(payload []byte) []byte {
+	padding := 8 - (len(payload)+5)%8
+	if padding < 4 {
+		padding += 8
+	}
+	pktLen := uint32(1 + len(payload) + padding)
+	buf := make([]byte, 4+1+len(payload)+padding)
+	binary.BigEndian.PutUint32(buf[0:4], pktLen)
+	buf[4] = byte(padding)
+	copy(buf[5:], payload)
+	return buf
+}
+
+func TestReadPacket(t *testing.T) {
+	payload := []byte{sshMsgKexInit, 1, 2, 3, 4}
+	raw := buildSSHPacket(payload)
+	conn := connFromBytes(t, raw)
+	got, err := readPacket(conn)
+	if err != nil {
+		t.Fatalf("readPacket: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("readPacket = %v; want %v", got, payload)
+	}
+}
+
+func TestReadPacketInvalidLength(t *testing.T) {
+	// packet_length = 0 is invalid (must be >= 2).
+	raw := make([]byte, 4)
+	binary.BigEndian.PutUint32(raw, 0)
+	conn := connFromBytes(t, raw)
+	_, err := readPacket(conn)
+	if err == nil {
+		t.Fatal("expected error for packet_length=0, got nil")
+	}
+}
+
+func TestParseNameList(t *testing.T) {
+	cases := []struct {
+		name    string
+		names   []string
+		wantErr bool
+	}{
+		{"empty list", nil, false},
+		{"single", []string{"curve25519-sha256"}, false},
+		{"multiple", []string{"mlkem768x25519-sha256", "curve25519-sha256", "diffie-hellman-group14-sha256"}, false},
+		{"1000 entries", makeEntries(1000, "alg"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := encodeNameList(tc.names)
+			got, newOff, err := parseNameList(payload, 0)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseNameList: %v", err)
+			}
+			if newOff != len(payload) {
+				t.Errorf("newOffset = %d; want %d", newOff, len(payload))
+			}
+			if len(tc.names) == 0 {
+				if len(got) != 0 {
+					t.Errorf("expected empty list, got %v", got)
+				}
+				return
+			}
+			if strings.Join(got, ",") != strings.Join(tc.names, ",") {
+				t.Errorf("got %v; want %v", got, tc.names)
+			}
+		})
+	}
+}
+
+func TestParseNameListTruncated(t *testing.T) {
+	// length field says 100 but payload only has 10 bytes.
+	payload := make([]byte, 4+10)
+	binary.BigEndian.PutUint32(payload, 100)
+	_, _, err := parseNameList(payload, 0)
+	if err == nil {
+		t.Fatal("expected error for truncated name-list, got nil")
+	}
+}
+
+func TestParseNameListTooShort(t *testing.T) {
+	// Only 3 bytes — not enough for the uint32 length prefix.
+	_, _, err := parseNameList([]byte{0, 0, 0}, 0)
+	if err == nil {
+		t.Fatal("expected error for payload too short for length, got nil")
+	}
+}
+
+func TestParseNameListMaxSize(t *testing.T) {
+	// Exactly at the 64 KB limit should succeed.
+	big := make([]byte, maxNameListLen)
+	for i := range big {
+		if i == 0 {
+			big[i] = 'a'
+		} else {
+			big[i] = 'b'
+		}
+	}
+	payload := encodeNameList([]string{string(big)})
+	_, _, err := parseNameList(payload, 0)
+	if err != nil {
+		t.Fatalf("unexpected error at max name-list size: %v", err)
+	}
+}
+
+func TestParseNameListExceedsMax(t *testing.T) {
+	// Claim a length one byte over the 64 KB cap.
+	payload := make([]byte, 4)
+	binary.BigEndian.PutUint32(payload, uint32(maxNameListLen+1))
+	_, _, err := parseNameList(payload, 0)
+	if err == nil {
+		t.Fatal("expected error for name-list exceeding max size, got nil")
+	}
+}
+
+// encodeNameList builds the wire-format byte slice for a name-list.
+func encodeNameList(names []string) []byte {
+	joined := strings.Join(names, ",")
+	buf := make([]byte, 4+len(joined))
+	binary.BigEndian.PutUint32(buf, uint32(len(joined)))
+	copy(buf[4:], joined)
+	return buf
+}
+
+func makeEntries(n int, prefix string) []string {
+	out := make([]string, n)
+	for i := range out {
+		out[i] = prefix + string(rune('0'+i%10))
+	}
+	return out
+}
+
+// connFromReader wraps a reader in a net.Conn using net.Pipe with a deadline.
+func connFromReader(t *testing.T, data []byte) net.Conn {
+	t.Helper()
+	c, s := net.Pipe()
+	_ = s.SetDeadline(time.Now().Add(5 * time.Second))
+	go func() {
+		_, _ = s.Write(data)
+		s.Close()
+	}()
+	t.Cleanup(func() { c.Close() })
+	return c
+}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -75,9 +75,9 @@ func (o *Orchestrator) EffectiveEngines(opts engines.ScanOptions) []engines.Engi
 	} else {
 		available = applyScanTypeFilter(available, opts.ScanType)
 	}
-	// Include Tier5Network engines when TLS or CT lookup targets are explicitly
+	// Include Tier5Network engines when TLS, CT, or SSH targets are explicitly
 	// provided, even if they were excluded by tier/scanType filtering above.
-	if len(opts.TLSTargets) > 0 || len(opts.CTLookupTargets) > 0 || opts.CTLookupFromECH {
+	if len(opts.TLSTargets) > 0 || len(opts.CTLookupTargets) > 0 || opts.CTLookupFromECH || len(opts.SSHTargets) > 0 {
 		available = appendNetworkEnginesIfAbsent(available, o.AvailableEngines())
 	}
 	return available
@@ -449,9 +449,9 @@ func (o *Orchestrator) scanPipeline(ctx context.Context, opts engines.ScanOption
 		available = applyScanTypeFilter(available, opts.ScanType)
 	}
 
-	// Include Tier5Network engines when TLS or CT lookup targets are explicitly
+	// Include Tier5Network engines when TLS, CT, or SSH targets are explicitly
 	// provided, overriding tier/scanType filtering (even in diff/quick mode).
-	if len(opts.TLSTargets) > 0 || len(opts.CTLookupTargets) > 0 || opts.CTLookupFromECH {
+	if len(opts.TLSTargets) > 0 || len(opts.CTLookupTargets) > 0 || opts.CTLookupFromECH || len(opts.SSHTargets) > 0 {
 		available = appendNetworkEnginesIfAbsent(available, o.AvailableEngines())
 	}
 

--- a/pkg/orchestrator/sshprobe_integration_test.go
+++ b/pkg/orchestrator/sshprobe_integration_test.go
@@ -1,0 +1,264 @@
+// sshprobe_integration_test.go — orchestrator integration tests for the SSH probe engine.
+//
+// Purpose: verify that the ssh-probe engine integrates correctly with the
+// orchestrator's scan pipeline — findings flow through classification,
+// deduplication, and output stages without errors. Tests use a real local TCP
+// listener to avoid mocking the network layer.
+//
+// Seam note: the orchestrator excludes Tier5Network engines by default when
+// ScanType="" (source scan). To include ssh-probe, tests use ScanType="all".
+// This is the same mechanism used by users who pass `--scan-type=all` on the CLI.
+// Flag for implementer: consider adding SSHTargets to the Tier5Network inclusion
+// condition in orchestrator.go (alongside TLSTargets/CTLookupTargets) so that
+// setting --ssh-targets automatically activates the ssh-probe without requiring
+// --scan-type=all.
+package orchestrator
+
+import (
+	"context"
+	"encoding/binary"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/engines"
+	"github.com/jimbo111/open-quantum-secure/pkg/engines/sshprobe"
+	"github.com/jimbo111/open-quantum-secure/pkg/findings"
+)
+
+// startFakeSSH starts a minimal SSH server that serves the given KEX methods.
+// Returns the TCP address (host:port) of the listener.
+func startFakeSSH(t *testing.T, serverID string, kexMethods []string) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+
+	go func() {
+		defer ln.Close()
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+		// Send banner.
+		_, _ = conn.Write([]byte(serverID + "\r\n"))
+
+		// Read (and discard) client banner.
+		buf := make([]byte, 512)
+		for {
+			n, err := conn.Read(buf)
+			if err != nil || n == 0 {
+				break
+			}
+			if strings.Contains(string(buf[:n]), "\n") {
+				break
+			}
+		}
+
+		// Send KEXINIT packet.
+		pkt := buildSSHTestPacket(kexMethods)
+		_, _ = conn.Write(pkt)
+	}()
+
+	return addr
+}
+
+// buildSSHTestPacket builds a minimal SSH binary packet containing a KEXINIT
+// payload for the given KEX methods. Replicates the encoding from probe_test.go
+// without creating a cross-package dependency.
+func buildSSHTestPacket(kexMethods []string) []byte {
+	const sshMsgKexInit = 20
+	const kexinitCookieLen = 16
+	const kexinitNameListCount = 10
+
+	// Build payload.
+	payload := []byte{sshMsgKexInit}
+	payload = append(payload, make([]byte, kexinitCookieLen)...)
+
+	// Encode kex_algorithms.
+	joined := strings.Join(kexMethods, ",")
+	lenBuf := make([]byte, 4)
+	binary.BigEndian.PutUint32(lenBuf, uint32(len(joined)))
+	payload = append(payload, lenBuf...)
+	payload = append(payload, []byte(joined)...)
+
+	// 9 remaining empty name-lists.
+	emptyList := make([]byte, 4) // uint32 length = 0
+	for i := 0; i < kexinitNameListCount-1; i++ {
+		payload = append(payload, emptyList...)
+	}
+	// first_kex_packet_follows + reserved.
+	payload = append(payload, 0, 0, 0, 0, 0)
+
+	// Wrap in SSH binary packet frame.
+	padding := 8 - (len(payload)+5)%8
+	if padding < 4 {
+		padding += 8
+	}
+	pktLen := uint32(1 + len(payload) + padding)
+	pkt := make([]byte, 4+1+len(payload)+padding)
+	binary.BigEndian.PutUint32(pkt[0:4], pktLen)
+	pkt[4] = byte(padding)
+	copy(pkt[5:], payload)
+	return pkt
+}
+
+// ─── Integration tests ────────────────────────────────────────────────────────
+
+// TestSSHProbeOrchestrator_ClassicalServer verifies that the orchestrator correctly
+// processes ssh-probe findings from a server advertising only classical KEX methods.
+func TestSSHProbeOrchestrator_ClassicalServer(t *testing.T) {
+	methods := []string{
+		"curve25519-sha256",
+		"diffie-hellman-group14-sha256",
+		"ecdh-sha2-nistp256",
+	}
+	addr := startFakeSSH(t, "SSH-2.0-OpenSSH_7.4", methods)
+
+	o := New(sshprobe.New())
+	ff, err := o.Scan(context.Background(), engines.ScanOptions{
+		SSHTargets: []string{addr},
+		ScanType:   "all", // required to include Tier5Network engines
+	})
+	if err != nil {
+		t.Fatalf("Scan error: %v", err)
+	}
+	if len(ff) != len(methods) {
+		t.Errorf("findings = %d; want %d (one per method)", len(ff), len(methods))
+	}
+	for _, f := range ff {
+		if f.PQCPresent {
+			t.Errorf("classical method %q flagged as PQCPresent=true", f.Algorithm.Name)
+		}
+		if f.QuantumRisk == findings.QRSafe {
+			t.Errorf("classical method %q has QuantumRisk=QRSafe", f.Algorithm.Name)
+		}
+		if f.SourceEngine != "ssh-probe" {
+			t.Errorf("finding SourceEngine=%q; want ssh-probe", f.SourceEngine)
+		}
+	}
+}
+
+// TestSSHProbeOrchestrator_PQCServer verifies that a server advertising a PQC
+// KEX method yields a finding with PQCPresent=true and QuantumRisk=QRSafe.
+func TestSSHProbeOrchestrator_PQCServer(t *testing.T) {
+	methods := []string{
+		"mlkem768x25519-sha256",
+		"curve25519-sha256",
+		"diffie-hellman-group14-sha256",
+	}
+	addr := startFakeSSH(t, "SSH-2.0-OpenSSH_10.0", methods)
+
+	o := New(sshprobe.New())
+	ff, err := o.Scan(context.Background(), engines.ScanOptions{
+		SSHTargets: []string{addr},
+		ScanType:   "all",
+	})
+	if err != nil {
+		t.Fatalf("Scan error: %v", err)
+	}
+	if len(ff) != 3 {
+		t.Fatalf("findings = %d; want 3", len(ff))
+	}
+
+	// Find the mlkem768 finding.
+	var pqcFound bool
+	for _, f := range ff {
+		if f.Algorithm.Name == "mlkem768x25519-sha256" {
+			pqcFound = true
+			if !f.PQCPresent {
+				t.Error("mlkem768x25519-sha256: PQCPresent=false, want true")
+			}
+			if f.QuantumRisk != findings.QRSafe {
+				t.Errorf("mlkem768x25519-sha256: QuantumRisk=%q, want QRSafe", f.QuantumRisk)
+			}
+			if f.PQCMaturity != "final" {
+				t.Errorf("mlkem768x25519-sha256: PQCMaturity=%q, want final", f.PQCMaturity)
+			}
+		}
+	}
+	if !pqcFound {
+		t.Error("mlkem768x25519-sha256 finding not returned by orchestrator")
+	}
+}
+
+// TestSSHProbeOrchestrator_MultiTarget verifies multiple SSH targets in one scan.
+func TestSSHProbeOrchestrator_MultiTarget(t *testing.T) {
+	methodsA := []string{"mlkem768x25519-sha256", "curve25519-sha256"}
+	methodsB := []string{"diffie-hellman-group14-sha256", "ecdh-sha2-nistp256"}
+
+	addrA := startFakeSSH(t, "SSH-2.0-OpenSSH_10.0", methodsA)
+	addrB := startFakeSSH(t, "SSH-2.0-OpenSSH_7.4", methodsB)
+
+	o := New(sshprobe.New())
+	ff, err := o.Scan(context.Background(), engines.ScanOptions{
+		SSHTargets: []string{addrA, addrB},
+		ScanType:   "all",
+	})
+	if err != nil {
+		t.Fatalf("Scan error: %v", err)
+	}
+
+	// Total findings = 2 + 2 = 4
+	if len(ff) != 4 {
+		t.Errorf("findings = %d; want 4 (2 per target)", len(ff))
+	}
+
+	var pqcCount int
+	for _, f := range ff {
+		if f.PQCPresent {
+			pqcCount++
+		}
+	}
+	if pqcCount != 1 {
+		t.Errorf("PQC findings = %d; want 1 (only mlkem768x25519-sha256)", pqcCount)
+	}
+}
+
+// TestSSHProbeOrchestrator_NoNetwork verifies that NoNetwork=true prevents the
+// orchestrator from probing even when SSHTargets is set.
+func TestSSHProbeOrchestrator_NoNetwork(t *testing.T) {
+	o := New(sshprobe.New())
+	ff, err := o.Scan(context.Background(), engines.ScanOptions{
+		SSHTargets: []string{"192.0.2.1:22"},
+		ScanType:   "all",
+		NoNetwork:  true,
+	})
+	if err != nil {
+		t.Fatalf("expected no error with NoNetwork=true, got: %v", err)
+	}
+	if len(ff) != 0 {
+		t.Errorf("expected no findings with NoNetwork=true, got %d", len(ff))
+	}
+}
+
+// TestSSHProbeOrchestrator_ContextCancellation verifies that cancelling the
+// context aborts the orchestrator scan cleanly.
+func TestSSHProbeOrchestrator_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before scan starts
+
+	o := New(sshprobe.New())
+	// Cancelled context: scan may return error or empty findings — either is fine.
+	// What matters: no hang, no panic.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = o.Scan(ctx, engines.ScanOptions{
+			SSHTargets: []string{"192.0.2.1:22"},
+			ScanType:   "all",
+		})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Scan did not return within 3s with pre-cancelled context")
+	}
+}

--- a/pkg/orchestrator/sshprobe_integration_test.go
+++ b/pkg/orchestrator/sshprobe_integration_test.go
@@ -238,6 +238,38 @@ func TestSSHProbeOrchestrator_NoNetwork(t *testing.T) {
 	}
 }
 
+// TestSSHProbeOrchestrator_A7_SSHTargetsAloneActivatesEngine verifies that
+// passing SSHTargets without --scan-type=all (A7: orchestrator seam fix) is
+// sufficient to include the ssh-probe Tier5Network engine. Previously the engine
+// was only activated when ScanType="all" was explicitly set.
+func TestSSHProbeOrchestrator_A7_SSHTargetsAloneActivatesEngine(t *testing.T) {
+	methods := []string{"mlkem768x25519-sha256", "diffie-hellman-group14-sha256"}
+	addr := startFakeSSH(t, "SSH-2.0-OpenSSH_10.0", methods)
+
+	o := New(sshprobe.New())
+	// ScanType is intentionally omitted (defaults to source scan).
+	// A7 fix: SSHTargets alone must activate Tier5Network engines.
+	ff, err := o.Scan(context.Background(), engines.ScanOptions{
+		SSHTargets: []string{addr},
+		// ScanType deliberately omitted — the seam must handle this.
+	})
+	if err != nil {
+		t.Fatalf("Scan error: %v", err)
+	}
+	if len(ff) == 0 {
+		t.Fatal("expected findings when SSHTargets set without scan-type=all (A7 seam fix)")
+	}
+	foundSSH := false
+	for _, f := range ff {
+		if f.SourceEngine == "ssh-probe" {
+			foundSSH = true
+		}
+	}
+	if !foundSSH {
+		t.Error("no findings from ssh-probe engine — SSHTargets did not activate the engine")
+	}
+}
+
 // TestSSHProbeOrchestrator_ContextCancellation verifies that cancelling the
 // context aborts the orchestrator scan cleanly.
 func TestSSHProbeOrchestrator_ContextCancellation(t *testing.T) {

--- a/pkg/output/sshprobe_format_test.go
+++ b/pkg/output/sshprobe_format_test.go
@@ -1,0 +1,377 @@
+// sshprobe_format_test.go — output format round-trip tests for SSH probe findings.
+//
+// Purpose: verify that a UnifiedFinding produced by the ssh-probe engine serializes
+// correctly through all four output formats (JSON, SARIF, CBOM, Table). Specifically:
+//   - PQC fields (PQCPresent, PQCMaturity) round-trip with correct values.
+//   - Classical SSH KEX findings carry no PQC annotations.
+//   - Attacker-controlled method names (e.g. `"; rm -rf /"`) are safely escaped
+//     in JSON, SARIF, and CBOM outputs — never interpreted as commands.
+//   - Sprint 4 ssh-probe findings co-exist with Sprint 1/2 TLS probe findings
+//     without field collision.
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jimbo111/open-quantum-secure/pkg/findings"
+)
+
+// ─── Fixture helpers ──────────────────────────────────────────────────────────
+
+// sshClassicalFinding returns a classical (quantum-vulnerable) SSH KEX finding.
+func sshClassicalFinding(method string) findings.UnifiedFinding {
+	return findings.UnifiedFinding{
+		Location:     findings.Location{File: "(ssh-probe)/198.51.100.1:22#kex", ArtifactType: "ssh-endpoint"},
+		Algorithm:    &findings.Algorithm{Name: method, Primitive: "kex"},
+		Confidence:   findings.ConfidenceHigh,
+		SourceEngine: "ssh-probe",
+		Reachable:    findings.ReachableYes,
+		QuantumRisk:  findings.QRVulnerable,
+		Severity:     findings.SevHigh,
+		PQCPresent:   false,
+	}
+}
+
+// sshPQCFinalFinding returns a PQC-final SSH KEX finding (mlkem768x25519-sha256).
+func sshPQCFinalFinding() findings.UnifiedFinding {
+	return findings.UnifiedFinding{
+		Location:     findings.Location{File: "(ssh-probe)/203.0.113.1:22#kex", ArtifactType: "ssh-endpoint"},
+		Algorithm:    &findings.Algorithm{Name: "mlkem768x25519-sha256", Primitive: "kex"},
+		Confidence:   findings.ConfidenceHigh,
+		SourceEngine: "ssh-probe",
+		Reachable:    findings.ReachableYes,
+		QuantumRisk:  findings.QRSafe,
+		Severity:     findings.SevInfo,
+		PQCPresent:   true,
+		PQCMaturity:  "final",
+	}
+}
+
+// sshPQCDraftFinding returns a PQC-draft SSH KEX finding (sntrup761).
+func sshPQCDraftFinding() findings.UnifiedFinding {
+	return findings.UnifiedFinding{
+		Location:     findings.Location{File: "(ssh-probe)/203.0.113.2:22#kex", ArtifactType: "ssh-endpoint"},
+		Algorithm:    &findings.Algorithm{Name: "sntrup761x25519-sha512@openssh.com", Primitive: "kex"},
+		Confidence:   findings.ConfidenceHigh,
+		SourceEngine: "ssh-probe",
+		Reachable:    findings.ReachableYes,
+		QuantumRisk:  findings.QRSafe,
+		Severity:     findings.SevInfo,
+		PQCPresent:   true,
+		PQCMaturity:  "draft",
+	}
+}
+
+// sshAdversarialFinding returns a finding with an attacker-controlled method name.
+// The name contains shell metacharacters that must be escaped in all outputs.
+func sshAdversarialFinding(methodName string) findings.UnifiedFinding {
+	return findings.UnifiedFinding{
+		Location:     findings.Location{File: "(ssh-probe)/10.0.0.1:22#kex", ArtifactType: "ssh-endpoint"},
+		Algorithm:    &findings.Algorithm{Name: methodName, Primitive: "kex"},
+		Confidence:   findings.ConfidenceHigh,
+		SourceEngine: "ssh-probe",
+		Reachable:    findings.ReachableYes,
+		QuantumRisk:  findings.QRUnknown,
+	}
+}
+
+// makeSshProbeResult wraps findings into a ScanResult for testing.
+func makeSshProbeResult(ff []findings.UnifiedFinding) ScanResult {
+	return ScanResult{
+		Version:  "0.0.0-test",
+		Target:   "/test-ssh",
+		Engines:  []string{"ssh-probe"},
+		Findings: ff,
+	}
+}
+
+// ─── JSON round-trip ─────────────────────────────────────────────────────────
+
+// TestSSHProbeFormat_JSON_PQCFieldsRoundTrip verifies that PQCPresent and PQCMaturity
+// survive a JSON marshal/unmarshal cycle for all three finding types.
+func TestSSHProbeFormat_JSON_PQCFieldsRoundTrip(t *testing.T) {
+	ff := []findings.UnifiedFinding{
+		sshClassicalFinding("curve25519-sha256"),
+		sshPQCFinalFinding(),
+		sshPQCDraftFinding(),
+	}
+	result := makeSshProbeResult(ff)
+
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, result); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+
+	var got ScanResult
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got.Findings) != 3 {
+		t.Fatalf("expected 3 findings, got %d", len(got.Findings))
+	}
+
+	// Classical: PQCPresent=false, PQCMaturity=""
+	classical := got.Findings[0]
+	if classical.PQCPresent {
+		t.Error("classical SSH KEX: PQCPresent=true after round-trip, want false")
+	}
+	if classical.PQCMaturity != "" {
+		t.Errorf("classical SSH KEX: PQCMaturity=%q, want empty", classical.PQCMaturity)
+	}
+
+	// PQC final: PQCPresent=true, PQCMaturity="final"
+	pqcFinal := got.Findings[1]
+	if !pqcFinal.PQCPresent {
+		t.Error("mlkem768x25519-sha256: PQCPresent=false after round-trip, want true")
+	}
+	if pqcFinal.PQCMaturity != "final" {
+		t.Errorf("mlkem768x25519-sha256: PQCMaturity=%q, want final", pqcFinal.PQCMaturity)
+	}
+
+	// PQC draft: PQCPresent=true, PQCMaturity="draft"
+	pqcDraft := got.Findings[2]
+	if !pqcDraft.PQCPresent {
+		t.Error("sntrup761: PQCPresent=false after round-trip, want true")
+	}
+	if pqcDraft.PQCMaturity != "draft" {
+		t.Errorf("sntrup761: PQCMaturity=%q, want draft", pqcDraft.PQCMaturity)
+	}
+}
+
+// TestSSHProbeFormat_JSON_SourceEngineField verifies that the source engine is
+// correctly serialized as "ssh-probe" in JSON output.
+func TestSSHProbeFormat_JSON_SourceEngineField(t *testing.T) {
+	result := makeSshProbeResult([]findings.UnifiedFinding{sshPQCFinalFinding()})
+
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, result); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "ssh-probe") {
+		t.Error("JSON output missing 'ssh-probe' source engine")
+	}
+}
+
+// TestSSHProbeFormat_JSON_ArtifactType verifies that ArtifactType="ssh-endpoint"
+// is preserved in JSON output.
+func TestSSHProbeFormat_JSON_ArtifactType(t *testing.T) {
+	result := makeSshProbeResult([]findings.UnifiedFinding{sshClassicalFinding("curve25519-sha256")})
+
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, result); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "ssh-endpoint") {
+		t.Error("JSON output missing artifactType=ssh-endpoint")
+	}
+}
+
+// ─── Attacker-controlled method name escaping ─────────────────────────────────
+
+var attackerMethodNames = []string{
+	`"; rm -rf /"`,
+	`<script>alert(1)</script>`,
+	`'; DROP TABLE findings; --`,
+	"curve25519\x00-sha256",       // embedded NUL
+	"diffie-hellman\r\ninjection", // CRLF injection
+	"\xc3\x28-invalid-utf8",       // invalid UTF-8
+	`../../../etc/passwd`,
+}
+
+// TestSSHProbeFormat_JSON_AttackerNamesEscaped verifies that attacker-controlled
+// method names are safely encoded in JSON — the raw shell/HTML characters must
+// not appear unescaped in a way that could be exploited.
+func TestSSHProbeFormat_JSON_AttackerNamesEscaped(t *testing.T) {
+	for _, name := range attackerMethodNames {
+		name := name
+		t.Run("name:"+strings.ReplaceAll(name, "\x00", "NUL"), func(t *testing.T) {
+			result := makeSshProbeResult([]findings.UnifiedFinding{sshAdversarialFinding(name)})
+
+			var buf bytes.Buffer
+			if err := WriteJSON(&buf, result); err != nil {
+				t.Fatalf("WriteJSON: %v", err)
+			}
+
+			// JSON must be valid (json.Valid rejects broken escaping).
+			if !json.Valid(buf.Bytes()) {
+				t.Errorf("JSON output is not valid JSON for method name %q", name)
+			}
+
+			// CRLF injection: the raw CRLF bytes must not appear literally in JSON strings.
+			// json.Marshal escapes \r as \u000d and \n as \u000a inside strings.
+			raw := buf.String()
+			if strings.Contains(raw, "\r\n") {
+				t.Errorf("JSON output contains literal CRLF (unescaped CRLF injection) for method %q", name)
+			}
+		})
+	}
+}
+
+// TestSSHProbeFormat_SARIF_AttackerNamesEscaped verifies that SARIF output safely
+// encodes attacker-controlled method names.
+func TestSSHProbeFormat_SARIF_AttackerNamesEscaped(t *testing.T) {
+	for _, name := range attackerMethodNames {
+		name := name
+		t.Run("name:"+strings.ReplaceAll(name, "\x00", "NUL"), func(t *testing.T) {
+			result := makeSshProbeResult([]findings.UnifiedFinding{sshAdversarialFinding(name)})
+
+			var buf bytes.Buffer
+			if err := WriteSARIF(&buf, result); err != nil {
+				t.Fatalf("WriteSARIF: %v", err)
+			}
+
+			if !json.Valid(buf.Bytes()) {
+				t.Errorf("SARIF output is not valid JSON for method name %q", name)
+			}
+		})
+	}
+}
+
+// TestSSHProbeFormat_CBOM_AttackerNamesEscaped verifies that CBOM output safely
+// encodes attacker-controlled method names.
+func TestSSHProbeFormat_CBOM_AttackerNamesEscaped(t *testing.T) {
+	for _, name := range attackerMethodNames {
+		name := name
+		t.Run("name:"+strings.ReplaceAll(name, "\x00", "NUL"), func(t *testing.T) {
+			result := makeSshProbeResult([]findings.UnifiedFinding{sshAdversarialFinding(name)})
+
+			var buf bytes.Buffer
+			if err := WriteCBOM(&buf, result); err != nil {
+				t.Fatalf("WriteCBOM: %v", err)
+			}
+
+			if !json.Valid(buf.Bytes()) {
+				t.Errorf("CBOM output is not valid JSON for method name %q", name)
+			}
+		})
+	}
+}
+
+// ─── SARIF Sprint 4 fields ────────────────────────────────────────────────────
+
+// TestSSHProbeFormat_SARIF_PQCFieldsPresent verifies that PQCPresent and PQCMaturity
+// appear in SARIF result.properties for PQC-capable SSH KEX findings.
+func TestSSHProbeFormat_SARIF_PQCFieldsPresent(t *testing.T) {
+	result := makeSshProbeResult([]findings.UnifiedFinding{
+		sshClassicalFinding("diffie-hellman-group14-sha256"),
+		sshPQCFinalFinding(),
+	})
+
+	var buf bytes.Buffer
+	if err := WriteSARIF(&buf, result); err != nil {
+		t.Fatalf("WriteSARIF: %v", err)
+	}
+
+	var sarifDoc struct {
+		Runs []struct {
+			Results []struct {
+				Properties map[string]json.RawMessage `json:"properties"`
+			} `json:"results"`
+		} `json:"runs"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &sarifDoc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(sarifDoc.Runs) == 0 || len(sarifDoc.Runs[0].Results) != 2 {
+		t.Fatalf("expected 2 SARIF results, got %d", len(sarifDoc.Runs[0].Results))
+	}
+
+	// Classical finding: pqcPresent must be absent.
+	classProps := sarifDoc.Runs[0].Results[0].Properties
+	if _, ok := classProps["pqcPresent"]; ok {
+		t.Error("SARIF classical SSH finding: pqcPresent must be absent")
+	}
+
+	// PQC final finding: pqcPresent + pqcMaturity must be present.
+	pqcProps := sarifDoc.Runs[0].Results[1].Properties
+	if _, ok := pqcProps["pqcPresent"]; !ok {
+		t.Error("SARIF mlkem768x25519-sha256 finding: pqcPresent absent")
+	}
+	var maturity string
+	if v, ok := pqcProps["pqcMaturity"]; ok {
+		_ = json.Unmarshal(v, &maturity)
+	}
+	if maturity != "final" {
+		t.Errorf("SARIF pqcMaturity=%q, want final", maturity)
+	}
+}
+
+// ─── Co-existence with TLS probe findings ─────────────────────────────────────
+
+// TestSSHProbeFormat_CoexistWithTLSProbe verifies that SSH probe findings and
+// TLS probe findings can be mixed in a single ScanResult without field collision.
+// Sprint 4 SSH fields (PQCPresent/PQCMaturity with no NegotiatedGroup) must
+// serialize cleanly alongside Sprint 1 TLS fields (NegotiatedGroup/NegotiatedGroupName).
+func TestSSHProbeFormat_CoexistWithTLSProbe(t *testing.T) {
+	mixed := []findings.UnifiedFinding{
+		// TLS probe finding (Sprint 1) — has NegotiatedGroup
+		{
+			Location:            findings.Location{File: "(tls-probe)/example.com:443#kex", ArtifactType: "tls-endpoint"},
+			Algorithm:           &findings.Algorithm{Name: "X25519MLKEM768", Primitive: "key-exchange"},
+			Confidence:          findings.ConfidenceHigh,
+			SourceEngine:        "tls-probe",
+			Reachable:           findings.ReachableYes,
+			QuantumRisk:         findings.QRSafe,
+			NegotiatedGroup:     0x11EC,
+			NegotiatedGroupName: "X25519MLKEM768",
+			PQCPresent:          true,
+			PQCMaturity:         "final",
+		},
+		// SSH probe finding (Sprint 4) — no NegotiatedGroup
+		sshPQCFinalFinding(),
+		sshClassicalFinding("ecdh-sha2-nistp256"),
+	}
+	result := ScanResult{
+		Version:  "0.0.0-test",
+		Target:   "/test-mixed",
+		Engines:  []string{"tls-probe", "ssh-probe"},
+		Findings: mixed,
+	}
+
+	// All formats must succeed and produce valid output.
+	var jsonBuf, sarifBuf, cbomBuf bytes.Buffer
+	if err := WriteJSON(&jsonBuf, result); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	if !json.Valid(jsonBuf.Bytes()) {
+		t.Fatal("WriteJSON: invalid JSON")
+	}
+
+	if err := WriteSARIF(&sarifBuf, result); err != nil {
+		t.Fatalf("WriteSARIF: %v", err)
+	}
+	if !json.Valid(sarifBuf.Bytes()) {
+		t.Fatal("WriteSARIF: invalid JSON")
+	}
+
+	if err := WriteCBOM(&cbomBuf, result); err != nil {
+		t.Fatalf("WriteCBOM: %v", err)
+	}
+	if !json.Valid(cbomBuf.Bytes()) {
+		t.Fatal("WriteCBOM: invalid JSON")
+	}
+
+	// Round-trip via JSON: 3 findings must survive.
+	var parsed ScanResult
+	if err := json.Unmarshal(jsonBuf.Bytes(), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(parsed.Findings) != 3 {
+		t.Errorf("expected 3 findings after round-trip, got %d", len(parsed.Findings))
+	}
+
+	// TLS finding still has NegotiatedGroup set; SSH finding must not.
+	tls := parsed.Findings[0]
+	if tls.NegotiatedGroup != 0x11EC {
+		t.Errorf("TLS finding NegotiatedGroup=0x%04x, want 0x11EC", tls.NegotiatedGroup)
+	}
+	ssh := parsed.Findings[1]
+	if ssh.NegotiatedGroup != 0 {
+		t.Errorf("SSH finding NegotiatedGroup=0x%04x, want 0 (not set for SSH probe)", ssh.NegotiatedGroup)
+	}
+}


### PR DESCRIPTION
## Summary

Sprint 4 of the OQS Scanner Network Engine Plan ships the `sshprobe` engine — TCP dial + banner exchange + SSH_MSG_KEXINIT parse, detecting PQC KEX methods per Sowa et al. IEEE QCE 2024.

- **New engine** `pkg/engines/sshprobe/` (Tier5Network, embedded): wire.go, kex.go, probe.go, classify.go, engine.go
- **New shared package** `pkg/engines/netutil/` with `IsPrivateIP` + `ResolveAndValidate` (SSRF guard reusable across network engines)
- **ScanOptions additions**: `SSHTargets []string`, `SSHTimeout int`, `SSHDenyPrivate bool`
- **CLI flags** on `scan` + `diff`: `--ssh-targets host:22`, `--ssh-strict` (deny private/loopback IPs)
- **Orchestrator seam**: `SSHTargets` alone activates Tier5Network engines (no `--scan-type=all` required)
- **PQC KEX coverage**: mlkem768x25519-sha256 (OpenSSH 10.0+ final), sntrup761x25519-sha512@openssh.com (8.5-9.9 draft), + 7 other draft/vendor variants; heuristic for unknown `mlkem/kyber/sntrup/frodo/ntruprime/bike/hqc/mceliece` substrings

## Hardening (review round)

- **RFC 4253 §4.2 preamble compliance** — loop banner read up to 10 lines / 8 KB, skip non-`SSH-` prefix lines (Google Cloud IAP, Bastillion, fail2ban wrappers)
- **SSRF guard** — `--ssh-strict` rejects private/loopback/link-local via `netutil.ResolveAndValidate` (parity with TLS probe)
- **Context watchdog** — goroutine closes `conn` on `ctx.Done()`, so cancel-mid-scan drops connections immediately instead of waiting full 10s deadline
- **Clean cancel semantics** — labelled `break outer` exits the target loop correctly inside a `select`
- **Accurate counters** — `launched int` counter; stderr summary reflects actual completed targets on cancel
- **Printable-ASCII validation** on KEX method names (RFC 4253 §5) and SSH banner (RFC 4253 §4.2) — blocks ANSI-escape injection into table output
- **Bounded preamble skip** — `maxSkip=2`, `maxSkipBytes=64KB` cumulative cap prevents attacker amplification
- **SSH-1.x explicit reject** — only `SSH-2.0-` / `SSH-1.99-` accepted (RFC 4253 §5.1)
- **RFC 4253 §6.1 packet cap** — 256 KB defensive ceiling (spec requires ≥35000; we accept larger with OOM protection)
- **Semaphore-in-parent** concurrency pattern (Sprint 2 M1 / Sprint 3 A5 lineage)

## Test plan

- [x] ~80 test functions across 10+ files (implementer 35 + test-automator 44 + fix-implementer new coverage)
- [x] Fuzz targets: `FuzzReadBanner`, `FuzzReadPacket`, `FuzzParseNameList` with RFC-derived seed corpora
- [x] `go test -race -count=1 ./...` — all packages pass
- [x] `go build ./...` + `go vet ./...` — clean
- [x] `--no-network` proven by injectable `probeFn` stub — never dials when gated
- [x] Preamble handling: 0 / 1 / 5 / 10+ / over-cap test cases
- [x] Context cancel mid-handshake returns <100ms (tested with stall server)
- [x] Sprint 0/1/2/3 regression — HNDL, TLS probe PQC, ECH detection, CT lookup two-pass all intact

## Consumes / enables

- **Consumes**: none (independent of Sprints 0-3)
- **Enables**: Tier A complete (Sprints 0-4). Sprint 5+ Tier B builds on these primitives (Zeek/Suricata ingest, raw ClientHello, group enumeration)