### PR TITLE
fix(ctlookup): clamp Retry-After to 1h before float→int overflow

### DIFF
--- a/pkg/engines/ctlookup/audit_adversarial_test.go
+++ b/pkg/engines/ctlookup/audit_adversarial_test.go
@@ -159,11 +159,12 @@ func TestAuditCT_RateLimiter_ConcurrentBurst_NoLostTokens(t *testing.T) {
 	}
 }
 
-// TestAuditCT_RetryAfter_Overflow_Clamps ensures a malicious Retry-After
-// header with a huge numeric value does not overflow time.Duration into a
-// negative wait (which would cause an immediate retry storm). The current
-// implementation multiplies before clamping — if this test fails, the
-// overflow finding is real.
+// TestAuditCT_RetryAfter_Overflow_Clamps — a malicious Retry-After header
+// with a huge numeric value must not overflow time.Duration into a negative
+// wait (retry-storm) or stall the scanner for an unreasonable positive
+// duration (DoS). Both modes were reachable before the source clamp: wrap
+// to MinInt64 on linux/amd64, saturation to MaxInt64 on darwin. Fix in
+// retryAfterDuration caps at 1h regardless of platform.
 func TestAuditCT_RetryAfter_Overflow_Clamps(t *testing.T) {
 	t.Parallel()
 
@@ -172,15 +173,11 @@ func TestAuditCT_RetryAfter_Overflow_Clamps(t *testing.T) {
 		Header: http.Header{"Retry-After": []string{"1000000000000000000"}}, // 1e18
 	}
 	got := retryAfterDuration(resp)
-	// On overflow, time.Duration becomes negative or wraps.
-	// Expected safe behaviour: clamp to a sane cap (say ≤ 1 h).
 	if got < 0 {
 		t.Errorf("retryAfterDuration overflowed to negative: %v (retry storm risk)", got)
 	}
 	if got > 1*time.Hour {
-		// Document: the library currently does NOT clamp; an attacker-controlled
-		// Retry-After can delay the scanner for a huge (but positive) duration.
-		t.Logf("retryAfterDuration returned %v for Retry-After=1e18 (no clamp — DoS risk)", got)
+		t.Errorf("retryAfterDuration = %v; want clamped to ≤ 1h (DoS risk)", got)
 	}
 }
 

--- a/pkg/engines/ctlookup/client.go
+++ b/pkg/engines/ctlookup/client.go
@@ -160,11 +160,21 @@ func (c *crtShClient) doWithRetry(ctx context.Context, req *http.Request) (*http
 }
 
 // retryAfterDuration parses the Retry-After response header as seconds.
-// Falls back to 2s when the header is absent or unparseable.
+// Falls back to 2s when the header is absent or unparseable. An
+// attacker-controlled Retry-After must not overflow or stall the scanner,
+// so values beyond maxRetryAfter are clamped.
 func retryAfterDuration(resp *http.Response) time.Duration {
+	const maxRetryAfter = 1 * time.Hour
 	if s := resp.Header.Get("Retry-After"); s != "" {
 		var secs float64
 		if _, err := fmt.Sscanf(s, "%f", &secs); err == nil && secs > 0 {
+			// Clamp before multiplying — secs * 1e9 can overflow int64
+			// (float→int conversion of an out-of-range value is
+			// implementation-defined per Go spec; observed to saturate
+			// to MaxInt64 on darwin and wrap to MinInt64 on linux).
+			if secs >= maxRetryAfter.Seconds() {
+				return maxRetryAfter
+			}
 			return time.Duration(secs * float64(time.Second))
 		}
 	}


### PR DESCRIPTION
## Summary
Hotfix for `main` red after PR #14 merged. `TestAuditCT_RetryAfter_Overflow_Clamps` failed on linux/amd64 but passed on darwin — real bug, platform-dependent behaviour.

## Root cause
`retryAfterDuration` (`pkg/engines/ctlookup/client.go:164`) did:
```go
return time.Duration(secs * float64(time.Second))
```

With attacker-controlled `Retry-After: 1000000000000000000`, `secs * 1e9 = 1e27` — out of int64 range. Go's spec (https://go.dev/ref/spec#Conversions) makes float→int conversion of out-of-range values implementation-dependent:
- **linux/amd64**: wraps to `MinInt64` (−292y) — retry-storm (negative timer)
- **darwin**: saturates to `MaxInt64` (+292y) — DoS stall (scanner blocked)

## Fix
- Clamp `secs` to `maxRetryAfter` (1h) **before** multiplying. Conversion then always in range.
- Flip test DoS branch from `t.Logf` to `t.Errorf` — clamp is now an enforced invariant.

## Test plan
- [x] `go test -race -count=1 ./...` — 51 ok / 0 FAIL (matches CI command)
- [x] `TestAuditCT_RetryAfter_Overflow_Clamps` passes on darwin
- [x] `TestAuditCT_RetryAfter_Negative` still passes (untouched)