### PR TITLE
fix: 3 bugs found by test-pipeline audit (migration / enginemgr / compliance-report CLI)

### DIFF
--- a/cmd/oqs-scanner/main.go
+++ b/cmd/oqs-scanner/main.go
@@ -3112,6 +3112,11 @@ func complianceReportCmd() *cobra.Command {
 		outputFile      string
 		projectOvr      string
 		reportStandards []string
+		engineNames     []string
+		excludePatterns []string
+		timeout         int
+		maxFileMB       int
+		noConfig        bool
 	)
 	cmd := &cobra.Command{
 		Use:   "compliance-report",
@@ -3124,6 +3129,9 @@ approved algorithm reference, and key deadlines. Output can be written to a file
 
 Supported frameworks: ` + strings.Join(compliance.SupportedIDs(), ", "),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Expand "all" sentinel before validation so downstream evaluation sees
+			// concrete framework IDs.
+			reportStandards = expandComplianceAll(reportStandards)
 			if len(reportStandards) == 0 {
 				reportStandards = []string{string(compliance.StandardCNSA20)}
 			}
@@ -3139,6 +3147,19 @@ Supported frameworks: ` + strings.Join(compliance.SupportedIDs(), ", "),
 				return fmt.Errorf("resolve path: %w", err)
 			}
 
+			// Load project config (unless --no-config) and apply fallbacks for flags
+			// that the user did not set explicitly. Mirrors the scan command so
+			// .oqs-scanner.yaml applies to compliance-report too.
+			cfg := config.Config{}
+			if !noConfig {
+				loaded, err := config.Load(absPath)
+				if err == nil {
+					cfg = loaded
+				}
+			}
+			unused := ""
+			applyCommonConfigFallbacks(cmd, cfg, &unused, &timeout, &maxFileMB, &engineNames, &excludePatterns, &unused)
+
 			// Determine project name: flag > git > directory basename.
 			project := projectOvr
 			if project == "" {
@@ -3148,10 +3169,19 @@ Supported frameworks: ` + strings.Join(compliance.SupportedIDs(), ", "),
 			orch := buildOrchestrator()
 
 			ctx := context.Background()
+			if timeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+				defer cancel()
+			}
 
 			opts := engines.ScanOptions{
-				TargetPath: absPath,
-				Mode:       engines.ModeFull,
+				TargetPath:      absPath,
+				Mode:            engines.ModeFull,
+				EngineNames:     engineNames,
+				ExcludePatterns: excludePatterns,
+				MaxFileMB:       maxFileMB,
+				Timeout:         timeout,
 			}
 
 			selected := orch.EffectiveEngines(opts)
@@ -3231,7 +3261,12 @@ Supported frameworks: ` + strings.Join(compliance.SupportedIDs(), ", "),
 	cmd.Flags().StringVar(&outputFile, "output", "", "Output file path (default: stdout)")
 	cmd.Flags().StringVar(&projectOvr, "project", "", "Project name for report header (default: inferred from git)")
 	cmd.Flags().StringSliceVar(&reportStandards, "compliance", []string{string(compliance.StandardCNSA20)},
-		"Compliance framework(s) to report on, comma-separated or repeated (supported: "+strings.Join(compliance.SupportedIDs(), ", ")+")")
+		"Compliance framework(s) to report on, comma-separated or repeated (supported: "+strings.Join(compliance.SupportedIDs(), ", ")+", or \"all\")")
+	cmd.Flags().StringSliceVar(&engineNames, "engine", nil, "Engines to use (default: all available). Example: --engine cipherscope,cryptoscan")
+	cmd.Flags().StringSliceVar(&excludePatterns, "exclude", nil, "Glob patterns to exclude from scan (comma-separated)")
+	cmd.Flags().IntVar(&timeout, "timeout", 300, "Scan timeout in seconds (0 = no timeout)")
+	cmd.Flags().IntVar(&maxFileMB, "max-file-mb", 50, "Skip files larger than this (MB)")
+	cmd.Flags().BoolVar(&noConfig, "no-config", false, "Skip loading .oqs-scanner.yaml config (use in CI to prevent policy bypass)")
 	return cmd
 }
 

--- a/pkg/enginemgr/enginemgr.go
+++ b/pkg/enginemgr/enginemgr.go
@@ -125,6 +125,52 @@ var registry = []EngineInfo{
 		BuildTool:   "embedded",
 		InstallHint: "Built-in (no installation required)",
 	},
+	// Tier 5 network engines — embedded Go probes, always available.
+	{
+		Name:        "tls-probe",
+		Description: "TLS endpoint probe — detects quantum-vulnerable key exchange and PQC-negotiated groups",
+		Tier:        5,
+		Languages:   nil, // protocol engine — no source languages
+		BinaryName:  "",  // embedded
+		BuildTool:   "embedded",
+		InstallHint: "Built-in (no installation required)",
+	},
+	{
+		Name:        "ct-lookup",
+		Description: "Certificate Transparency log lookup — discovers certificate signature algorithms via crt.sh",
+		Tier:        5,
+		Languages:   nil,
+		BinaryName:  "",
+		BuildTool:   "embedded",
+		InstallHint: "Built-in (no installation required)",
+	},
+	{
+		Name:        "ssh-probe",
+		Description: "SSH KEX advertisement probe — detects host-key and KEX algorithm support",
+		Tier:        5,
+		Languages:   nil,
+		BinaryName:  "",
+		BuildTool:   "embedded",
+		InstallHint: "Built-in (no installation required)",
+	},
+	{
+		Name:        "zeek-log",
+		Description: "Zeek ssl.log / x509.log passive ingestion (TSV or JSON, optional .gz)",
+		Tier:        5,
+		Languages:   nil,
+		BinaryName:  "",
+		BuildTool:   "embedded",
+		InstallHint: "Built-in (no installation required)",
+	},
+	{
+		Name:        "suricata-log",
+		Description: "Suricata eve.json passive ingestion (NDJSON, optional .gz)",
+		Tier:        5,
+		Languages:   nil,
+		BinaryName:  "",
+		BuildTool:   "embedded",
+		InstallHint: "Built-in (no installation required)",
+	},
 }
 
 // Registry returns the list of all known engines.

--- a/pkg/enginemgr/enginemgr_test.go
+++ b/pkg/enginemgr/enginemgr_test.go
@@ -21,6 +21,11 @@ func TestRegistry(t *testing.T) {
 		"cbomkit-theia":  "cbomkit-theia",
 		"binary-scanner": "", // embedded engine — no external binary
 		"config-scanner": "", // embedded engine — no external binary
+		"tls-probe":      "", // Tier 5 network engine — embedded
+		"ct-lookup":      "", // Tier 5 network engine — embedded
+		"ssh-probe":      "", // Tier 5 network engine — embedded
+		"zeek-log":       "", // Tier 5 network engine — embedded
+		"suricata-log":   "", // Tier 5 network engine — embedded
 	}
 
 	reg := Registry()
@@ -48,6 +53,7 @@ func TestRegistry_Tiers(t *testing.T) {
 	tier2 := map[string]bool{"semgrep": true}
 	tier3 := map[string]bool{"cryptodeps": true, "cdxgen": true, "syft": true, "cbomkit-theia": true}
 	tier4 := map[string]bool{"binary-scanner": true}
+	tier5 := map[string]bool{"tls-probe": true, "ct-lookup": true, "ssh-probe": true, "zeek-log": true, "suricata-log": true}
 
 	for _, e := range Registry() {
 		switch {
@@ -66,6 +72,10 @@ func TestRegistry_Tiers(t *testing.T) {
 		case tier4[e.Name]:
 			if e.Tier != 4 {
 				t.Errorf("engine %q: expected tier 4, got %d", e.Name, e.Tier)
+			}
+		case tier5[e.Name]:
+			if e.Tier != 5 {
+				t.Errorf("engine %q: expected tier 5, got %d", e.Name, e.Tier)
 			}
 		default:
 			t.Errorf("engine %q has unexpected tier %d", e.Name, e.Tier)
@@ -278,9 +288,15 @@ func TestRegistry_AllHaveInstallHints(t *testing.T) {
 	}
 }
 
-// TestRegistry_AllHaveLanguages verifies every engine has at least one language.
+// TestRegistry_AllHaveLanguages verifies every source-scanning engine has at
+// least one language. Tier 5 network/protocol engines (tls-probe, ct-lookup,
+// ssh-probe, zeek-log, suricata-log) probe wire protocols or ingest logs and
+// intentionally have no associated source language — they are exempt.
 func TestRegistry_AllHaveLanguages(t *testing.T) {
 	for _, e := range Registry() {
+		if e.Tier == 5 {
+			continue
+		}
 		if len(e.Languages) == 0 {
 			t.Errorf("engine %q has no languages defined", e.Name)
 		}

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -68,6 +68,53 @@ func isSafePQC(alg string) bool {
 	return false
 }
 
+// familyFromTargetAlg infers snippet family ("sign" or "kem") from the PQC target
+// algorithm. ML-KEM → "kem", ML-DSA/SLH-DSA → "sign". Returns "" when the target
+// does not map to a known PQC family.
+//
+// Used by GenerateSnippet as an override: when the primitive hint disagrees with
+// the classical algorithm's hardcoded family (e.g. quantum pkg recommends ML-KEM
+// for RSA used as encryption, but classicalAlgFamily("RSA") returns "sign"), the
+// target-derived family wins so the emitted code matches the recommended algorithm.
+func familyFromTargetAlg(targetAlg string) string {
+	upper := strings.ToUpper(targetAlg)
+	switch {
+	case strings.HasPrefix(upper, "ML-KEM") || strings.HasPrefix(upper, "MLKEM"):
+		return "kem"
+	case strings.HasPrefix(upper, "ML-DSA") || strings.HasPrefix(upper, "MLDSA"),
+		strings.HasPrefix(upper, "SLH-DSA") || strings.HasPrefix(upper, "SLHDSA"):
+		return "sign"
+	}
+	return ""
+}
+
+// pqcStdSuffix returns a parenthetical FIPS standard suffix for a PQC target,
+// or an empty string when the target is unknown. Used to build explanation
+// strings without hardcoding the standard number — so SLH-DSA targets render
+// as "(FIPS 205)" instead of the incorrect "(FIPS 204)".
+func pqcStdSuffix(targetAlg string) string {
+	std := fipsStandardFor(targetAlg)
+	if std == "" {
+		return ""
+	}
+	return " (" + std + ")"
+}
+
+// fipsStandardFor returns the NIST FIPS publication that standardises targetAlg.
+// ML-KEM → FIPS 203, ML-DSA → FIPS 204, SLH-DSA → FIPS 205. Returns "" otherwise.
+func fipsStandardFor(targetAlg string) string {
+	upper := strings.ToUpper(targetAlg)
+	switch {
+	case strings.HasPrefix(upper, "ML-KEM") || strings.HasPrefix(upper, "MLKEM"):
+		return "FIPS 203"
+	case strings.HasPrefix(upper, "ML-DSA") || strings.HasPrefix(upper, "MLDSA"):
+		return "FIPS 204"
+	case strings.HasPrefix(upper, "SLH-DSA") || strings.HasPrefix(upper, "SLHDSA"):
+		return "FIPS 205"
+	}
+	return ""
+}
+
 // classicalAlgFamily maps an arbitrary classical algorithm name (case-insensitive)
 // to a canonical two-value family: "sign" or "kem".
 // Returns "" when the algorithm is already PQC-safe or is unrecognised.
@@ -205,6 +252,15 @@ func GenerateSnippet(filePath, classicalAlg, primitive, targetAlg string) *Snipp
 		}
 	}
 
+	// Target-derived family overrides classical family when they disagree.
+	// Prevents the bug where RSA (classicalAlgFamily="sign") paired with a
+	// KEM target (e.g. ML-KEM-768, picked by pkg/quantum for RSA used in
+	// encryption/KEM context) produced signing code calling oqs.Signature
+	// on a KEM algorithm — runtime-invalid and misleading.
+	if tf := familyFromTargetAlg(target); tf != "" && tf != family {
+		family = tf
+	}
+
 	switch lang {
 	case "go":
 		return goSnippet(classicalAlg, primitive, family, target)
@@ -259,7 +315,7 @@ isValid, _ := signer.Verify(message, sig, pub)`
 			Language:    "go",
 			Before:      before,
 			After:       after,
-			Explanation: "Replace RSA/ECDSA signing with " + targetAlg + " (FIPS 204) via liboqs-go.",
+			Explanation: "Replace RSA/ECDSA signing with " + targetAlg + pqcStdSuffix(targetAlg) + " via liboqs-go.",
 		}
 
 	case "kem":
@@ -284,7 +340,7 @@ ciphertext, sharedSecret, _ := kem.EncapSecret(pub)`
 			Language:    "go",
 			Before:      before,
 			After:       after,
-			Explanation: "Replace ECDH/X25519 key exchange with " + targetAlg + " (FIPS 203) via liboqs-go.",
+			Explanation: "Replace ECDH/X25519 key exchange with " + targetAlg + pqcStdSuffix(targetAlg) + " via liboqs-go.",
 		}
 	}
 	return nil
@@ -313,7 +369,7 @@ with oqs.Signature("` + targetAlg + `") as signer:
 			Language:    "python",
 			Before:      before,
 			After:       after,
-			Explanation: "Replace RSA/ECDSA signing with " + targetAlg + " (FIPS 204) via liboqs-python.",
+			Explanation: "Replace RSA/ECDSA signing with " + targetAlg + pqcStdSuffix(targetAlg) + " via liboqs-python.",
 		}
 
 	case "kem":
@@ -332,7 +388,7 @@ with oqs.KeyEncapsulation("` + targetAlg + `") as kem:
 			Language:    "python",
 			Before:      before,
 			After:       after,
-			Explanation: "Replace ECDH key exchange with " + targetAlg + " (FIPS 203) via liboqs-python.",
+			Explanation: "Replace ECDH key exchange with " + targetAlg + pqcStdSuffix(targetAlg) + " via liboqs-python.",
 		}
 	}
 	return nil
@@ -381,7 +437,7 @@ KeyPair kp = kpg.generateKeyPair();`
 			Language:    "java",
 			Before:      before,
 			After:       after,
-			Explanation: "Replace RSA/ECDSA with " + targetAlg + " (FIPS 204) using Bouncy Castle BCPQC provider.",
+			Explanation: "Replace RSA/ECDSA with " + targetAlg + pqcStdSuffix(targetAlg) + " using Bouncy Castle BCPQC provider.",
 		}
 
 	case "kem":
@@ -403,7 +459,7 @@ KeyPair kp = kpg.generateKeyPair();`
 			Language:    "java",
 			Before:      before,
 			After:       after,
-			Explanation: "Replace ECDH key agreement with " + targetAlg + " (FIPS 203) using Bouncy Castle BCPQC provider.",
+			Explanation: "Replace ECDH key agreement with " + targetAlg + pqcStdSuffix(targetAlg) + " using Bouncy Castle BCPQC provider.",
 		}
 	}
 	return nil
@@ -437,7 +493,7 @@ sig.verify(message, &signature, &pk)?;`
 			Language:    "rust",
 			Before:      before,
 			After:       after,
-			Explanation: "Replace RSA/ECDSA signing with " + targetAlg + " (FIPS 204) via the oqs crate.",
+			Explanation: "Replace RSA/ECDSA signing with " + targetAlg + pqcStdSuffix(targetAlg) + " via the oqs crate.",
 		}
 
 	case "kem":
@@ -457,7 +513,7 @@ let (ciphertext, shared_secret) = kem.encapsulate(&pk)?;`
 			Language:    "rust",
 			Before:      before,
 			After:       after,
-			Explanation: "Replace X25519/ECDH key exchange with " + targetAlg + " (FIPS 203) via the oqs crate.",
+			Explanation: "Replace X25519/ECDH key exchange with " + targetAlg + pqcStdSuffix(targetAlg) + " via the oqs crate.",
 		}
 	}
 	return nil
@@ -665,7 +721,7 @@ const signature = sig.sign(message);`
 			Language:    lang,
 			Before:      before,
 			After:       after,
-			Explanation: "Replace RSA/ECDSA signing with " + targetAlg + " (FIPS 204) via liboqs-node.",
+			Explanation: "Replace RSA/ECDSA signing with " + targetAlg + pqcStdSuffix(targetAlg) + " via liboqs-node.",
 		}
 
 	case "kem":
@@ -687,7 +743,7 @@ const { ciphertext, sharedSecret } = kem.encapSecret(publicKey);`
 			Language:    lang,
 			Before:      before,
 			After:       after,
-			Explanation: "Replace ECDH key exchange with " + targetAlg + " (FIPS 203) via liboqs-node.",
+			Explanation: "Replace ECDH key exchange with " + targetAlg + pqcStdSuffix(targetAlg) + " via liboqs-node.",
 		}
 	}
 	return nil
@@ -719,7 +775,7 @@ EVP_PKEY_keygen(ctx, &pkey);`
 			Language:    lang,
 			Before:      before,
 			After:       after,
-			Explanation: "Replace RSA/ECDSA key generation with " + targetAlg + " (FIPS 204) via OpenSSL 3.5+ or oqs-provider.",
+			Explanation: "Replace RSA/ECDSA key generation with " + targetAlg + pqcStdSuffix(targetAlg) + " via OpenSSL 3.5+ or oqs-provider.",
 		}
 
 	case "kem":
@@ -741,7 +797,7 @@ EVP_PKEY_keygen(ctx, &pkey);`
 			Language:    lang,
 			Before:      before,
 			After:       after,
-			Explanation: "Replace ECDH/X25519 key exchange with " + targetAlg + " (FIPS 203) via OpenSSL 3.5+ or oqs-provider.",
+			Explanation: "Replace ECDH/X25519 key exchange with " + targetAlg + pqcStdSuffix(targetAlg) + " via OpenSSL 3.5+ or oqs-provider.",
 		}
 	}
 	return nil
@@ -769,7 +825,7 @@ var keyPair = keyGen.GenerateKeyPair();`
 			Language:    "csharp",
 			Before:      before,
 			After:       after,
-			Explanation: "Replace RSA/ECDSA signing with " + targetAlg + " (FIPS 204) via BouncyCastle for .NET.",
+			Explanation: "Replace RSA/ECDSA signing with " + targetAlg + pqcStdSuffix(targetAlg) + " via BouncyCastle for .NET.",
 		}
 
 	case "kem":
@@ -789,7 +845,7 @@ var keyPair = keyGen.GenerateKeyPair();`
 			Language:    "csharp",
 			Before:      before,
 			After:       after,
-			Explanation: "Replace ECDH key exchange with " + targetAlg + " (FIPS 203) via BouncyCastle for .NET.",
+			Explanation: "Replace ECDH key exchange with " + targetAlg + pqcStdSuffix(targetAlg) + " via BouncyCastle for .NET.",
 		}
 	}
 	return nil

--- a/pkg/quantum/classify.go
+++ b/pkg/quantum/classify.go
@@ -586,8 +586,6 @@ func normalizePrimitive(p string) string {
 		return "key-agree"
 	case "signature", "sign", "digital-signature":
 		return "signature"
-	case "asymmetric":
-		return "pke"
 	case "hash", "digest":
 		return "hash"
 	case "mac", "hmac":


### PR DESCRIPTION
## Summary
- **BUG-A · migration snippet** — RSA findings produced signing code calling `oqs.Signature.Init("ML-KEM-768")` (runtime-invalid) with "FIPS 204" (should be 203). Root cause: `pkg/quantum` normalised primitive `"asymmetric"` → `"pke"` → ML-KEM target, while `pkg/migration` hard-coded RSA → "sign" family. Fix drops the misleading `"asymmetric"` mapping and adds a target-derived family override in `GenerateSnippet`, plus `fipsStandardFor`/`pqcStdSuffix` helpers so SLH-DSA targets render "(FIPS 205)".
- **BUG-B · enginemgr registry** — `version` listed 15 engines but `engines list/doctor/install` only saw 10. The 5 Tier 5 network engines (tls-probe, ct-lookup, ssh-probe, zeek-log, suricata-log) were never added to `enginemgr.registry`. Fix registers them with `BinaryName=""` so the existing embedded-engine fast paths (always-available, skip download) apply.
- **BUG-C · compliance-report CLI** — command accepted only 4 flags and rejected `--no-config`, unusable in most CI setups. Fix adds `--no-config`, `--engine`, `--exclude`, `--timeout`, `--max-file-mb`; loads project config + applies fallbacks like `scan`; expands the `"all"` sentinel on `--compliance`.

## Test plan
- [x] `go test -race -count=1 ./...` — 51 packages pass, 0 failures, 0 data races
- [x] `go vet ./...` — clean
- [x] `go build ./cmd/oqs-scanner/` — 18 MB binary
- [x] Scan RSA fixture → snippet now uses `oqs.Signature.Init("ML-DSA-44")` with "(FIPS 204)"
- [x] `engines doctor` reports "9/15 engines available" (was 4/10)
- [x] `engines list` shows all 15 engines including tls-probe/ct-lookup/ssh-probe/zeek-log/suricata-log at Tier 5
- [x] `compliance-report --path … --compliance cnsa-2.0 --no-config --engine cryptoscan --output /tmp/x.md` writes a valid 59-line report
- [x] Updated tests: `TestRegistry` (15 entries), `TestRegistry_Tiers` (adds tier5 map), `TestRegistry_AllHaveLanguages` (exempts Tier 5)

## Commits
- `7de2f00` fix(migration): align PQC migration snippet with recommended target algorithm
- `7661984` fix(enginemgr): register Tier 5 network engines so engines list/doctor see them
- `811fe81` fix(cli): complianceReportCmd gains CI flags + config loading + "all" expansion